### PR TITLE
feat: storage host collects reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Available sub-commands:
 codex initNode
 ```
 
+#### Logging
+
+Codex uses [Chronicles](https://github.com/status-im/nim-chronicles) logging library, which allows great flexibility in working with logs.
+Chronicles has the concept of topics, which categorize log entries into semantic groups.
+
+Using the `log-level` parameter, you can set the top-level log level like `--log-level="TRACE"`, but more importantly,
+you can set log levels for specific topics like `--log-level="INFO; TRACE: marketplace,node; ERROR: blockexchange"`,
+which sets the top-level log level to `INFO` and then for topics `marketplace` and `node` sets the level to `TRACE` and so on.
+
 ### Example: running two Codex clients
 
 To get acquainted with Codex, consider running the manual two-client test described [HERE](docs/TWOCLIENTTEST.md).

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -10,7 +10,7 @@ import ./marketplace
 export market
 
 logScope:
-    topics = "onchain market"
+    topics = "marketplace onchain market"
 
 type
   OnChainMarket* = ref object of Market
@@ -30,7 +30,7 @@ func new*(_: type OnChainMarket, contract: Marketplace): OnChainMarket =
   )
 
 proc approveFunds(market: OnChainMarket, amount: UInt256) {.async.} =
-  notice "approving tokens", amount
+  debug "Approving tokens", amount
   let tokenAddress = await market.contract.token()
   let token = Erc20Token.new(tokenAddress, market.signer)
 
@@ -55,6 +55,7 @@ method mySlots*(market: OnChainMarket): Future[seq[SlotId]] {.async.} =
   return await market.contract.mySlots()
 
 method requestStorage(market: OnChainMarket, request: StorageRequest){.async.} =
+  debug "Requesting storage"
   await market.approveFunds(request.price())
   await market.contract.requestStorage(request)
 

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -11,7 +11,7 @@ import ./reservations
 export reservations
 
 logScope:
-  topics = "sales statemachine"
+  topics = "marketplace sales"
 
 type SalesAgent* = ref object of Machine
   context*: SalesContext

--- a/codex/sales/states/downloading.nim
+++ b/codex/sales/states/downloading.nim
@@ -17,7 +17,7 @@ type
   SaleDownloading* = ref object of ErrorHandlingState
 
 logScope:
-    topics = "sales downloading"
+    topics = "marketplace sales downloading"
 
 method `$`*(state: SaleDownloading): string = "SaleDownloading"
 
@@ -46,13 +46,16 @@ method run*(state: SaleDownloading, machine: Machine): Future[?State] {.async.} 
   without request =? data.request:
     raiseAssert "no sale request"
 
+  debug "New request detected, downloading info", requestId = $data.requestId
+
   without availability =? await reservations.find(
       request.ask.slotSize,
       request.ask.duration,
       request.ask.pricePerSlot,
       request.ask.collateral,
       used = false):
-    info "no availability found for request, ignoring",
+    info "No availability found for request, ignoring",
+      requestId = $data.requestId,
       slotSize = request.ask.slotSize,
       duration = request.ask.duration,
       pricePerSlot = request.ask.pricePerSlot,

--- a/codex/sales/states/errored.nim
+++ b/codex/sales/states/errored.nim
@@ -5,6 +5,9 @@ import pkg/chronicles
 import ../statemachine
 import ../salesagent
 
+logScope:
+    topics = "marketplace sales errored"
+
 type SaleErrored* = ref object of SaleState
   error*: ref CatchableError
 
@@ -25,4 +28,4 @@ method run*(state: SaleErrored, machine: Machine): Future[?State] {.async.} =
 
   await agent.unsubscribe()
 
-  error "Sale error", error=state.error.msg
+  error "Sale error", error=state.error.msg, requestId = $data.requestId

--- a/codex/sales/states/filling.nim
+++ b/codex/sales/states/filling.nim
@@ -1,3 +1,4 @@
+import pkg/chronicles
 import ../../market
 import ../statemachine
 import ../salesagent
@@ -5,6 +6,9 @@ import ./errorhandling
 import ./filled
 import ./cancelled
 import ./failed
+
+logScope:
+    topics = "marketplace sales filling"
 
 type
   SaleFilling* = ref object of ErrorHandlingState
@@ -28,4 +32,5 @@ method run(state: SaleFilling, machine: Machine): Future[?State] {.async.} =
   without (collateral =? data.request.?ask.?collateral):
     raiseAssert "Request not set"
 
+  debug "Filling slot", requestId = $data.requestId, slot = $data.slotIndex
   await market.fillSlot(data.requestId, data.slotIndex, state.proof, collateral)

--- a/codex/sales/states/finished.nim
+++ b/codex/sales/states/finished.nim
@@ -1,9 +1,13 @@
 import pkg/chronos
+import pkg/chronicles
 import ../statemachine
 import ../salesagent
 import ./errorhandling
 import ./cancelled
 import ./failed
+
+logScope:
+    topics = "marketplace sales finished"
 
 type
   SaleFinished* = ref object of ErrorHandlingState
@@ -21,8 +25,11 @@ method run*(state: SaleFinished, machine: Machine): Future[?State] {.async.} =
   let data = agent.data
   let context = agent.context
 
+  debug "Request succesfully filled", requestId = $data.requestId
+
   if request =? data.request and
       slotIndex =? data.slotIndex:
+    debug "Adding request to proving list", requestId = $data.requestId
     context.proving.add(Slot(request: request, slotIndex: slotIndex))
 
     if onSale =? context.onSale:

--- a/codex/sales/states/proving.nim
+++ b/codex/sales/states/proving.nim
@@ -1,3 +1,4 @@
+import pkg/chronicles
 import ../statemachine
 import ../salesagent
 import ./errorhandling
@@ -5,6 +6,9 @@ import ./filling
 import ./cancelled
 import ./failed
 import ./filled
+
+logScope:
+    topics = "marketplace sales proving"
 
 type
   SaleProving* = ref object of ErrorHandlingState
@@ -31,5 +35,8 @@ method run*(state: SaleProving, machine: Machine): Future[?State] {.async.} =
   without onProve =? context.proving.onProve:
     raiseAssert "onProve callback not set"
 
+  debug "Start proving", requestId = $data.requestId
   let proof = await onProve(Slot(request: request, slotIndex: data.slotIndex))
+  debug "Finished proving", requestId = $data.requestId
+
   return some State(SaleFilling(proof: proof))

--- a/tests/integration/nodes.nim
+++ b/tests/integration/nodes.nim
@@ -30,10 +30,10 @@ proc start(node: NodeProcess) =
       if line.contains("Started codex node"):
         break
 
-proc startNode*(args: openArray[string], debug = false): NodeProcess =
+proc startNode*(args: openArray[string], debug: string | bool = false): NodeProcess =
   ## Starts a Codex Node with the specified arguments.
   ## Set debug to 'true' to see output of the node.
-  let node = NodeProcess(arguments: @args, debug: debug)
+  let node = NodeProcess(arguments: @args, debug: ($debug != "false"))
   node.start()
   node
 

--- a/tests/integration/twonodes.nim
+++ b/tests/integration/twonodes.nim
@@ -10,14 +10,8 @@ export ethertest
 export codexclient
 export nodes
 
-template twonodessuite*(name: string, debug1, debug2: bool, body) =
+template twonodessuite*(name: string, debug1, debug2: bool | string, body) =
   twonodessuite(name, $debug1, $debug2, body)
-
-template twonodessuite*(name: string, debug1: string, debug2: bool, body) =
-  twonodessuite(name, debug1, $debug2, body)
-
-template twonodessuite*(name: string, debug1: bool, debug2: string, body) =
-  twonodessuite(name, $debug1, debug2, body)
 
 template twonodessuite*(name: string, debug1, debug2: string, body) =
 

--- a/tests/integration/twonodes.nim
+++ b/tests/integration/twonodes.nim
@@ -46,7 +46,7 @@ template twonodessuite*(name: string, debug1, debug2: string, body) =
       if debug1 != "true" and debug1 != "false":
         node1Args.add("--log-level=" & debug1)
 
-      node1 = startNode(node1Args, debug = (debug1 != "false"))
+      node1 = startNode(node1Args, debug = debug1)
 
       let bootstrap = client1.info()["spr"].getStr()
 
@@ -64,7 +64,7 @@ template twonodessuite*(name: string, debug1, debug2: string, body) =
       if debug2 != "true" and debug2 != "false":
         node2Args.add("--log-level=" & debug2)
 
-      node2 = startNode(node2Args, debug = (debug2 != "false"))
+      node2 = startNode(node2Args, debug = debug2)
 
     teardown:
       client1.close()

--- a/tests/integration/twonodes.nim
+++ b/tests/integration/twonodes.nim
@@ -11,6 +11,15 @@ export codexclient
 export nodes
 
 template twonodessuite*(name: string, debug1, debug2: bool, body) =
+  twonodessuite(name, $debug1, $debug2, body)
+
+template twonodessuite*(name: string, debug1: string, debug2: bool, body) =
+  twonodessuite(name, debug1, $debug2, body)
+
+template twonodessuite*(name: string, debug1: bool, debug2: string, body) =
+  twonodessuite(name, $debug1, debug2, body)
+
+template twonodessuite*(name: string, debug1, debug2: string, body) =
 
   ethersuite name:
 
@@ -18,6 +27,8 @@ template twonodessuite*(name: string, debug1, debug2: bool, body) =
     var node2 {.inject, used.}: NodeProcess
     var client1 {.inject, used.}: CodexClient
     var client2 {.inject, used.}: CodexClient
+    var account1 {.inject, used.}: Address
+    var account2 {.inject, used.}: Address
 
     let dataDir1 = getTempDir() / "Codex1"
     let dataDir2 = getTempDir() / "Codex2"
@@ -25,20 +36,27 @@ template twonodessuite*(name: string, debug1, debug2: bool, body) =
     setup:
       client1 = CodexClient.new("http://localhost:8080/api/codex/v1")
       client2 = CodexClient.new("http://localhost:8081/api/codex/v1")
+      account1 = accounts[0]
+      account2 = accounts[1]
 
-      node1 = startNode([
+      var node1Args = @[
         "--api-port=8080",
         "--data-dir=" & dataDir1,
         "--nat=127.0.0.1",
         "--disc-ip=127.0.0.1",
         "--disc-port=8090",
         "--persistence",
-        "--eth-account=" & $accounts[0]
-      ], debug = debug1)
+        "--eth-account=" & $account1
+      ]
+
+      if debug1 != "true" and debug1 != "false":
+        node1Args.add("--log-level=" & debug1)
+
+      node1 = startNode(node1Args, debug = (debug1 != "false"))
 
       let bootstrap = client1.info()["spr"].getStr()
 
-      node2 = startNode([
+      var node2Args = @[
         "--api-port=8081",
         "--data-dir=" & dataDir2,
         "--nat=127.0.0.1",
@@ -46,8 +64,13 @@ template twonodessuite*(name: string, debug1, debug2: bool, body) =
         "--disc-port=8091",
         "--bootstrap-node=" & bootstrap,
         "--persistence",
-        "--eth-account=" & $accounts[1]
-      ], debug = debug2)
+        "--eth-account=" & $account2
+      ]
+
+      if debug2 != "true" and debug2 != "false":
+        node2Args.add("--log-level=" & debug2)
+
+      node2 = startNode(node2Args, debug = (debug2 != "false"))
 
     teardown:
       client1.close()


### PR DESCRIPTION
This PR adds hotfix-style support for collecting a host's reward. It is plugged into the proving component, but it will be refactored later, as described in #414. 

The test case is also temporary, as we currently do not have any endpoint that would expose the state of a host's requests that he or she hosts. This will be improved once #415 is fixed. 

As I had a hard time making the test pass, I have improved the logging support for the Sales State Machine, integration tests, and some documentation around this. Only then I have realized that the proving component requires new blocks to be mined in order for the proving cycle to kick in, so I added `provider.advanceTime()` and then all worked 🙄