### PR TITLE
Enable codex_enable_api_debug_peers (#471)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,10 @@ env:
   DOCKER_FILE: docker/codex.Dockerfile
   DOCKER_REPO: codexstorage/nim-codex
   MAKE_PARALLEL: 4
+  NIMFLAGS: '-d:disableMarchNative -d:codex_enable_api_debug_peers=true'
+  NIMFLAGS_RELEASE: '-d:disableMarchNative'
+  NAT_IP_AUTO: true
+  NAT_IP_AUTO_RELEASE: false
 
 
 jobs:
@@ -57,6 +61,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Docker - Variables
+        run: |
+          # Release
+          if [[ ${{ startsWith(github.ref, 'refs/tags/') }} == "true" ]]; then
+            echo "NIMFLAGS=${{ env.NIMFLAGS_RELEASE }}" >>$GITHUB_ENV
+            echo "NAT_IP_AUTO=${{ env.NAT_IP_AUTO_RELEASE }}" >>$GITHUB_ENV
+          fi
+
       - name: Docker - Meta
         id: meta
         uses: docker/metadata-action@v4
@@ -83,39 +95,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker - Build and export to Docker
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ${{ env.DOCKER_FILE }}
-          platforms: ${{ env.PLATFORM }}
-          build-args: |
-            MAKE_PARALLEL=${{ env.MAKE_PARALLEL }}
-          load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Docker - Minify image
-        uses: kitabisa/docker-slim-action@v1
-        id: slim
-        env:
-          DSLIM_HTTP_PROBE: false
-        with:
-          target: ${{ steps.meta.outputs.tags }}
-          overwrite: true
-
-      - name: Docker - Show slim report
-        run: echo "${REPORT}" | jq -r
-        env:
-          REPORT: ${{ steps.slim.outputs.report }}
-
-      - name: Docker - Push to Docker registry
+      - name: Docker - Build and Push
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ${{ env.DOCKER_FILE }}
           platforms: ${{ env.PLATFORM }}
           push: true
+          build-args: |
+            MAKE_PARALLEL=${{ env.MAKE_PARALLEL }}
+            NIMFLAGS=${{ env.NIMFLAGS }}
+            NAT_IP_AUTO=${{ env.NAT_IP_AUTO }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,13 +31,19 @@
 
  It means that at the image run it will just run `codex` application without any arguments and we can pass them as a regular arguments, by overriding command
  ```shell
- docker run codexstorage/nim-codex codex --api-bindaddr=0.0.0.0
+ docker run codexstorage/nim-codex codex --api-bindaddr=0.0.0.0 --api-port=8080
  ```
 
 
 ## Environment variables
 
  We can configure Codex using [Environment variables](../README#environment-variables) and [docker-compose.yaml](docker-compose.yaml) file can be useful as an example.
+
+ We also added a temporary environment variable `NAT_IP_AUTO` to the entrypoint which is set as `false` for releases and ` true` for regular builds. That approach is useful for Dist-Tests.
+ ```shell
+ # Disable NAT_IP_AUTO for regular builds
+ docker run -e NAT_IP_AUTO=false codexstorage/nim-codex
+ ```
 
 
 ## Slim

--- a/docker/codex.Dockerfile
+++ b/docker/codex.Dockerfile
@@ -3,14 +3,15 @@ ARG BUILDER=ubuntu:lunar-20230415
 ARG IMAGE=${BUILDER}
 ARG BUILD_HOME=/src
 ARG MAKE_PARALLEL=${MAKE_PARALLEL:-4}
-ARG MAKE_PARAMS=${MAKE_PARAMS:-NIM_PARAMS="-d:disableMarchNative"}
+ARG NIMFLAGS="${NIMFLAGS:-"-d:disableMarchNative"}"
 ARG APP_HOME=/codex
+ARG NAT_IP_AUTO=${NAT_IP_AUTO:-false}
 
 # Build
 FROM ${BUILDER} AS builder
 ARG BUILD_HOME
 ARG MAKE_PARALLEL
-ARG MAKE_PARAMS
+ARG NIMFLAGS
 
 RUN apt-get update && apt-get install -y git cmake curl make bash lcov build-essential nim
 RUN echo 'export NIMBLE_DIR="${HOME}/.nimble"' >> "${HOME}/.bash_env"
@@ -20,16 +21,18 @@ WORKDIR ${BUILD_HOME}
 COPY . .
 RUN make clean
 RUN make -j ${MAKE_PARALLEL} update
-RUN make -j ${MAKE_PARALLEL} ${MAKE_PARAMS}
+RUN make -j ${MAKE_PARALLEL}
 
 # Create
 FROM ${IMAGE}
 ARG BUILD_HOME
 ARG APP_HOME
+ARG NAT_IP_AUTO
 
 WORKDIR ${APP_HOME}
 COPY --from=builder ${BUILD_HOME}/build/codex /usr/local/bin
 COPY --chmod=0755 docker/docker-entrypoint.sh /
 RUN apt-get update && apt-get install -y libgomp1 bash && rm -rf /var/lib/apt/lists/*
+ENV NAT_IP_AUTO=${NAT_IP_AUTO}
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["codex"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Parameters
+if [[ "${NAT_IP_AUTO}" == "true" ]]; then
+  export CODEX_NAT=$(hostname --ip-address)
+  echo "Set CODEX_NAT: ${CODEX_NAT}"
+fi
+
 # Run
 echo "Run Codex node"
 exec "$@"


### PR DESCRIPTION
This PR introduce 2 main changes
 - Enable `codex_enable_api_debug_peers`
 - Add `NAT_IP_AUTO` for Dist-Tests

Also, we disabled slim step as it will be required to change workflow, but the final size is smaller - so it has a good impact
```
linux/amd64 - 60.77 MB / 56.94 MB
linux/arm64 - 61.25 MB / 57.74 MB
```

<details>
<summary>Verification</summary>

**Check regular build** - [sha-00f6554](https://hub.docker.com/layers/codexstorage/nim-codex/sha-00f6554/images/sha256-d6529789bf8dc2d1fd2d14b200f26271a56747d6adc2d2d287676d959d241897?context=explore)
```shell
# Run
docker run --rm -p 8080:8080 codexstorage/nim-codex:sha-00f6554 codex --api-bindaddr=0.0.0.0
Set CODEX_NAT: 172.17.0.2
Run Codex node
...

# Debug peer endpoint
curl -s localhost:8080/api/codex/v1/debug/peer/$(curl -s localhost:8080/api/codex/v1/debug/info | jq -r '.id') | jq -r
{
  "peerId": "16Uiu2HAmSb6pMRVGYbkQwy12edcDATsTrvaCuzU9TDEsjn1zzDjc",
  "seqNo": "1688745198",
  "addresses": [
    {
      "address": "/ip4/172.17.0.2/tcp/38701"
    }
  ]
}

# Disable NAT_IP_AUTO
docker run --rm -p 8080:8080 -e NAT_IP_AUTO=false codexstorage/nim-codex:sha-00f6554 codex --api-bindaddr=0.0.0.0
Run Codex node
...
```

**Check release build** - [0.0.3](https://hub.docker.com/layers/codexstorage/nim-codex/0.0.3/images/sha256-bbf35acef1f198b195261b5842cadd5b6e826df43e3433e4722c2030df33df04?context=explore)
```shell
# Run
docker run --rm -p 8080:8080 codexstorage/nim-codex:0.0.3 codex --api-bindaddr=0.0.0.0
Run Codex node
...

# Debug peer endpoint
curl -s localhost:8080/api/codex/v1/debug/peer/$(curl -s localhost:8080/api/codex/v1/debug/info | jq -r '.id') | jq -r
{
  "peerId": "16Uiu2HAmSb6pMRVGYbkQwy12edcDATsTrvaCuzU9TDEsjn1zzDjc",
  "seqNo": "1688745198",
  "addresses": [
    {
      "address": "/ip4/172.17.0.2/tcp/38701"
    }
  ]
}

# Enable
docker run --rm -p 8080:8080 -e NAT_IP_AUTO=true codexstorage/nim-codex:0.0.3 codex --api-bindaddr=0.0.0.0
Set CODEX_NAT: 172.17.0.2
Run Codex node
...
```

**Conclussions**
1. Endpoint `codex_enable_api_debug_peers` is enabled only on regular builds
2. Option `NAT_IP_AUTO` is set to `true` on regular builds and to `false` on releases
3. We can disable `NAT_IP_AUTO` on regular builds and enable on releases 
</summary>
