### PR TITLE
split windows CI tests into parts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,23 +27,23 @@ jobs:
             cpu: amd64
             builder: windows-latest
             shell: msys2
-            tests: part1
+            tests: unittest
           - os: windows
             cpu: amd64
             builder: windows-latest
             shell: msys2
-            tests: part2
+            tests: contract
           - os: windows
             cpu: amd64
             builder: windows-latest
             shell: msys2
-            tests: part3
+            tests: integration
 
     defaults:
       run:
         shell: ${{ matrix.shell }} {0}
 
-    name: '${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.tests }}'
+    name: '${{ matrix.os }}-${{ matrix.cpu }}-tests-${{ matrix.tests }}'
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:
@@ -61,7 +61,7 @@ jobs:
 
       ## Part 1 Tests ##
       - name: Unit tests
-        if: matrix.tests == 'part1' || matrix.tests == 'all'
+        if: matrix.tests == 'unittest' || matrix.tests == 'all'
         run: make -j${ncpu} test
 
       # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
@@ -71,7 +71,7 @@ jobs:
          node-version: 18.15
 
       - name: Start Ethereum node with Codex contracts
-        if: matrix.tests == 'part2' || matrix.tests == 'part3' || matrix.tests == 'all'
+        if: matrix.tests == 'contract' || matrix.tests == 'integration' || matrix.tests == 'all'
         working-directory: vendor/codex-contracts-eth
         env:
           MSYS2_PATH_TYPE: inherit
@@ -81,12 +81,12 @@ jobs:
 
       ## Part 2 Tests ##
       - name: Contract tests
-        if: matrix.tests == 'part2' || matrix.tests == 'all'
+        if: matrix.tests == 'contract' || matrix.tests == 'all'
         run: make -j${ncpu} testContracts
 
       ## Part 3 Tests ##
       - name: Integration tests
-        if: matrix.tests == 'part3' || matrix.tests == 'all'
+        if: matrix.tests == 'integration' || matrix.tests == 'all'
         run: make -j${ncpu} testIntegration
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,18 @@ jobs:
       - name: Env
         run: env
 
+      - name: Run all tests
+        if: runner.os != 'Windows'
+        run: echo "all"
+
+      - name: Run windows tests part1
+        if: runner.os == 'Windows' && matrix.target.tests == 'part1'
+        run: echo "part1"
+
+      - name: Run windows tests part2
+        if: runner.os == 'Windows' && matrix.target.tests == 'part2'
+        run: echo "part2"
+
       # - name: Unit tests
       #   run: make -j${ncpu} test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,31 +84,31 @@ jobs:
         if: matrix.tests == 'part2' || matrix.tests == 'all'
         run: make -j${ncpu} testIntegration
 
-  # coverage:
-  #   continue-on-error: true
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: recursive
+  coverage:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-  #     - name: Setup Nimbus Build System
-  #       uses: ./.github/actions/nimbus-build-system
-  #       with:
-  #         os: linux
-  #         nim_version: ${{ env.nim_version }}
+      - name: Setup Nimbus Build System
+        uses: ./.github/actions/nimbus-build-system
+        with:
+          os: linux
+          nim_version: ${{ env.nim_version }}
 
-  #     - name: Generate coverage data
-  #       run: make -j${ncpu} coverage
-  #       shell: bash
+      - name: Generate coverage data
+        run: make -j${ncpu} coverage
+        shell: bash
 
-  #     - name: Upload coverage data to Codecov
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         directory: ./coverage/
-  #         fail_ci_if_error: true
-  #         files: ./coverage/coverage.f.info
-  #         flags: unittests
-  #         name: codecov-umbrella
-  #         verbose: true
+      - name: Upload coverage data to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./coverage/
+          fail_ci_if_error: true
+          files: ./coverage/coverage.f.info
+          flags: unittests
+          name: codecov-umbrella
+          verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
          node-version: 18.15
 
       - name: Start Ethereum node with Codex contracts
-        if: matrix.tests == 'part1' || matrix.tests == 'all'
+        if: matrix.tests == 'part1' || matrix.tests == 'part2' || matrix.tests == 'all'
         working-directory: vendor/codex-contracts-eth
         env:
           MSYS2_PATH_TYPE: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,11 @@ jobs:
 
       # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
       - name: Setup Node.js
-        if: matrix.tests == 'part1' || matrix.tests == 'all'
         uses: actions/setup-node@v3
         with:
          node-version: 18.15
 
       - name: Start Ethereum node with Codex contracts
-        if: matrix.tests == 'part1' || matrix.tests == 'part2' || matrix.tests == 'all'
         working-directory: vendor/codex-contracts-eth
         env:
           MSYS2_PATH_TYPE: inherit
@@ -75,11 +73,12 @@ jobs:
           npm install
           npm start &
 
-      ## Part 2 Tests ##
+      ## Part 1 Tests ##
       - name: Contract tests
-        if: matrix.tests == 'part2' || matrix.tests == 'all'
+        if: matrix.tests == 'part1' || matrix.tests == 'all'
         run: make -j${ncpu} testContracts
 
+      ## Part 2 Tests ##
       - name: Integration tests
         if: matrix.tests == 'part2' || matrix.tests == 'all'
         run: make -j${ncpu} testIntegration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
             builder: windows-latest
             shell: msys2
             tests: part2
+          - os: windows
+            cpu: amd64
+            builder: windows-latest
+            shell: msys2
+            tests: part3
 
     defaults:
       run:
@@ -75,12 +80,12 @@ jobs:
 
       ## Part 1 Tests ##
       - name: Contract tests
-        if: matrix.tests == 'part1' || matrix.tests == 'all'
+        if: matrix.tests == 'part2' || matrix.tests == 'all'
         run: make -j${ncpu} testContracts
 
-      ## Part 2 Tests ##
+      ## Part 3 Tests ##
       - name: Integration tests
-        if: matrix.tests == 'part2' || matrix.tests == 'all'
+        if: matrix.tests == 'part3' || matrix.tests == 'all'
         run: make -j${ncpu} testIntegration
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
          node-version: 18.15
 
       - name: Start Ethereum node with Codex contracts
+        if: matrix.tests == 'part2' || matrix.tests == 'part3' || matrix.tests == 'all'
         working-directory: vendor/codex-contracts-eth
         env:
           MSYS2_PATH_TYPE: inherit
@@ -78,7 +79,7 @@ jobs:
           npm install
           npm start &
 
-      ## Part 1 Tests ##
+      ## Part 2 Tests ##
       - name: Contract tests
         if: matrix.tests == 'part2' || matrix.tests == 'all'
         run: make -j${ncpu} testContracts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,17 @@ jobs:
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:
-      # - name: Checkout sources
-      #   uses: actions/checkout@v3
-      #   with:
-      #     submodules: recursive
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-      # - name: Setup Nimbus Build System
-      #   uses: ./.github/actions/nimbus-build-system
-      #   with:
-      #     os: ${{ matrix.os }}
-      #     shell: ${{ matrix.shell }}
-      #     nim_version: ${{ env.nim_version }}
+      - name: Setup Nimbus Build System
+        uses: ./.github/actions/nimbus-build-system
+        with:
+          os: ${{ matrix.os }}
+          shell: ${{ matrix.shell }}
+          nim_version: ${{ env.nim_version }}
 
       - name: Run test part 1
         if: matrix.target.tests == 'part1' || matrix.target.tests == 'all'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,28 +47,24 @@ jobs:
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      # - name: Checkout sources
+      #   uses: actions/checkout@v3
+      #   with:
+      #     submodules: recursive
 
-      - name: Setup Nimbus Build System
-        uses: ./.github/actions/nimbus-build-system
-        with:
-          os: ${{ matrix.os }}
-          shell: ${{ matrix.shell }}
-          nim_version: ${{ env.nim_version }}
+      # - name: Setup Nimbus Build System
+      #   uses: ./.github/actions/nimbus-build-system
+      #   with:
+      #     os: ${{ matrix.os }}
+      #     shell: ${{ matrix.shell }}
+      #     nim_version: ${{ env.nim_version }}
 
-      - name: Run all tests
-        if: runner.os != 'Windows'
-        run: echo "all"
-
-      - name: Run windows tests part1
-        if: runner.os == 'Windows' && matrix.target.tests == 'part1'
+      - name: Run test part 1
+        if: matrix.target.tests == 'part1' || matrix.target.tests == 'all'
         run: echo "part1"
 
-      - name: Run windows tests part2
-        if: runner.os == 'Windows' && matrix.target.tests == 'part2'
+      - name: Run test part 2
+        if: matrix.target.tests == 'part2' || matrix.target.tests == 'all'
         run: echo "part2"
 
       # - name: Unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
-  nim_version: v1.6.10
+  nim_version: v1.6.14
 jobs:
   build:
     strategy:
@@ -35,7 +35,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }} {0}
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch }})'
+    name: '${{ matrix.os }}-${{ matrix.cpu }} (Nim ${{ matrix.branch }})'
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:
@@ -52,11 +52,11 @@ jobs:
           nim_version: ${{ env.nim_version }}
 
       - name: Run test part 1
-        if: matrix.target.tests == 'part1' || matrix.target.tests == 'all'
+        if: matrix.tests == 'part1' || matrix.tests == 'all'
         run: echo "part1"
 
       - name: Run test part 2
-        if: matrix.target.tests == 'part2' || matrix.target.tests == 'all'
+        if: matrix.tests == 'part2' || matrix.tests == 'all'
         run: echo "part2"
 
       # - name: Unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,36 +54,35 @@ jobs:
           shell: ${{ matrix.shell }}
           nim_version: ${{ env.nim_version }}
 
-      - name: Run test part 1
+      ## Part 1 Tests ##
+      - name: Unit tests
         if: matrix.tests == 'part1' || matrix.tests == 'all'
-        run: echo "part1"
+        run: make -j${ncpu} test
 
-      - name: Run test part 2
+      # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
+      - name: Setup Node.js
+        if: matrix.tests == 'part1' || matrix.tests == 'all'
+        uses: actions/setup-node@v3
+        with:
+         node-version: 18.15
+
+      - name: Start Ethereum node with Codex contracts
+        if: matrix.tests == 'part1' || matrix.tests == 'all'
+        working-directory: vendor/codex-contracts-eth
+        env:
+          MSYS2_PATH_TYPE: inherit
+        run: |
+          npm install
+          npm start &
+
+      ## Part 2 Tests ##
+      - name: Contract tests
         if: matrix.tests == 'part2' || matrix.tests == 'all'
-        run: echo "part2"
+        run: make -j${ncpu} testContracts
 
-      # - name: Unit tests
-      #   run: make -j${ncpu} test
-
-      # # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
-      # - name: Setup Node.js
-      #   uses: actions/setup-node@v3
-      #   with:
-      #    node-version: 18.15
-
-      # - name: Start Ethereum node with Codex contracts
-      #   working-directory: vendor/codex-contracts-eth
-      #   env:
-      #     MSYS2_PATH_TYPE: inherit
-      #   run: |
-      #     npm install
-      #     npm start &
-
-      # - name: Contract tests
-      #   run: make -j${ncpu} testContracts
-
-      # - name: Integration tests
-      #   run: make -j${ncpu} testIntegration
+      - name: Integration tests
+        if: matrix.tests == 'part2' || matrix.tests == 'all'
+        run: make -j${ncpu} testIntegration
 
   # coverage:
   #   continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,32 +12,24 @@ jobs:
   build:
     strategy:
       matrix:
-        target:
+        include:
           - os: linux
             cpu: amd64
-            tests: all
-          - os: macos
-            cpu: amd64
-            tests: all
-          - os: windows
-            cpu: amd64
-            tests: part1
-          - os: windows
-            cpu: amd64
-            tests: part2
-        include:
-          - target:
-              os: linux
             builder: ubuntu-latest
             shell: bash --noprofile --norc -e -o pipefail
-          - target:
-              os: macos
+            tests: all
+          - os: macos
             builder: macos-latest
             shell: bash --noprofile --norc -e -o pipefail
-          - target:
-              os: windows
+            tests: all
+          - os: windows
             builder: windows-latest
             shell: msys2
+            tests: part1
+          - os: windows
+            builder: windows-latest
+            shell: msys2
+            tests: part2
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }} {0}
 
-    name: '${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.tests }} (Nim ${{ env.nim_version }})'
+    name: '${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.tests }}'
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,17 @@ jobs:
             shell: bash --noprofile --norc -e -o pipefail
             tests: all
           - os: macos
+            cpu: amd64
             builder: macos-latest
             shell: bash --noprofile --norc -e -o pipefail
             tests: all
           - os: windows
+            cpu: amd64
             builder: windows-latest
             shell: msys2
             tests: part1
           - os: windows
+            cpu: amd64
             builder: windows-latest
             shell: msys2
             tests: part2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,19 @@ jobs:
           - os: linux
             builder: ubuntu-latest
             shell: bash --noprofile --norc -e -o pipefail
+            tests: all
           - os: macos
             builder: macos-latest
             shell: bash --noprofile --norc -e -o pipefail
+            tests: all
           - os: windows
             builder: windows-latest
             shell: msys2
+            tests: part1
+          - os: windows
+            builder: windows-latest
+            shell: msys2
+            tests: part2
 
     defaults:
       run:
@@ -44,54 +51,57 @@ jobs:
           shell: ${{ matrix.shell }}
           nim_version: ${{ env.nim_version }}
 
-      - name: Unit tests
-        run: make -j${ncpu} test
+      - name: Env
+        run: env
 
-      # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-         node-version: 18.15
+      # - name: Unit tests
+      #   run: make -j${ncpu} test
 
-      - name: Start Ethereum node with Codex contracts
-        working-directory: vendor/codex-contracts-eth
-        env:
-          MSYS2_PATH_TYPE: inherit
-        run: |
-          npm install
-          npm start &
+      # # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
+      # - name: Setup Node.js
+      #   uses: actions/setup-node@v3
+      #   with:
+      #    node-version: 18.15
 
-      - name: Contract tests
-        run: make -j${ncpu} testContracts
+      # - name: Start Ethereum node with Codex contracts
+      #   working-directory: vendor/codex-contracts-eth
+      #   env:
+      #     MSYS2_PATH_TYPE: inherit
+      #   run: |
+      #     npm install
+      #     npm start &
 
-      - name: Integration tests
-        run: make -j${ncpu} testIntegration
+      # - name: Contract tests
+      #   run: make -j${ncpu} testContracts
 
-  coverage:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      # - name: Integration tests
+      #   run: make -j${ncpu} testIntegration
 
-      - name: Setup Nimbus Build System
-        uses: ./.github/actions/nimbus-build-system
-        with:
-          os: linux
-          nim_version: ${{ env.nim_version }}
+  # coverage:
+  #   continue-on-error: true
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
 
-      - name: Generate coverage data
-        run: make -j${ncpu} coverage
-        shell: bash
+  #     - name: Setup Nimbus Build System
+  #       uses: ./.github/actions/nimbus-build-system
+  #       with:
+  #         os: linux
+  #         nim_version: ${{ env.nim_version }}
 
-      - name: Upload coverage data to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          directory: ./coverage/
-          fail_ci_if_error: true
-          files: ./coverage/coverage.f.info
-          flags: unittests
-          name: codecov-umbrella
-          verbose: true
+  #     - name: Generate coverage data
+  #       run: make -j${ncpu} coverage
+  #       shell: bash
+
+  #     - name: Upload coverage data to Codecov
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         directory: ./coverage/
+  #         fail_ci_if_error: true
+  #         files: ./coverage/coverage.f.info
+  #         flags: unittests
+  #         name: codecov-umbrella
+  #         verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
-  nim_version: v1.6.14
+  nim_version: v1.6.10
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,17 @@ jobs:
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:
-      # - name: Checkout sources
-      #   uses: actions/checkout@v3
-      #   with:
-      #     submodules: recursive
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-      # - name: Setup Nimbus Build System
-      #   uses: ./.github/actions/nimbus-build-system
-      #   with:
-      #     os: ${{ matrix.os }}
-      #     shell: ${{ matrix.shell }}
-      #     nim_version: ${{ env.nim_version }}
+      - name: Setup Nimbus Build System
+        uses: ./.github/actions/nimbus-build-system
+        with:
+          os: ${{ matrix.os }}
+          shell: ${{ matrix.shell }}
+          nim_version: ${{ env.nim_version }}
 
       - name: Run all tests
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
       #     shell: ${{ matrix.shell }}
       #     nim_version: ${{ env.nim_version }}
 
-      - name: Env
-        run: env
-
       - name: Run all tests
         if: runner.os != 'Windows'
         run: echo "all"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }} {0}
 
-    name: '${{ matrix.os }}-${{ matrix.cpu }} (Nim ${{ env.nim_version }})'
+    name: '${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.tests }} (Nim ${{ env.nim_version }})'
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,16 @@ jobs:
             cpu: amd64
             tests: part2
         include:
-          - os: linux
+          - target:
+              os: linux
             builder: ubuntu-latest
             shell: bash --noprofile --norc -e -o pipefail
-          - os: macos
+          - target:
+              os: macos
             builder: macos-latest
             shell: bash --noprofile --norc -e -o pipefail
-          - os: windows
+          - target:
+              os: windows
             builder: windows-latest
             shell: msys2
 
@@ -44,17 +47,17 @@ jobs:
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      # - name: Checkout sources
+      #   uses: actions/checkout@v3
+      #   with:
+      #     submodules: recursive
 
-      - name: Setup Nimbus Build System
-        uses: ./.github/actions/nimbus-build-system
-        with:
-          os: ${{ matrix.os }}
-          shell: ${{ matrix.shell }}
-          nim_version: ${{ env.nim_version }}
+      # - name: Setup Nimbus Build System
+      #   uses: ./.github/actions/nimbus-build-system
+      #   with:
+      #     os: ${{ matrix.os }}
+      #     shell: ${{ matrix.shell }}
+      #     nim_version: ${{ env.nim_version }}
 
       - name: Env
         run: env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }} {0}
 
-    name: '${{ matrix.os }}'
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch }})'
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,24 +12,29 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [linux, macos, windows]
+        target:
+          - os: linux
+            cpu: amd64
+            tests: all
+          - os: macos
+            cpu: amd64
+            tests: all
+          - os: windows
+            cpu: amd64
+            tests: part1
+          - os: windows
+            cpu: amd64
+            tests: part2
         include:
           - os: linux
             builder: ubuntu-latest
             shell: bash --noprofile --norc -e -o pipefail
-            tests: all
           - os: macos
             builder: macos-latest
             shell: bash --noprofile --norc -e -o pipefail
-            tests: all
           - os: windows
             builder: windows-latest
             shell: msys2
-            tests: part1
-          - os: windows
-            builder: windows-latest
-            shell: msys2
-            tests: part2
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }} {0}
 
-    name: '${{ matrix.os }}-${{ matrix.cpu }} (Nim ${{ matrix.branch }})'
+    name: '${{ matrix.os }}-${{ matrix.cpu }} (Nim ${{ env.nim_version }})'
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:


### PR DESCRIPTION
Splite the unit, contract, and integration tests into separate parts. 

This incurs a slight overhead per Windows VM for duplicating `nimble setup` stages (~3min) but should cut each windows run down to ~20-25min. 

Another possible issue would be CI time. IIRC, Github Actions charge per minute. If so that'd mean the total minutes of CI runner time would roughly be about the same (give or take 3x * 3min or so).

If anyone else knows of other downsides let me know! 
