### PR TITLE
Copy all fields when [un]protect Manifest

### DIFF
--- a/codex/erasure/erasure.nim
+++ b/codex/erasure/erasure.nim
@@ -156,8 +156,7 @@ proc encode*(
 proc decode*(
   self: Erasure,
   encoded: Manifest): Future[?!Manifest] {.async.} =
-  ## Decode a protected manifest into it's original
-  ## manifest
+  ## Decode a protected manifest into its original manifest
   ##
   ## `encoded` - the encoded (protected) manifest to
   ##             be recovered
@@ -254,10 +253,10 @@ proc decode*(
   finally:
     decoder.release()
 
-  without decoded =? Manifest.new(blocks = encoded.blocks[0..<encoded.originalLen]), error:
-    return error.failure
+  without decoded =? encoded.unprotect(blocks = encoded.blocks[0..<encoded.originalLen]), error:
+    return failure error
 
-  return decoded.success
+  return success decoded
 
 proc start*(self: Erasure) {.async.} =
   return

--- a/codex/erasure/erasure.nim
+++ b/codex/erasure/erasure.nim
@@ -82,7 +82,7 @@ proc encode*(
     parity       = parity
 
   trace "Erasure coding manifest", blocks, parity
-  without var encoded =? manifest.addProtection(blocks, parity), error:
+  without var encoded =? manifest.protect(blocks, parity), error:
     trace "Unable to create manifest", msg = error.msg
     return error.failure
 
@@ -262,7 +262,7 @@ proc decode*(
   finally:
     decoder.release()
 
-  without decoded =? encoded.removeProtection(), error:
+  without decoded =? encoded.unprotect(), error:
     return failure error
 
   return success decoded

--- a/codex/erasure/erasure.nim
+++ b/codex/erasure/erasure.nim
@@ -82,7 +82,7 @@ proc encode*(
     parity       = parity
 
   trace "Erasure coding manifest", blocks, parity
-  without var encoded =? Manifest.new(manifest, blocks, parity), error:
+  without var encoded =? manifest.addProtection(blocks, parity), error:
     trace "Unable to create manifest", msg = error.msg
     return error.failure
 
@@ -253,7 +253,7 @@ proc decode*(
   finally:
     decoder.release()
 
-  without decoded =? encoded.unprotect(blocks = encoded.blocks[0..<encoded.originalLen]), error:
+  without decoded =? encoded.removeProtection(), error:
     return failure error
 
   return success decoded

--- a/codex/erasure/erasure.nim
+++ b/codex/erasure/erasure.nim
@@ -195,8 +195,17 @@ proc decode*(
         resolved = 0
 
       while true:
-        # Continue to receive blocks until we have just enough for decoding
-        # or no more blocks can arrive
+        # Continue to receive blocks until one of the following:
+        # - we received K blocks
+        # - there are no more blocks to wait
+        #
+        # In the former case, we received just enough blocks to decode ECC group.
+        #   Since Leopard decoding is very fast (~~ 1 GB/sec), it may be faster
+        #   to reconstruct not yet arrived data blocks rather than wait more.
+        #
+        # We can replace this condition with dataPieces>=K to conserve some CPU resources.
+        # Or, develop a more complex algorithm with parallel downloading of multiple groups
+        #   and timeouts.
         if (resolved >= encoded.K) or (idxPendingBlocks.len == 0):
           break
 

--- a/codex/manifest/manifest.nim
+++ b/codex/manifest/manifest.nim
@@ -204,11 +204,10 @@ proc new*(
     originalBytes: blocks.len * blockSize,
     protected: protected).success
 
-proc new*(
-  T: type Manifest,
+proc addProtection*(
   manifest: Manifest,
   K, M: int): ?!Manifest =
-  ## Create an erasure protected dataset from an unprotected one
+  ## Create an erasure protected dataset manifest from an unprotected one
   ##
 
   ? manifest.verify()
@@ -238,11 +237,10 @@ proc new*(
   ? self.verify()
   self.success
 
-proc unprotect*(
-  manifest: Manifest,
-  blocks: openArray[Cid] = []
+proc removeProtection*(
+  manifest: Manifest
   ): ?!Manifest =
-  ## Create an unprotected dataset from an erasure protected one
+  ## Create an unprotected dataset manifest from an erasure protected one
   ##
 
   ? manifest.verify()
@@ -250,7 +248,7 @@ proc unprotect*(
     return failure newException(CodexError, "Trying to unprotect already non-protected manifest")
 
   var self = copyAllScalarFields(manifest, protected = false)
-  self.blocks = @blocks
+  self.blocks = manifest.blocks[0..<manifest.originalLen]
 
   ? self.verify()
   self.success

--- a/codex/manifest/manifest.nim
+++ b/codex/manifest/manifest.nim
@@ -206,7 +206,7 @@ proc new*(
     originalBytes: blocks.len * blockSize,
     protected: protected).success
 
-proc addProtection*(
+proc protect*(
   manifest: Manifest,
   K, M: int): ?!Manifest =
   ## Create an erasure protected dataset manifest from an unprotected one
@@ -239,7 +239,7 @@ proc addProtection*(
   ? self.verify()
   self.success
 
-proc removeProtection*(
+proc unprotect*(
   manifest: Manifest
   ): ?!Manifest =
   ## Create an unprotected dataset manifest from an erasure protected one

--- a/codex/manifest/manifest.nim
+++ b/codex/manifest/manifest.nim
@@ -157,13 +157,15 @@ func copyAllScalarFields(
   original: Manifest,
   protected: bool
   ): Manifest =
-  # Sometimes we need to copy all but a few fields
-  # from a manifest to another one.
-  # It can be mplemented by copying all fields and then
-  # making a few edits, but it is inefficient to copy
-  # an entire `blocks` array only to drop it.
-  # So we made a helper that copies all scalar fields,
-  # i.e. all fields except for `blocks`.
+  ## Sometimes we need to copy all but a few fields
+  ## from a manifest to another one.
+  ## It can be mplemented by copying all fields and then
+  ## making a few edits, but it is inefficient to copy
+  ## an entire `blocks` array only to drop it.
+  ## So we made a helper that copies all scalar fields,
+  ## i.e. all fields except for `blocks`.
+  ##
+
   var copy = Manifest(
     rootHash: original.rootHash,
     originalBytes: original.originalBytes,
@@ -252,7 +254,6 @@ proc removeProtection*(
 
   ? self.verify()
   self.success
-
 
 proc new*(
   T: type Manifest,

--- a/codex/manifest/types.nim
+++ b/codex/manifest/types.nim
@@ -27,6 +27,7 @@ const
 
 type
   Manifest* = ref object of RootObj
+    # when adding/changing fields - make sure to modify ALL constructors in manifest.nim
     rootHash*: ?Cid         # Root (tree) hash of the contained data set
     originalBytes*: int     # Exact size of the original (uploaded) file
     blockSize*: int         # Size of each contained block (might not be needed if blocks are len-prefixed)

--- a/tests/codex/testerasure.nim
+++ b/tests/codex/testerasure.nim
@@ -16,7 +16,10 @@ import ./helpers
 
 suite "Erasure encode/decode":
 
-  const dataSetSize = BlockSize * 123 # weird geometry
+  const
+    localBlockSize = 43*64  # check that code can work with non-default BlockSize
+                            # (but it should be x*64 for Leopard)
+    dataSetSize = BlockSize * 123  # ... and weird geometry
 
   var rng: Rng
   var chunker: Chunker
@@ -26,9 +29,9 @@ suite "Erasure encode/decode":
 
   setup:
     rng = Rng.instance()
-    chunker = RandomChunker.new(rng, size = dataSetSize, chunkSize = BlockSize)
-    manifest = !Manifest.new(blockSize = BlockSize)
-    store = CacheStore.new(cacheSize = (dataSetSize * 2), chunkSize = BlockSize)
+    chunker = RandomChunker.new(rng, size = dataSetSize, chunkSize = localBlockSize)
+    manifest = !Manifest.new(blockSize = localBlockSize)
+    store = CacheStore.new(cacheSize = dataSetSize*2, chunkSize = localBlockSize)
     erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider)
 
     while (

--- a/tests/codex/testmanifest.nim
+++ b/tests/codex/testmanifest.nim
@@ -54,22 +54,33 @@ suite "Manifest":
       decoded = Manifest.decode(e).tryGet()
 
     check:
-      decoded.blocks == blocks
       decoded.protected == false
+      decoded.cid.tryGet() == manifest.cid.tryGet()
+      decoded.blocks == manifest.blocks
 
   test "Should produce a protected manifest":
     let
-      blocks = (0..<333).mapIt(
+      N = 333
+      blocks = (0..<N).mapIt(
         Block.new(("Block " & $it).toBytes).tryGet().cid
       )
       manifest = Manifest.new(blocks).tryGet()
-      protected = manifest.addProtection(2, 2).tryGet()
 
+    let
+      protected = manifest.addProtection(2, 2).tryGet()
     check:
-        protected.originalCid == manifest.cid.tryGet()
-        protected.blocks[0..<333] == manifest.blocks
-        protected.protected == true
-        protected.originalLen == manifest.len
+      protected.protected == true
+      protected.originalLen == manifest.len
+      protected.originalCid == manifest.cid.tryGet()
+      protected.blocks[0..<N] == manifest.blocks
+
+    let
+      unprotected = protected.removeProtection().tryGet()
+    check:
+      unprotected.protected == false
+      unprotected.cid.tryGet() == manifest.cid.tryGet()
+      unprotected.blocks == manifest.blocks
+
 
     # fill up with empty Cid's
     for i in protected.rounded..<protected.len:
@@ -94,4 +105,4 @@ suite "Manifest":
       decoded.originalCid == manifest.cid.tryGet()
 
       decoded.blocks == protected.blocks
-      decoded.blocks[0..<333] == manifest.blocks
+      decoded.blocks[0..<N] == manifest.blocks

--- a/tests/codex/testmanifest.nim
+++ b/tests/codex/testmanifest.nim
@@ -67,7 +67,7 @@ suite "Manifest":
       manifest = Manifest.new(blocks).tryGet()
 
     let
-      protected = manifest.addProtection(2, 2).tryGet()
+      protected = manifest.protect(2, 2).tryGet()
     check:
       protected.protected == true
       protected.originalLen == manifest.len
@@ -75,7 +75,7 @@ suite "Manifest":
       protected.blocks[0..<N] == manifest.blocks
 
     let
-      unprotected = protected.removeProtection().tryGet()
+      unprotected = protected.unprotect().tryGet()
     check:
       unprotected.protected == false
       unprotected.cid.tryGet() == manifest.cid.tryGet()

--- a/tests/codex/testmanifest.nim
+++ b/tests/codex/testmanifest.nim
@@ -63,7 +63,7 @@ suite "Manifest":
         Block.new(("Block " & $it).toBytes).tryGet().cid
       )
       manifest = Manifest.new(blocks).tryGet()
-      protected = Manifest.new(manifest, 2, 2).tryGet()
+      protected = manifest.addProtection(2, 2).tryGet()
 
     check:
         protected.originalCid == manifest.cid.tryGet()


### PR DESCRIPTION
Manifest has quite a lot of fields and it's important to copy all of them when we create a new Manifest from the old one. Now we do it only in two situations - when we add ECC info to Manifest, and when we drop it back. So, I created a helper function that copies all Manifest fields except for `blocks` and changed all code making a new Manifest from the old one to call this function.

Change list:
- [x] fixed bug in erasure.decode - decoded manifest didn't copy fields of original, in particular blockSize
- [x] introduced manifest.addProtection and manifest.removeProtection functions specifically to convert manifest between protected and unprotected forms
- [x] added test of manifest.removeProtection
- [x] added test of erasure.encode and erasure.decode with non-default blockSize
- [x] added comment to erasure.encode

Closes #224