### PR TITLE
chore: move the docker-compose volume

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       - 2345:2345/tcp # libp2p
       - 8090:8090/udp # DHT discovery
     volumes:
-      - /datadir:/datadir
+      - ./datadir:/datadir:z
     networks:
       - codex
 networks:


### PR DESCRIPTION
I was playing around with Codex and noticed the `datadir` is created in root (i.e. `/`) of my disk, which is not great.

This PR moves the `datadir` to `docker/` folder when you run something like

```
docker-compose -f docker/docker-compose.yaml up
```

I am also adding `:z` which is useful when you use SELinux to properly label the volume  (https://prefetch.net/blog/2017/09/30/using-docker-volumes-on-selinux-enabled-servers/)