### PR TITLE
[marketplace] restart sales state machine and memory leak prevention

### DIFF
--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -3,6 +3,8 @@ import pkg/contractabi
 import pkg/nimcrypto
 import pkg/ethers/fields
 import pkg/questionable/results
+import pkg/json_serialization
+import pkg/upraises
 
 export contractabi
 
@@ -193,3 +195,17 @@ func price*(request: StorageRequest): UInt256 =
 
 func size*(ask: StorageAsk): UInt256 =
   ask.slots.u256 * ask.slotSize
+
+proc writeValue*(
+  writer: var JsonWriter,
+  value: SlotId | RequestId) {.upraises:[IOError].} =
+
+  mixin writeValue
+  writer.writeValue value.toArray
+
+proc readValue*[T: SlotId | RequestId](
+  reader: var JsonReader,
+  value: var T) {.upraises: [SerializationError, IOError].} =
+
+  mixin readValue
+  value = T reader.readValue(T.distinctBase)

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -74,7 +74,7 @@ func new*(_: type Sales,
   ))
 
 proc remove(sales: Sales, agent: SalesAgent): OnCleanUp =
-  proc: Future[void] {.gcsafe, upraises:[], async.} =
+  proc(): Future[void] {.gcsafe, upraises:[], async.} =
     await agent.stop()
     sales.agents.keepItIf(it != agent)
 

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -74,7 +74,7 @@ func new*(_: type Sales,
   ))
 
 proc remove(sales: Sales, agent: SalesAgent): OnCleanUp =
-  proc(): Future[void] {.gcsafe, upraises:[], async.} =
+  proc (): Future[void] {.gcsafe, upraises:[], async.} =
     await agent.stop()
     sales.agents.keepItIf(it != agent)
 

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -73,8 +73,6 @@ func new*(_: type Sales,
     reservations: Reservations.new(repo)
   ))
 
-
-
 proc handleRequest(sales: Sales,
                    requestId: RequestId,
                    ask: StorageAsk) =
@@ -89,6 +87,11 @@ proc handleRequest(sales: Sales,
     none UInt256,
     none StorageRequest
   )
+  agent.context.onStartOver =
+    proc(slotIndex: UInt256) {.gcsafe, upraises:[], async.} =
+      await agent.stop()
+      agent.start(SalePreparing(ignoreSlotIndex: some slotIndex))
+
   agent.context.onIgnored = proc {.gcsafe, upraises:[].} =
                               sales.agents.keepItIf(it != agent)
   agent.start(SalePreparing())

--- a/codex/sales/reservations.nim
+++ b/codex/sales/reservations.nim
@@ -97,12 +97,12 @@ proc toErr[E1: ref CatchableError, E2: AvailabilityError](
 
 proc writeValue*(
   writer: var JsonWriter,
-  value: SlotId | AvailabilityId) {.upraises:[IOError].} =
+  value: AvailabilityId) {.upraises:[IOError].} =
 
   mixin writeValue
   writer.writeValue value.toArray
 
-proc readValue*[T: SlotId | AvailabilityId](
+proc readValue*[T: AvailabilityId](
   reader: var JsonReader,
   value: var T) {.upraises: [SerializationError, IOError].} =
 

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -51,8 +51,11 @@ proc nextRandom(sample: openArray[uint64]): uint64 =
   let rng = Rng.instance
   return rng.sample(sample)
 
-proc assignRandomSlotIndex*(agent: SalesAgent,
-                            numSlots: uint64): Future[?!void] {.async.} =
+proc assignRandomSlotIndex*(
+    agent: SalesAgent,
+    numSlots: uint64,
+    ignoreSlotIndex: ?UInt256 = none UInt256): Future[?!void] {.async.} =
+
   let market = agent.context.market
   let data = agent.data
 
@@ -63,6 +66,8 @@ proc assignRandomSlotIndex*(agent: SalesAgent,
 
   var idx: UInt256
   var sample = toSeq(0'u64..<numSlots)
+  if ignored =? ignoreSlotIndex:
+    sample.keepItIf(it != ignored.truncate(uint64))
 
   while true:
     if sample.len == 0:
@@ -121,7 +126,8 @@ proc subscribeFailure(agent: SalesAgent) {.async.} =
 
 proc subscribeSlotFilled(agent: SalesAgent) {.async.} =
   let data = agent.data
-  let market = agent.context.market
+  let context = agent.context
+  let market = context.market
 
   without slotIndex =? data.slotIndex:
     raiseAssert("no slot index assigned")

--- a/codex/sales/salescontext.nim
+++ b/codex/sales/salescontext.nim
@@ -14,7 +14,7 @@ type
     onStore*: ?OnStore
     onClear*: ?OnClear
     onSale*: ?OnSale
-    onIgnored*: OnIgnored
+    onCleanUp*: OnCleanUp
     onStartOver*: OnStartOver
     proving*: Proving
     reservations*: Reservations
@@ -28,5 +28,5 @@ type
                   slotIndex: UInt256) {.gcsafe, upraises: [].}
   OnSale* = proc(request: StorageRequest,
                  slotIndex: UInt256) {.gcsafe, upraises: [].}
-  OnIgnored* = proc() {.gcsafe, upraises: [].}
+  OnCleanUp* = proc: Future[void] {.gcsafe, upraises: [].}
   OnStartOver* = proc(slotIndex: UInt256): Future[void] {.gcsafe, upraises: [].}

--- a/codex/sales/salescontext.nim
+++ b/codex/sales/salescontext.nim
@@ -15,6 +15,7 @@ type
     onClear*: ?OnClear
     onSale*: ?OnSale
     onIgnored*: OnIgnored
+    onStartOver*: OnStartOver
     proving*: Proving
     reservations*: Reservations
 
@@ -28,3 +29,4 @@ type
   OnSale* = proc(request: StorageRequest,
                  slotIndex: UInt256) {.gcsafe, upraises: [].}
   OnIgnored* = proc() {.gcsafe, upraises: [].}
+  OnStartOver* = proc(slotIndex: UInt256): Future[void] {.gcsafe, upraises: [].}

--- a/codex/sales/states/downloading.nim
+++ b/codex/sales/states/downloading.nim
@@ -8,9 +8,9 @@ import ../statemachine
 import ./errorhandling
 import ./cancelled
 import ./failed
-import ./filled
 import ./proving
 import ./errored
+import ./restart
 
 type
   SaleDownloading* = ref object of ErrorHandlingState
@@ -29,7 +29,8 @@ method onFailed*(state: SaleDownloading, request: StorageRequest): ?State =
 
 method onSlotFilled*(state: SaleDownloading, requestId: RequestId,
                      slotIndex: UInt256): ?State =
-  return some State(SaleFilled())
+  notice "Slot filled by other host, starting over", requestId, slotIndex
+  return some State(SaleRestart())
 
 method run*(state: SaleDownloading, machine: Machine): Future[?State] {.async.} =
   let agent = SalesAgent(machine)

--- a/codex/sales/states/errored.nim
+++ b/codex/sales/states/errored.nim
@@ -18,11 +18,13 @@ method run*(state: SaleErrored, machine: Machine): Future[?State] {.async.} =
   let data = agent.data
   let context = agent.context
 
+  error "Sale error", error=state.error.msg
+
   if onClear =? context.onClear and
       request =? data.request and
       slotIndex =? data.slotIndex:
     onClear(request, slotIndex)
 
-  await agent.unsubscribe()
+  if onCleanUp =? context.onCleanUp:
+    await onCleanUp()
 
-  error "Sale error", error=state.error.msg

--- a/codex/sales/states/finished.nim
+++ b/codex/sales/states/finished.nim
@@ -28,4 +28,5 @@ method run*(state: SaleFinished, machine: Machine): Future[?State] {.async.} =
     if onSale =? context.onSale:
       onSale(request, slotIndex)
 
-  await agent.unsubscribe()
+  if onCleanUp =? context.onCleanUp:
+    await onCleanUp()

--- a/codex/sales/states/ignored.nim
+++ b/codex/sales/states/ignored.nim
@@ -12,7 +12,5 @@ method run*(state: SaleIgnored, machine: Machine): Future[?State] {.async.} =
   let agent = SalesAgent(machine)
   let context = agent.context
 
-  if onIgnored =? context.onIgnored:
-    onIgnored()
-
-  await agent.unsubscribe()
+  if onCleanUp =? context.onCleanUp:
+    await onCleanUp()

--- a/codex/sales/states/restart.nim
+++ b/codex/sales/states/restart.nim
@@ -1,0 +1,25 @@
+import pkg/chronicles
+import ../statemachine
+import ../salesagent
+import ./errorhandling
+
+type
+  SaleRestart* = ref object of ErrorHandlingState
+
+logScope:
+  topics = "sales restart"
+
+method `$`*(state: SaleRestart): string = "SaleRestart"
+
+method run*(state: SaleRestart, machine: Machine): Future[?State] {.async.} =
+  let agent = SalesAgent(machine)
+  let data = agent.data
+  let context = agent.context
+
+  without slotIndex =? data.slotIndex:
+    raiseAssert("no slot index assigned")
+
+  if onStartOver =? context.onStartOver:
+    notice "Slot filled by other host, starting over",
+      requestId = data.requestId, slotIndex
+    await onStartOver(slotIndex)

--- a/tests/codex/sales/states/testdownloading.nim
+++ b/tests/codex/sales/states/testdownloading.nim
@@ -4,7 +4,7 @@ import pkg/codex/contracts/requests
 import pkg/codex/sales/states/downloading
 import pkg/codex/sales/states/cancelled
 import pkg/codex/sales/states/failed
-import pkg/codex/sales/states/filled
+import pkg/codex/sales/states/restart
 import ../../examples
 
 suite "sales state 'downloading'":
@@ -24,6 +24,6 @@ suite "sales state 'downloading'":
     let next = state.onFailed(request)
     check !next of SaleFailed
 
-  test "switches to filled state when slot is filled":
+  test "switches to restart state when slot is filled":
     let next = state.onSlotFilled(request.id, slotIndex)
-    check !next of SaleFilled
+    check !next of SaleRestart

--- a/tests/codex/sales/states/testfilled.nim
+++ b/tests/codex/sales/states/testfilled.nim
@@ -4,7 +4,7 @@ import pkg/codex/sales
 import pkg/codex/sales/salesagent
 import pkg/codex/sales/salescontext
 import pkg/codex/sales/states/filled
-import pkg/codex/sales/states/errored
+import pkg/codex/sales/states/restart
 import pkg/codex/sales/states/finished
 import ../../helpers/mockmarket
 import ../../examples
@@ -38,8 +38,8 @@ suite "sales state 'filled'":
     let next = await state.run(agent)
     check !next of SaleFinished
 
-  test "switches to error state when slot is filled by another host":
+  test "switches to restart state when slot is filled by another host":
     slot.host = Address.example
     market.filled = @[slot]
     let next = await state.run(agent)
-    check !next of SaleErrored
+    check !next of SaleRestart

--- a/tests/codex/sales/states/testpreparing.nim
+++ b/tests/codex/sales/states/testpreparing.nim
@@ -4,7 +4,7 @@ import pkg/codex/contracts/requests
 import pkg/codex/sales/states/downloading
 import pkg/codex/sales/states/cancelled
 import pkg/codex/sales/states/failed
-import pkg/codex/sales/states/filled
+import pkg/codex/sales/states/restart
 import ../../examples
 
 suite "sales state 'preparing'":
@@ -24,6 +24,6 @@ suite "sales state 'preparing'":
     let next = state.onFailed(request)
     check !next of SaleFailed
 
-  test "switches to filled state when slot is filled":
+  test "switches to restart state when slot is filled":
     let next = state.onSlotFilled(request.id, slotIndex)
-    check !next of SaleFilled
+    check !next of SaleRestart

--- a/tests/codex/sales/states/testproving.nim
+++ b/tests/codex/sales/states/testproving.nim
@@ -4,7 +4,7 @@ import pkg/codex/contracts/requests
 import pkg/codex/sales/states/proving
 import pkg/codex/sales/states/cancelled
 import pkg/codex/sales/states/failed
-import pkg/codex/sales/states/filled
+import pkg/codex/sales/states/restart
 import ../../examples
 
 suite "sales state 'proving'":
@@ -24,7 +24,7 @@ suite "sales state 'proving'":
     let next = state.onFailed(request)
     check !next of SaleFailed
 
-  test "switches to filled state when slot is filled":
+  test "switches to restart state when slot is filled":
     let next = state.onSlotFilled(request.id, slotIndex)
-    check !next of SaleFilled
+    check !next of SaleRestart
 


### PR DESCRIPTION
### restart sales state machine if slot is filled by other host
When a slot is filled by other host, the state machine should not park in the `SaleErrored` state, and instead moves to the `SaleRestart` state, where it calls `onSaleRestart`. The sales module handles `onSaleRestart`, restarting the state machine, getting a new slot index while ignoring the previously attempting slot index.

### [statemachine] prevent memory leak by cleaning up ended agents
Once agents have parked in an end state (eg ignored, cancelled, finished, failed, errored), they were not getting cleaned up and the sales module was keeping a handle on their reference. This could prvent a memory leak if the number of requests coming in is high.

Add an `onCleanUp` that stops the agents and removes them from the sales module agent list. `onCleanUp` is called from sales end states (eg ignored, cancelled, finished, failed, errored).