### PR TITLE
Slows down block maintenance iteration

### DIFF
--- a/codex/stores/maintenance.nim
+++ b/codex/stores/maintenance.nim
@@ -42,9 +42,9 @@ proc new*(
     clock: Clock = SystemClock.new()
 ): BlockMaintainer =
   ## Create new BlockMaintainer instance
-  ## 
+  ##
   ## Call `start` to begin looking for for expired blocks
-  ## 
+  ##
   BlockMaintainer(
     repoStore: repoStore,
     interval: interval,
@@ -78,6 +78,7 @@ proc runBlockCheck(self: BlockMaintainer): Future[void] {.async.} =
     if be =? await maybeBeFuture:
       inc numberReceived
       await self.processBlockExpiration(be)
+      await sleepAsync(50.millis)
 
   # If we received fewer blockExpirations from the iterator than we asked for,
   # We're at the end of the dataset and should start from 0 next time.

--- a/tests/integration/testblockexpiration.nim
+++ b/tests/integration/testblockexpiration.nim
@@ -65,7 +65,7 @@ ethersuite "Node block expiration tests":
 
     let contentId = uploadTestFile()
 
-    await sleepAsync(2.seconds)
+    await sleepAsync(3.seconds)
 
     expect TimeoutError:
       discard downloadTestFile(contentId)


### PR DESCRIPTION
This combined with https://github.com/codex-storage/nim-codex/pull/536 have greatly improved node stability and network stability in the continuous testing environment.
