### PR TITLE
Cancel and wait for asyncstatemachine futures when stopping

### DIFF
--- a/codex/purchasing/purchase.nim
+++ b/codex/purchasing/purchase.nim
@@ -31,13 +31,14 @@ func new*(
     clock: Clock
 ): Purchase =
   ## create a new instance of a Purchase
-  ## 
-  Purchase(
-    future: Future[void].new(),
-    requestId: requestId,
-    market: market,
-    clock: clock
-  )
+  ##
+  var purchase = Purchase.new()
+  purchase.future = Future[void].new()
+  purchase.requestId = requestId
+  purchase.market = market
+  purchase.clock = clock
+
+  return purchase
 
 func new*(
     _: type Purchase,

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -15,10 +15,10 @@ import ./sales/salescontext
 import ./sales/salesagent
 import ./sales/statemachine
 import ./sales/slotqueue
-import ./sales/trackedfutures
 import ./sales/states/preparing
 import ./sales/states/unknown
 import ./utils/then
+import ./utils/trackedfutures
 
 ## Sales holds a list of available storage that it may sell.
 ##

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -32,12 +32,13 @@ proc newSalesAgent*(context: SalesContext,
                     requestId: RequestId,
                     slotIndex: UInt256,
                     request: ?StorageRequest): SalesAgent =
-  SalesAgent(
-    context: context,
-    data: SalesData(
-      requestId: requestId,
-      slotIndex: slotIndex,
-      request: request))
+  var agent = SalesAgent.new()
+  agent.context = context
+  agent.data = SalesData(
+                requestId: requestId,
+                slotIndex: slotIndex,
+                request: request)
+  return agent
 
 proc retrieveRequest*(agent: SalesAgent) {.async.} =
   let data = agent.data
@@ -96,5 +97,5 @@ proc unsubscribe*(agent: SalesAgent) {.async.} =
   agent.subscribed = false
 
 proc stop*(agent: SalesAgent) {.async.} =
-  procCall Machine(agent).stop()
+  await Machine(agent).stop()
   await agent.unsubscribe()

--- a/codex/sales/slotqueue.nim
+++ b/codex/sales/slotqueue.nim
@@ -1,5 +1,4 @@
 import std/sequtils
-import std/sugar
 import std/tables
 import pkg/chronicles
 import pkg/chronos
@@ -7,13 +6,13 @@ import pkg/questionable
 import pkg/questionable/results
 import pkg/upraises
 import ./reservations
-import ./trackedfutures
 import ../errors
 import ../rng
 import ../utils
 import ../contracts/requests
 import ../utils/asyncheapqueue
 import ../utils/then
+import ../utils/trackedfutures
 
 logScope:
   topics = "marketplace slotqueue"

--- a/codex/utils/then.nim
+++ b/codex/utils/then.nim
@@ -22,12 +22,11 @@ import pkg/upraises
 # `.catch` is called when the `Future` fails. In the case when the `Future`
 # returns a `Result[T, ref CatchableError` (or `?!T`), `.catch` will be called
 # if the `Result` contains an error. If the `Future` is already failed (or
-# `Future[?!T]` contains an error), the `.catch` callback will be excuted
+# `Future[?!T]` contains an error), the `.catch` callback will be executed
 # immediately.
 
-# NOTE: Cancelled `Futures` are discarded as bubbling the `CancelledError` to
-# the synchronous closure will likely cause an unintended and unhandled
-# exception.
+# `.cancelled` is called when the `Future` is cancelled. If the `Future` is
+# already cancelled, the `.cancelled` callback will be executed immediately.
 
 # More info on JavaScript's Promise API can be found at:
 # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
@@ -56,44 +55,30 @@ runnableExamples:
 type
   OnSuccess*[T] = proc(val: T) {.gcsafe, upraises: [].}
   OnError* = proc(err: ref CatchableError) {.gcsafe, upraises: [].}
+  OnCancelled* = proc() {.gcsafe, upraises: [].}
 
 proc ignoreError(err: ref CatchableError) = discard
+proc ignoreCancelled() = discard
 
-template returnOrError(future: FutureBase, onError: OnError) =
+template handleFinished(future: FutureBase,
+                        onError: OnError,
+                        onCancelled: OnCancelled) =
+
   if not future.finished:
     return
 
   if future.cancelled:
-    # do not bubble as closure is synchronous
+    onCancelled()
     return
 
   if future.failed:
     onError(future.error)
     return
 
-
-proc then*(future: Future[void],
-           onError: OnError):
-          Future[void] =
+proc then*(future: Future[void], onSuccess: OnSuccess[void]): Future[void] =
 
   proc cb(udata: pointer) =
-    future.returnOrError(onError)
-
-  proc cancellation(udata: pointer) =
-    if not future.finished():
-      future.removeCallback(cb)
-
-  future.addCallback(cb)
-  future.cancelCallback = cancellation
-  return future
-
-proc then*(future: Future[void],
-           onSuccess: OnSuccess[void],
-           onError: OnError = ignoreError):
-          Future[void] =
-
-  proc cb(udata: pointer) =
-    future.returnOrError(onError)
+    future.handleFinished(ignoreError, ignoreCancelled)
     onSuccess()
 
   proc cancellation(udata: pointer) =
@@ -104,42 +89,13 @@ proc then*(future: Future[void],
   future.cancelCallback = cancellation
   return future
 
-proc then*[T](future: Future[T],
-              onSuccess: OnSuccess[T],
-              onError: OnError = ignoreError):
-             Future[T] =
+proc then*[T](future: Future[T], onSuccess: OnSuccess[T]): Future[T] =
 
   proc cb(udata: pointer) =
-    future.returnOrError(onError)
+    future.handleFinished(ignoreError, ignoreCancelled)
 
-    without val =? future.read.catch, err:
-      onError(err)
-      return
-    onSuccess(val)
-
-  proc cancellation(udata: pointer) =
-    if not future.finished():
-      future.removeCallback(cb)
-
-  future.addCallback(cb)
-  future.cancelCallback = cancellation
-  return future
-
-proc then*[T](future: Future[?!T],
-              onSuccess: OnSuccess[T],
-              onError: OnError = ignoreError):
-             Future[?!T] =
-
-  proc cb(udata: pointer) =
-    future.returnOrError(onError)
-
-    try:
-      without val =? future.read, err:
-        onError(err)
-        return
+    if val =? future.read.catch:
       onSuccess(val)
-    except CatchableError as e:
-      onError(e)
 
   proc cancellation(udata: pointer) =
     if not future.finished():
@@ -149,18 +105,16 @@ proc then*[T](future: Future[?!T],
   future.cancelCallback = cancellation
   return future
 
-proc then*(future: Future[?!void],
-           onError: OnError = ignoreError):
-          Future[?!void] =
+proc then*[T](future: Future[?!T], onSuccess: OnSuccess[T]): Future[?!T] =
 
   proc cb(udata: pointer) =
-    future.returnOrError(onError)
+    future.handleFinished(ignoreError, ignoreCancelled)
 
     try:
-      if err =? future.read.errorOption:
-        onError(err)
+      if val =? future.read:
+        onSuccess(val)
     except CatchableError as e:
-      onError(e)
+      ignoreError(e)
 
   proc cancellation(udata: pointer) =
     if not future.finished():
@@ -170,22 +124,17 @@ proc then*(future: Future[?!void],
   future.cancelCallback = cancellation
   return future
 
-proc then*(future: Future[?!void],
-           onSuccess: OnSuccess[void],
-           onError: OnError = ignoreError):
-          Future[?!void] =
+proc then*(future: Future[?!void], onSuccess: OnSuccess[void]): Future[?!void] =
 
   proc cb(udata: pointer) =
-    future.returnOrError(onError)
+    future.handleFinished(ignoreError, ignoreCancelled)
 
     try:
-      if err =? future.read.errorOption:
-        onError(err)
-        return
+      if future.read.isOk:
+        onSuccess()
     except CatchableError as e:
-      onError(e)
+      ignoreError(e)
       return
-    onSuccess()
 
   proc cancellation(udata: pointer) =
     if not future.finished():
@@ -197,8 +146,10 @@ proc then*(future: Future[?!void],
 
 proc catch*[T](future: Future[T], onError: OnError) =
 
+  if future.isNil: return
+
   proc cb(udata: pointer) =
-    future.returnOrError(onError)
+    future.handleFinished(onError, ignoreCancelled)
 
   proc cancellation(udata: pointer) =
     if not future.finished():
@@ -209,8 +160,10 @@ proc catch*[T](future: Future[T], onError: OnError) =
 
 proc catch*[T](future: Future[?!T], onError: OnError) =
 
+  if future.isNil: return
+
   proc cb(udata: pointer) =
-    future.returnOrError(onError)
+    future.handleFinished(onError, ignoreCancelled)
 
     try:
       if err =? future.read.errorOption:
@@ -224,3 +177,31 @@ proc catch*[T](future: Future[?!T], onError: OnError) =
 
   future.addCallback(cb)
   future.cancelCallback = cancellation
+
+proc cancelled*[T](future: Future[T], onCancelled: OnCancelled): Future[T] =
+
+  proc cb(udata: pointer) =
+    future.handleFinished(ignoreError, onCancelled)
+
+  proc cancellation(udata: pointer) =
+    if not future.finished():
+      future.removeCallback(cb)
+    onCancelled()
+
+  future.addCallback(cb)
+  future.cancelCallback = cancellation
+  return future
+
+proc cancelled*[T](future: Future[?!T], onCancelled: OnCancelled): Future[?!T] =
+
+  proc cb(udata: pointer) =
+    future.handleFinished(ignoreError, onCancelled)
+
+  proc cancellation(udata: pointer) =
+    if not future.finished():
+      future.removeCallback(cb)
+    onCancelled()
+
+  future.addCallback(cb)
+  future.cancelCallback = cancellation
+  return future

--- a/tests/codex/sales/testsalesagent.nim
+++ b/tests/codex/sales/testsalesagent.nim
@@ -10,6 +10,7 @@ import pkg/codex/proving
 import ../helpers/mockmarket
 import ../helpers/mockclock
 import ../helpers/eventually
+import ../helpers
 import ../examples
 
 var onCancelCalled = false

--- a/tests/codex/testutils.nim
+++ b/tests/codex/testutils.nim
@@ -3,5 +3,6 @@ import ./utils/testkeyutils
 import ./utils/testasyncstatemachine
 import ./utils/testtimer
 import ./utils/testthen
+import ./utils/testtrackedfutures
 
 {.warning[UnusedImport]: off.}

--- a/tests/codex/utils/testasyncstatemachine.nim
+++ b/tests/codex/utils/testasyncstatemachine.nim
@@ -99,7 +99,7 @@ asyncchecksuite "async state machines":
   test "stops scheduling and current state":
     machine.start(State2.new())
     await sleepAsync(1.millis)
-    machine.stop()
+    await machine.stop()
     machine.schedule(moveToNextStateEvent)
     await sleepAsync(1.millis)
     check runs == [0, 1, 0, 0]
@@ -130,5 +130,5 @@ asyncchecksuite "async state machines":
 
     machine.start(State2.new())
     check eventually machine.query(description).isSome
-    machine.stop()
+    await machine.stop()
     check machine.query(description).isNone

--- a/tests/codex/utils/testtrackedfutures.nim
+++ b/tests/codex/utils/testtrackedfutures.nim
@@ -1,0 +1,67 @@
+import pkg/asynctest
+import pkg/chronos
+import codex/utils/trackedfutures
+import ../helpers/eventually
+import ../helpers
+
+type Module = object
+  trackedFutures: TrackedFutures
+
+asyncchecksuite "tracked futures":
+  var module: Module
+
+  setup:
+    module = Module(trackedFutures: TrackedFutures.new())
+
+  test "starts with zero tracked futures":
+    check module.trackedFutures.len == 0
+
+  test "tracks unfinished futures":
+    let fut = newFuture[void]("test")
+    discard fut.track(module)
+    check module.trackedFutures.len == 1
+
+  test "does not track completed futures":
+    let fut = newFuture[void]("test")
+    fut.complete()
+    discard fut.track(module)
+    check eventually module.trackedFutures.len == 0
+
+  test "does not track failed futures":
+    let fut = newFuture[void]("test")
+    fut.fail((ref CatchableError)(msg: "some error"))
+    discard fut.track(module)
+    check eventually module.trackedFutures.len == 0
+
+  test "does not track cancelled futures":
+    let fut = newFuture[void]("test")
+    await fut.cancelAndWait()
+    discard fut.track(module)
+    check eventually module.trackedFutures.len == 0
+
+  test "removes tracked future when finished":
+    let fut = newFuture[void]("test")
+    discard fut.track(module)
+    fut.complete()
+    check eventually module.trackedFutures.len == 0
+
+  test "removes tracked future when cancelled":
+    let fut = newFuture[void]("test")
+    discard fut.track(module)
+    await fut.cancelAndWait()
+    check eventually module.trackedFutures.len == 0
+
+  test "cancels and removes all tracked futures":
+    let fut1 = newFuture[void]("test1")
+    let fut2 = newFuture[void]("test2")
+    let fut3 = newFuture[void]("test3")
+    discard fut1.track(module)
+    discard fut2.track(module)
+    discard fut3.track(module)
+    await module.trackedFutures.cancelTracked()
+    check eventually fut1.cancelled
+    check eventually fut2.cancelled
+    check eventually fut3.cancelled
+    check eventually module.trackedFutures.len == 0
+
+


### PR DESCRIPTION
Fixes #490.

Previously, the async state machine created futures for the current state's run method, the internal state machine's scheduler, and the `AsyncQueue.pop` that waits for events to be pushed to the queue. During `stop`, all three of these futures are now cancelled and waited before completing `stop`.

The implementation uses the `TrackedFutures` to track both futures, and `machine.trackedFutures.cancelTracked` in `stop`.

Simplifications to the `then` (promise) api were made that removed multiple callbacks in `.then`, borrowed from the javascript promise api. Additionally, the `then` tests were revamped for simplicity.

The `TrackedFutures` module was updated to remove tracked futures when a future is cancelled, and all futures are removed from the table once `cancelTracked` completes cancelling (and waiting) all futures.