### PR TITLE
Use latest tag for Tags and Default branch only

### DIFF
--- a/.github/workflows/docker-dist-tests.yml
+++ b/.github/workflows/docker-dist-tests.yml
@@ -26,5 +26,6 @@ jobs:
     with:
       nimflags: '-d:disableMarchNative -d:codex_enable_api_debug_peers=true -d:codex_enable_simulated_proof_failures'
       nat_ip_auto: true
+      tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
       tag_suffix: dist-tests
     secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,4 +23,6 @@ jobs:
   build-and-push:
     name: Build and Push
     uses: ./.github/workflows/docker-reusable.yml
+    with:
+      tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
     secrets: inherit


### PR DESCRIPTION
This is a quick fix for possible issue discovered by @AuHau when we can override `latest` tags with a builds from a custom branch. And now
- `tag_latest` will be set to true for `default branch`
- `tag_latest` will be set to true for `tagged commit`

I would like to review that behaviour in the future and I will reborn https://github.com/codex-storage/cs-codex-dist-tests/issues/42 slightly later.