### PR TITLE
Support logging to file

### DIFF
--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -129,7 +129,7 @@ proc bootstrapInteractions(
   return (client, host, validator)
 
 proc start*(s: CodexServer) {.async.} =
-  notice "Starting codex node", config = $s.config
+  trace "Starting codex node", config = $s.config
 
   await s.repoStore.start()
   s.maintenance.start()

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -129,13 +129,7 @@ proc bootstrapInteractions(
   return (client, host, validator)
 
 proc start*(s: CodexServer) {.async.} =
-  notice "Starting codex node",
-    persistence = s.config.persistence,
-    validator = s.config.validator,
-    ethAccount = s.config.ethAccount,
-    simProofFailures = s.config.simulateProofFailures,
-    dataDir = s.config.dataDir,
-    logFile = s.config.logFile
+  notice "Starting codex node", config = $s.config
 
   await s.repoStore.start()
   s.maintenance.start()

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -129,7 +129,13 @@ proc bootstrapInteractions(
   return (client, host, validator)
 
 proc start*(s: CodexServer) {.async.} =
-  notice "Starting codex node"
+  notice "Starting codex node",
+    persistence = s.config.persistence,
+    validator = s.config.validator,
+    ethAccount = s.config.ethAccount,
+    simProofFailures = s.config.simulateProofFailures,
+    dataDir = s.config.dataDir,
+    logFile = s.config.logFile
 
   await s.repoStore.start()
   s.maintenance.start()

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -28,8 +28,11 @@ import pkg/metrics
 import pkg/metrics/chronos_httpserver
 import pkg/stew/shims/net as stewnet
 import pkg/stew/shims/parseutils
+import pkg/stew/byteutils
 import pkg/libp2p
 import pkg/ethers
+import pkg/questionable
+import pkg/questionable/results
 
 import ./discovery
 import ./stores
@@ -260,6 +263,13 @@ type
           hidden
         .}: int
 
+      logFile* {.
+          desc: "Logs to file"
+          defaultValue: string.none
+          name: "log-file"
+          hidden
+        .}: Option[string]
+
     of initNode:
       discard
 
@@ -445,9 +455,10 @@ proc updateLogLevel*(logLevel: string) {.upraises: [ValueError].} =
         warn "Unrecognized logging topic", topic = topicName
 
 proc setupLogging*(conf: CodexConf) =
-  when defaultChroniclesStream.outputs.type.arity != 2:
+  when defaultChroniclesStream.outputs.type.arity != 3:
     warn "Logging configuration options not enabled in the current build"
   else:
+    var logFile: ?IoHandle
     proc noOutput(logLevel: LogLevel, msg: LogOutputStr) = discard
     proc writeAndFlush(f: File, msg: LogOutputStr) =
       try:
@@ -461,6 +472,25 @@ proc setupLogging*(conf: CodexConf) =
 
     proc noColorsFlush(logLevel: LogLevel, msg: LogOutputStr) =
       writeAndFlush(stdout, stripAnsi(msg))
+
+    proc fileFlush(logLevel: LogLevel, msg: LogOutputStr) =
+      if file =? logFile:
+        if error =? file.writeFile(stripAnsi(msg).toBytes).errorOption:
+          error "failed to write to log file", errorCode = $error
+
+    defaultChroniclesStream.outputs[2].writer = noOutput
+    if logFilePath =? conf.logFile and logFilePath.len > 0:
+      let logFileHandle = openFile(
+        logFilePath,
+        {OpenFlags.Write, OpenFlags.Create, OpenFlags.Truncate}
+      )
+      if logFileHandle.isErr:
+        error "failed to open log file",
+          path = logFilePath,
+          errorCode = $logFileHandle.error
+      else:
+        logFile = logFileHandle.option
+        defaultChroniclesStream.outputs[2].writer = fileFlush
 
     defaultChroniclesStream.outputs[1].writer = noOutput
 

--- a/config.nims
+++ b/config.nims
@@ -111,7 +111,7 @@ switch("define", "libp2p_pki_schemes=secp256k1")
 #TODO this infects everything in this folder, ideally it would only
 # apply to codex.nim, but since codex.nims is used for other purpose
 # we can't use it. And codex.cfg doesn't work
-switch("define", "chronicles_sinks=textlines[dynamic],json[dynamic]")
+switch("define", "chronicles_sinks=textlines[dynamic],json[dynamic],textlines[dynamic]")
 
 # begin Nimble config (version 1)
 when system.fileExists("nimble.paths"):

--- a/tests/contracts/testContracts.nim
+++ b/tests/contracts/testContracts.nim
@@ -68,7 +68,8 @@ ethersuite "Marketplace contracts":
     switchAccount(host)
     await waitUntilProofRequired(slotId)
     let missingPeriod = periodicity.periodOf(await provider.currentTime())
-    await provider.advanceTime(periodicity.seconds)
+    let endOfPeriod = periodicity.periodEnd(missingPeriod)
+    await provider.advanceTimeTo(endOfPeriod + 1)
     switchAccount(client)
     await marketplace.markProofAsMissing(slotId, missingPeriod)
 
@@ -77,7 +78,7 @@ ethersuite "Marketplace contracts":
     let address = await host.getAddress()
     await startContract()
     let requestEnd = await marketplace.requestEnd(request.id)
-    await provider.advanceTimeTo(requestEnd.u256)
+    await provider.advanceTimeTo(requestEnd.u256 + 1)
     let startBalance = await token.balanceOf(address)
     await marketplace.freeSlot(slotId)
     let endBalance = await token.balanceOf(address)

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -70,7 +70,7 @@ ethersuite "On-Chain Market":
 
   test "supports withdrawing of funds":
     await market.requestStorage(request)
-    await provider.advanceTimeTo(request.expiry)
+    await provider.advanceTimeTo(request.expiry + 1)
     await market.withdrawFunds(request.id)
 
   test "supports request subscriptions":
@@ -213,7 +213,7 @@ ethersuite "On-Chain Market":
       receivedIds.add(id)
     let subscription = await market.subscribeRequestCancelled(request.id, onRequestCancelled)
 
-    await provider.advanceTimeTo(request.expiry)
+    await provider.advanceTimeTo(request.expiry + 1)
     await market.withdrawFunds(request.id)
     check receivedIds == @[request.id]
     await subscription.unsubscribe()
@@ -252,7 +252,7 @@ ethersuite "On-Chain Market":
       receivedIds.add(requestId)
 
     let subscription = await market.subscribeRequestCancelled(request.id, onRequestCancelled)
-    await provider.advanceTimeTo(request.expiry) # shares expiry with otherRequest
+    await provider.advanceTimeTo(request.expiry + 1) # shares expiry with otherRequest
     await market.withdrawFunds(otherRequest.id)
     check receivedIds.len == 0
     await market.withdrawFunds(request.id)


### PR DESCRIPTION
Closes #554.

As in #554, this supports logging to a file, however in this PR, it is accomplished via a dynamic Chronicle's sink. The reason for a dynamic sink (`textlines[dynamic]`) is so that file logging can be disabled, because Chronicles' default behavior for `textlines[file]` is to log to a default file.

The main drawback, as discussed in #554 is that the file is not closed, which is no better than Chronicles. I did attempt to return the opened file from `setupLogging` and subsequently close it (on SIGINT and SIGTERM), however Chronicles continues to log past these events, so handling of file close would need to come after Chronicles is done with it (I'm not entirely sure if this is doable).