### PR TITLE
Nimsuggest tweaks

### DIFF
--- a/codex.nimble
+++ b/codex.nimble
@@ -7,29 +7,30 @@ license = "MIT"
 binDir = "build"
 srcDir = "."
 
-requires "nim >= 1.2.0",
-         "asynctest >= 0.3.2 & < 0.4.0",
-         "bearssl >= 0.1.4",
-         "chronicles >= 0.7.2",
-         "chronos >= 2.5.2",
-         "confutils",
-         "ethers >= 0.2.4 & < 0.3.0",
-         "libbacktrace",
-         "libp2p",
-         "metrics",
-         "nimcrypto >= 0.4.1",
-         "nitro >= 0.5.1 & < 0.6.0",
-         "presto",
-         "protobuf_serialization >= 0.2.0 & < 0.3.0",
-         "questionable >= 0.10.6 & < 0.11.0",
-         "secp256k1",
-         "stew",
-         "upraises >= 0.1.0 & < 0.2.0",
-         "https://github.com/status-im/lrucache.nim#1.2.2",
-         "leopard >= 0.1.0 & < 0.2.0",
-         "blscurve",
-         "libp2pdht",
-         "eth"
+requires "nim >= 1.2.0"
+requires "asynctest >= 0.3.2 & < 0.4.0"
+requires "bearssl >= 0.1.4"
+requires "chronicles >= 0.7.2"
+requires "chronos >= 2.5.2"
+requires "confutils"
+requires "ethers >= 0.2.4 & < 0.3.0"
+requires "libbacktrace"
+requires "libp2p"
+requires "metrics"
+requires "nimcrypto >= 0.4.1"
+requires "nitro >= 0.5.1 & < 0.6.0"
+requires "presto"
+requires "protobuf_serialization >= 0.2.0 & < 0.3.0"
+requires "questionable >= 0.10.6 & < 0.11.0"
+requires "secp256k1"
+requires "stew"
+requires "upraises >= 0.1.0 & < 0.2.0"
+requires "toml_serialization"
+requires "https://github.com/status-im/lrucache.nim#1.2.2"
+requires "leopard >= 0.1.0 & < 0.2.0"
+requires "blscurve"
+requires "libp2pdht"
+requires "eth"
 
 when declared(namedBin):
   namedBin = {

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -141,14 +141,17 @@ proc stop*(s: CodexServer) {.async.} =
 
   s.runHandle.complete()
 
-proc new*(T: type CodexServer, config: CodexConf, privateKey: CodexPrivateKey): T =
-
+proc new*(
+    T: type CodexServer,
+    config: CodexConf,
+    privateKey: CodexPrivateKey): CodexServer =
+  ## create CodexServer including setting up datastore, repostore, etc
   let
     switch = SwitchBuilder
     .new()
     .withPrivateKey(privateKey)
     .withAddresses(config.listenAddrs)
-    .withRng(Rng.instance())
+    .withRng(rng.Rng.instance())
     .withNoise()
     .withMplex(5.minutes, 5.minutes)
     .withMaxConnections(config.maxPeers)
@@ -221,6 +224,7 @@ proc new*(T: type CodexServer, config: CodexConf, privateKey: CodexPrivateKey): 
       .expect("Should start rest server!")
 
   switch.mount(network)
+
   T(
     config: config,
     codexNode: codexNode,

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -151,7 +151,7 @@ proc new*(
     .new()
     .withPrivateKey(privateKey)
     .withAddresses(config.listenAddrs)
-    .withRng(rng.Rng.instance())
+    .withRng(Rng.instance())
     .withNoise()
     .withMplex(5.minutes, 5.minutes)
     .withMaxConnections(config.maxPeers)

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -249,7 +249,10 @@ proc getCodexVersion(): string =
   return tag
 
 proc getCodexRevision(): string =
-  strip(staticExec("git rev-parse --short HEAD"))[0..5]
+  # using a slice in a static context breaks nimsuggest for some reason
+  var res = strip(staticExec("git rev-parse --short HEAD"))
+  res.setLen(6)
+  return res
 
 proc getNimBanner(): string =
   staticExec("nim --version | grep Version")


### PR DESCRIPTION
- Fix weird nimsuggest failures with static getCodexVersion and rng.Rng. Now nimsuggest doesn't routinely crash. 
- Some formatting tweaks. It's a style I've seen "in the wild" in a few Nim projects and find that for procs with many variables it helps readability. In particular the return type is much quicker to pick out which helps with `Result` types.