### PR TITLE
Add reusable workflow for Docker

### DIFF
--- a/.github/workflows/docker-dist-tests.yml
+++ b/.github/workflows/docker-dist-tests.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Docker - Dist-Tests
 
 
 on:
@@ -11,7 +11,7 @@ on:
       - '**/*.md'
       - '.gitignore'
       - '.github/**'
-      - '!.github/workflows/docker.yml'
+      - '!.github/workflows/docker-dist-tests.yml'
       - '!.github/workflows/docker-reusable.yml'
       - 'docker/**'
       - '!docker/codex.Dockerfile'
@@ -23,4 +23,8 @@ jobs:
   build-and-push:
     name: Build and Push
     uses: ./.github/workflows/docker-reusable.yml
+    with:
+      nimflags: '-d:disableMarchNative -d:codex_enable_api_debug_peers=true -d:codex_enable_simulated_proof_failures'
+      nat_ip_auto: true
+      tag_suffix: dist-tests
     secrets: inherit

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -1,0 +1,199 @@
+name: Docker - Reusable
+
+
+on:
+  workflow_call:
+    inputs:
+      docker_file:
+        default: docker/codex.Dockerfile
+        description: Dockerfile
+        required: false
+        type: string
+      docker_repo:
+        default: codexstorage/nim-codex
+        description: DockerHub repository
+        required: false
+        type: string
+      make_parallel:
+        default: 4
+        description: Make parallel
+        required: false
+        type: number
+      nimflags:
+        default: '-d:disableMarchNative'
+        description: Nim flags for builds
+        required: false
+        type: string
+      nat_ip_auto:
+        default: false
+        description: Enable NAT IP auto
+        required: false
+        type: boolean
+      tag_latest:
+        default: true
+        description: Set latest tag for Docker images
+        required: false
+        type: boolean
+      tag_sha:
+        default: true
+        description: Set Git short commit as Docker tag
+        required: false
+        type: boolean
+      tag_suffix:
+        default: ''
+        description: Suffix for Docker images tag
+        required: false
+        type: string
+
+
+env:
+  DOCKER_FILE: ${{ inputs.docker_file }}
+  DOCKER_REPO: ${{ inputs.docker_repo }}
+  MAKE_PARALLEL: ${{ inputs.make_parallel }}
+  NIMFLAGS: ${{ inputs.nimflags }}
+  NAT_IP_AUTO: ${{ inputs.nat_ip_auto }}
+  TAG_LATEST: ${{ inputs.tag_latest }}
+  TAG_SHA: ${{ inputs.tag_sha }}
+  TAG_SUFFIX: ${{ inputs.tag_suffix }}
+
+
+jobs:
+  # Build platform specific image
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+        include:
+          - target:
+              os: linux
+              arch: amd64
+            builder: ubuntu-22.04
+          - target:
+              os: linux
+              arch: arm64
+            builder: buildjet-4vcpu-ubuntu-2204-arm
+
+    name: Build ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    runs-on: ${{ matrix.builder }}
+    env:
+      PLATFORM: ${{ format('{0}/{1}', 'linux', matrix.target.arch) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker - Meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_REPO }}
+
+      - name: Docker - Set up Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker - Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker - Build and Push by digest
+        id: build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.PLATFORM }}
+          push: true
+          build-args: |
+            MAKE_PARALLEL=${{ env.MAKE_PARALLEL }}
+            NIMFLAGS=${{ env.NIMFLAGS }}
+            NAT_IP_AUTO=${{ env.NAT_IP_AUTO }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.DOCKER_REPO }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Docker - Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Docker - Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+
+  # Publish multi-platform image
+  publish:
+    name: Publish multi-platform image
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Docker - Variables
+        run: |
+          # Adjust custom suffix when set and
+          if [[ -n "${{ env.TAG_SUFFIX }}" ]]; then
+            echo "TAG_SUFFIX=-${{ env.TAG_SUFFIX }}" >>$GITHUB_ENV
+          fi
+          # Disable SHA tags on tagged release
+          if [[ ${{ startsWith(github.ref, 'refs/tags/') }} == "true" ]]; then
+            echo "TAG_SHA=false" >>$GITHUB_ENV
+          fi
+          # Handle latest and latest-custom using raw
+          if [[ ${{ env.TAG_SHA }} == "false" ]]; then
+            echo "TAG_LATEST=false" >>$GITHUB_ENV
+            echo "TAG_RAW=true" >>$GITHUB_ENV
+            if [[ -z "${{ env.TAG_SUFFIX }}" ]]; then
+              echo "TAG_RAW_VALUE=latest" >>$GITHUB_ENV
+            else
+              echo "TAG_RAW_VALUE=latest-{{ env.TAG_SUFFIX }}" >>$GITHUB_ENV
+            fi
+          else
+            echo "TAG_RAW=false" >>$GITHUB_ENV
+          fi
+
+      - name: Docker - Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+
+      - name: Docker - Set up Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker - Meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_REPO }}
+          flavor: |
+            latest=${{ env.TAG_LATEST }}
+            suffix=${{ env.TAG_SUFFIX }},onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,enable=${{ env.TAG_RAW }},value=latest
+            type=sha,enable=${{ env.TAG_SHA }}
+
+      - name: Docker - Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker - Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.DOCKER_REPO }}@sha256:%s ' *)
+
+      - name: Docker - Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKER_REPO }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
This PR adds reusable workflow for Docker builds (codex-storage/cs-codex-dist-tests/issues/42)
1. Reusable workflow - `docker-reusable.yml`
2. Main workflow - `docker.yml`
3. Dist-Tests workflow - `docker-dist-tests.yml`

####  Usage example
```yaml
# Minimal
jobs:
  build-and-push:
    name: Build and Push
    uses: ./.github/workflows/docker-reusable.yaml
    secrets: inherit

# Fully customized
jobs:
  build-and-push:
    name: Build and Push
    uses: ./.github/workflows/docker-reusable.yaml
    with:
      docker_file: docker/codex.Dockerfile
      docker_repo: codexstorage/nim-codex
      make_parallel: 4
      nat_ip_auto: false
      tag_latest: true
      tag_sha: true
      tag_suffix: ''
    secrets: inherit
```

#### Workflow accept the following parameters
| Parameter       | Default                   |
| --------------- | ------------------------- |
| `docker_file`   | `docker/codex.Dockerfile` |
| `docker_repo`   | `codexstorage/nim-codex`  |
| `make_parallel` | `4`                       |
| `nimflags`      | `-d:disableMarchNative`   |
| `nat_ip_auto`   | `false`                   |
| `tag_latest`    | `true`                    |
| `tag_sha`       | `true`                    |
| `tag_suffix`    | `''`                      |

#### Tags
| # | Configuration                                                   | Git Commit                            | Git Tag                             |
| - | --------------------------------------------------------------- | ------------------------------------- | ----------------------------------- |
| 1 | `tag_latest=false` <br> `tag_sha=true`                          | `sha-af3cc6d`                         | `0.0.1`                             |
| 2 | `tag_latest=true` <br> `tag_sha=false`                          | `latest`                              | `0.0.1` <br> `latest`               |
| 3 | `tag_latest=true` <br> `tag_sha=true`                           | `latest`, `sha-af3cc6d`               | `latest` <br> `0.0.1`               |
| 4 | `tag_latest=false` <br> `tag_sha=true` <br> `tag_suffix=custom` | `sha-af3cc6d-custom`                  | `0.0.1-custom`                      |
| 5 | `tag_latest=true` <br> `tag_sha=false` <br> `tag_suffix=custom` | `latest-custom`                       | `latest-custom` <br> `0.0.1-custom` |
| 6 | `tag_latest=true` <br> `tag_sha=true` <br> `tag_suffix=custom`  | `latest-custom`, `sha-af3cc6d-custom` | `latest-custom`, `0.0.1-custom`     |


#### Test result

```shell
# Main
docker run --rm -p 8080:8080 codexstorage/nim-codex:latest codex --api-bindaddr=0.0.0.0

# Dist-Tests
docker run --rm -p 8080:8080 codexstorage/nim-codex:latest-dist-tests codex --api-bindaddr=0.0.0.0
```
