### PR TITLE
chore(logging): decimal stint values

### DIFF
--- a/codex/node.nim
+++ b/codex/node.nim
@@ -254,7 +254,7 @@ proc requestStorage*(
   ## - Run the PoR setup on the erasure dataset
   ## - Call into the marketplace and purchasing contracts
   ##
-  trace "Received a request for storage!", cid, duration, nodes, tolerance, reward, proofProbability, collateral, expiry
+  trace "Received a request for storage!", cid, duration = duration.toString, nodes, tolerance, reward = reward.toString, proofProbability = proofProbability.toString, collateral = collateral.toString, expiry = (expiry |? 0.u256).toString
 
   without contracts =? self.contracts.client:
     trace "Purchasing not available"


### PR DESCRIPTION
If the normal "to-string" operator ($) or default conversion is used on StInt values in logging, then hex encoded values are returned. This changes it to decimal values, but only for one entry 😳

Is there some way to say chronicles to use the `stint`'s `toString` function (which by default returns decimal values) on StInt types?