### PR TITLE
Update links to codex-storage organization

### DIFF
--- a/.github/workflows/Readme.md
+++ b/.github/workflows/Readme.md
@@ -68,7 +68,7 @@ one. You might be tempted to disable fail-fast, but keep in mind that this keeps
 runners busy for longer on a workflow that you know is going to fail anyway.
 Consequent runs will therefore take longer to start. Fail fast is most likely better for overall development speed.
 
-[usage]: https://github.com/status-im/nim-codex/actions/runs/3462031231/usage
+[usage]: https://github.com/codex-storage/nim-codex/actions/runs/3462031231/usage
 [composite]: https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
 [reusable]: https://docs.github.com/en/actions/using-workflows/reusing-workflows
 [cache]: https://github.com/actions/cache/blob/main/workarounds.md#update-a-cache

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -18,7 +18,7 @@
 
 To build nim-codex, developer tools need to be installed and accessible in the OS.
 
-Instructions below correspond roughly to environmental setups in nim-codex's [CI workflow](https://github.com/status-im/nim-codex/blob/main/.github/workflows/ci.yml) and are known to work.
+Instructions below correspond roughly to environmental setups in nim-codex's [CI workflow](https://github.com/codex-storage/nim-codex/blob/main/.github/workflows/ci.yml) and are known to work.
 
 Other approaches may be viable. On macOS, some users may prefer [MacPorts](https://www.macports.org/) to [Homebrew](https://brew.sh/). On Windows, rather than use MSYS2, some users may prefer to install developer tools with [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/), [Scoop](https://scoop.sh/), or [Chocolatey](https://chocolatey.org/), or download installers for e.g. Make and CMake while otherwise relying on official Windows developer tools. Community contributions to these docs and our build system are welcome!
 
@@ -110,7 +110,7 @@ It is possible that nim-codex can be built and run on other platforms supported 
 
 In Bash run
 ```text
-$ git clone https://github.com/status-im/nim-codex.git repos/nim-codex && cd repos/nim-codex
+$ git clone https://github.com/codex-storage/nim-codex.git repos/nim-codex && cd repos/nim-codex
 ```
 
 nim-codex uses the [nimbus-build-system](https://github.com/status-im/nimbus-build-system#readme), so next run

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![License: Apache](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Stability: experimental](https://img.shields.io/badge/stability-experimental-orange.svg)](#stability)
-[![CI](https://github.com/status-im/nim-codex/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/status-im/nim-codex/actions?query=workflow%3ACI+branch%3Amain)
-[![Codecov](https://codecov.io/gh/status-im/nim-codex/branch/main/graph/badge.svg?token=XFmCyPSNzW)](https://codecov.io/gh/status-im/nim-codex)
+[![CI](https://github.com/codex-storage/nim-codex/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/codex-storage/nim-codex/actions?query=workflow%3ACI+branch%3Amain)
+[![Codecov](https://codecov.io/gh/codex-storage/nim-codex/branch/main/graph/badge.svg?token=XFmCyPSNzW)](https://codecov.io/gh/codex-storage/nim-codex)
 [![Discord](https://img.shields.io/discord/895609329053474826)](https://discord.gg/CaJTh24ddQ)
 
 


### PR DESCRIPTION
Some badges may not show status correctly and as we moved repository it is better to update all the links to point to the new organization.