### PR TITLE
REST: added /upload?chunk=uint parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,15 @@ Example:
  curl -vvv "127.0.0.1:8080/api/codex/v1/download/<Cid of the content>" --output <name of output file>
  ```
 
-### `/api/codex/v1/upload`
+### `/api/codex/v1/upload[?chunk=N]`
 
 Upload a file, upon success returns the `Cid` of the uploaded file.
+The optional 'chunk' parameter specifies Manifest.blockSize.
 
 Example:
 
 ```bash
-curl -vvv -H "content-type: application/octet-stream" -H Expect: -T "<path to file>" "127.0.0.1:8080/api/codex/v1/upload" -X POST
+curl -vvv -H "content-type: application/octet-stream" -H Expect: -T "127.0.0.1:8080/api/codex/v1/upload?chunk=65536" -X POST "<path to file>"
 ```
 
 ### `/api/codex/v1/debug/info`

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -181,7 +181,7 @@ proc initRestApi*(node: CodexNodeRef, conf: CodexConf): RestRouter =
 
       try:
         let runUpload =
-          if blockSize =? chunk.get:
+          if (chunkOpt =? chunk) and (blockSize =? chunkOpt) and (blockSize <= MaxBlockSize):
             node.store(bodyStream, blockSize = blockSize.int)
           else:
             node.store(bodyStream)


### PR DESCRIPTION
Uploaded file split into blocks of requested size when being stored in BlockStore, that allows user to control efficiency of storage, and provide us simple facility to test performance with various block sizes.

To do:
- [x] make REST parameter optional, rename it to "chunk"
- [x] fix memleak by closing AsyncStreamWrapper (and look for similar problems in other program parts)

Closes #225