### PR TITLE
[repostore] Retrieve empty blocks

### DIFF
--- a/codex/stores/repostore.nim
+++ b/codex/stores/repostore.nim
@@ -85,6 +85,10 @@ method getBlock*(self: RepoStore, cid: Cid): Future[?!Block] {.async.} =
   ## Get a block from the blockstore
   ##
 
+  if cid.isEmpty:
+    trace "Empty block, ignoring"
+    return success cid.emptyBlock
+
   without key =? makePrefixKey(self.postFixLen, cid), err:
     trace "Error getting key from provider", err = err.msg
     return failure(err)

--- a/tests/codex/stores/testrepostore.nim
+++ b/tests/codex/stores/testrepostore.nim
@@ -19,6 +19,7 @@ import pkg/codex/clock
 
 import ../helpers
 import ../helpers/mockclock
+import ../examples
 import ./commonstoretests
 
 checksuite "Test RepoStore start/stop":
@@ -282,6 +283,28 @@ asyncchecksuite "RepoStore":
 
     check blockExpirations2.len == 1
     assertExpiration(blockExpirations2[0], blk3)
+
+  test "should put empty blocks":
+    let blk = Cid.example.emptyBlock
+    check (await repo.putBlock(blk)).isOk
+
+  test "should get empty blocks":
+    let blk = Cid.example.emptyBlock
+
+    let got = await repo.getBlock(blk.cid)
+    check got.isOk
+    check got.get.cid == blk.cid
+
+  test "should delete empty blocks":
+    let blk = Cid.example.emptyBlock
+    check (await repo.delBlock(blk.cid)).isOk
+
+  test "should have empty block":
+    let blk = Cid.example.emptyBlock
+
+    let has = await repo.hasBlock(blk.cid)
+    check has.isOk
+    check has.get
 
 commonBlockStoreTests(
   "RepoStore Sql backend", proc: BlockStore =

--- a/tests/codex/testerasure.nim
+++ b/tests/codex/testerasure.nim
@@ -2,6 +2,7 @@ import std/sequtils
 
 import pkg/asynctest
 import pkg/chronos
+import pkg/datastore
 import pkg/questionable/results
 
 import pkg/codex/erasure
@@ -21,12 +22,16 @@ asyncchecksuite "Erasure encode/decode":
   var manifest: Manifest
   var store: BlockStore
   var erasure: Erasure
+  var repoDs: Datastore
+  var metaDs: SQLiteDatastore
 
   setup:
     rng = Rng.instance()
     chunker = RandomChunker.new(rng, size = dataSetSize, chunkSize = BlockSize)
     manifest = !Manifest.new(blockSize = BlockSize)
-    store = CacheStore.new(cacheSize = (dataSetSize * 2), chunkSize = BlockSize)
+    repoDs = SQLiteDatastore.new(Memory).tryGet()
+    metaDs = SQLiteDatastore.new(Memory).tryGet()
+    store = RepoStore.new(repoDs, metaDs)
     erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider)
 
     while (


### PR DESCRIPTION
Empty blocks were not retrievable by the RepoStore, and this was causing integration tests to fail when K > 1, as empty blocks were used for padding protected manifests. The failures, however, were only being witnessed on ARM64 (Apple silicon M2's and likely M1's, though untested), and not on AMD64, for reasons that are still unknown. @dryajov was looking into checking that the erasure coding was indeed being done correctly. 