### PR TITLE
fix: sales concurrency bug

### DIFF
--- a/codex/sales/salescontext.nim
+++ b/codex/sales/salescontext.nim
@@ -29,6 +29,11 @@ type
                   slotIndex: UInt256) {.gcsafe, upraises: [].}
   OnSale* = proc(request: StorageRequest,
                  slotIndex: UInt256) {.gcsafe, upraises: [].}
+
+  # OnFilled has same function as OnSale, but is kept for internal purposes and should not be set by any external
+  # purposes as it is used for freeing Queue Workers after slot is filled. And the callbacks allows only
+  # one callback to be set, so if some other component would use it, it would override the Slot Queue freeing
+  # mechanism which would lead to blocking of the queue.
   OnFilled* = proc(request: StorageRequest,
                  slotIndex: UInt256) {.gcsafe, upraises: [].}
   OnCleanUp* = proc: Future[void] {.gcsafe, upraises: [].}

--- a/codex/sales/salescontext.nim
+++ b/codex/sales/salescontext.nim
@@ -14,6 +14,7 @@ type
     onStore*: ?OnStore
     onClear*: ?OnClear
     onSale*: ?OnSale
+    onFilled*: ?OnFilled
     onCleanUp*: OnCleanUp
     onProve*: ?OnProve
     reservations*: Reservations
@@ -27,5 +28,7 @@ type
   OnClear* = proc(request: StorageRequest,
                   slotIndex: UInt256) {.gcsafe, upraises: [].}
   OnSale* = proc(request: StorageRequest,
+                 slotIndex: UInt256) {.gcsafe, upraises: [].}
+  OnFilled* = proc(request: StorageRequest,
                  slotIndex: UInt256) {.gcsafe, upraises: [].}
   OnCleanUp* = proc: Future[void] {.gcsafe, upraises: [].}

--- a/codex/sales/states/filled.nim
+++ b/codex/sales/states/filled.nim
@@ -38,9 +38,11 @@ method run*(state: SaleFilled, machine: Machine): Future[?State] {.async.} =
   if host == me.some:
     info "Slot succesfully filled", requestId = $data.requestId, slotIndex
 
-    if request =? data.request and slotIndex =? data.slotIndex and
-        onSale =? context.onSale:
-      onSale(request, slotIndex)
+    if request =? data.request and slotIndex =? data.slotIndex:
+      if onSale =? context.onSale:
+        onSale(request, slotIndex)
+      if onFilled =? context.onFilled:
+        onFilled(request, slotIndex)
 
     when codex_enable_proof_failures:
       if context.simulateProofFailures > 0:

--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -401,7 +401,7 @@ asyncchecksuite "Sales":
     check market.filled[0].proof == proof
     check market.filled[0].host == await market.getSigner()
 
-  test "calls onSale when slot is filled":
+  test "calls onFilled when slot is filled":
     var soldAvailability: Availability
     var soldRequest: StorageRequest
     var soldSlotIndex: UInt256


### PR DESCRIPTION
Closes #532.

Since the `onSale` callback can potentially be overridden (for example, like in [`testsales`](https://github.com/codex-storage/nim-codex/blob/9c487d9f028db4e59e3efa96bbf2806baf160a04/tests/codex/sales/testsales.nim#L408)), I have decided to create a new `onFilled` function instead. This function is not public and should only be used to clear the futures of the Queue.

Other options include making the `onSale` function "private" or supporting multiple functions in hooks.