### PR TITLE
fix: unknown state goes to payout when slot state is finished

### DIFF
--- a/codex/sales/states/unknown.nim
+++ b/codex/sales/states/unknown.nim
@@ -6,6 +6,7 @@ import ./finished
 import ./failed
 import ./errored
 import ./cancelled
+import ./payout
 
 logScope:
     topics = "marketplace sales unknown"
@@ -47,7 +48,9 @@ method run*(state: SaleUnknown, machine: Machine): Future[?State] {.async.} =
     return some State(SaleErrored(error: error))
   of SlotState.Filled:
     return some State(SaleFilled())
-  of SlotState.Finished, SlotState.Paid:
+  of SlotState.Finished:
+    return some State(SalePayout())
+  of SlotState.Paid:
     return some State(SaleFinished())
   of SlotState.Failed:
     return some State(SaleFailed())

--- a/tests/codex/sales/states/testunknown.nim
+++ b/tests/codex/sales/states/testunknown.nim
@@ -8,6 +8,7 @@ import pkg/codex/sales/states/errored
 import pkg/codex/sales/states/filled
 import pkg/codex/sales/states/finished
 import pkg/codex/sales/states/failed
+import pkg/codex/sales/states/payout
 import ../../helpers/mockmarket
 import ../../examples
 import ../../helpers
@@ -45,10 +46,10 @@ checksuite "sales state 'unknown'":
     let next = await state.run(agent)
     check !next of SaleFilled
 
-  test "switches to finished state when on chain state is 'finished'":
+  test "switches to payout state when on chain state is 'finished'":
     market.slotState[slotId] = SlotState.Finished
     let next = await state.run(agent)
-    check !next of SaleFinished
+    check !next of SalePayout
 
   test "switches to finished state when on chain state is 'paid'":
     market.slotState[slotId] = SlotState.Paid


### PR DESCRIPTION
With the merging refactor of the sale and proving state machine, when a slot is "Finished" (i.e., it successfully reached the end of the storage request and the host is now eligible to collect payout), it needs to be paid out. The "unknown" state (i.e., when Codex restarts and loads the slots from the chain) incorrectly passed the state into the "Finished" state machine's state, even though it should collect the payout with the "Payout" state.

It is unlikely that this bug would surface, but it is better to have it corrected :-)