### PR TITLE
Fix Open API workflow branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: OpenAPI
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
     paths:
       - 'openapi.yaml'
       - '.github/workflows/docs.yml'
@@ -41,7 +41,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
We recently renamed `main` branch into the `master` and it broke the [Open API workflow](../../actions/workflows/docs.yml).

codex-storage/infra-codex/issues/5