### PR TITLE
feat: partial payouts for cancelled requests

### DIFF
--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -54,6 +54,7 @@ type
     Finished
     Failed
     Paid
+    Cancelled
 
 proc `==`*(x, y: Nonce): bool {.borrow.}
 proc `==`*(x, y: RequestId): bool {.borrow.}

--- a/codex/purchasing/states/cancelled.nim
+++ b/codex/purchasing/states/cancelled.nim
@@ -22,4 +22,4 @@ method run*(state: PurchaseCancelled, machine: Machine): Future[?State] {.async.
   await purchase.market.withdrawFunds(purchase.requestId)
 
   let error = newException(Timeout, "Purchase cancelled due to timeout")
-  return some State(PurchaseErrored(error: error))
+  purchase.future.fail(error)

--- a/codex/purchasing/states/submitted.nim
+++ b/codex/purchasing/states/submitted.nim
@@ -33,7 +33,7 @@ method run*(state: PurchaseSubmitted, machine: Machine): Future[?State] {.async.
     await subscription.unsubscribe()
 
   proc withTimeout(future: Future[void]) {.async.} =
-    let expiry = request.expiry.truncate(int64)
+    let expiry = request.expiry.truncate(int64) + 1
     await future.withTimeout(clock, expiry)
 
   try:

--- a/codex/purchasing/states/submitted.nim
+++ b/codex/purchasing/states/submitted.nim
@@ -33,15 +33,6 @@ method run*(state: PurchaseSubmitted, machine: Machine): Future[?State] {.async.
     await subscription.unsubscribe()
 
   proc withTimeout(future: Future[void]) {.async.} =
-    # while true:
-    #   await clock.waitUntil(max(clock.now+1, request.expiry.truncate(int64)))
-    #
-    #   if (state =? await agent.retrieveRequestState()) and state == RequestState.Cancelled:
-    #     agent.schedule(cancelledEvent(request))
-    #     break
-    #
-    #   trace "Request is not yet cancelled, even it should be. Waiting some more."
-
     let expiry = request.expiry.truncate(int64) + 1
     await future.withTimeout(clock, expiry)
 

--- a/codex/purchasing/states/submitted.nim
+++ b/codex/purchasing/states/submitted.nim
@@ -33,6 +33,15 @@ method run*(state: PurchaseSubmitted, machine: Machine): Future[?State] {.async.
     await subscription.unsubscribe()
 
   proc withTimeout(future: Future[void]) {.async.} =
+    # while true:
+    #   await clock.waitUntil(max(clock.now+1, request.expiry.truncate(int64)))
+    #
+    #   if (state =? await agent.retrieveRequestState()) and state == RequestState.Cancelled:
+    #     agent.schedule(cancelledEvent(request))
+    #     break
+    #
+    #   trace "Request is not yet cancelled, even it should be. Waiting some more."
+
     let expiry = request.expiry.truncate(int64) + 1
     await future.withTimeout(clock, expiry)
 

--- a/codex/sales/states/cancelled.nim
+++ b/codex/sales/states/cancelled.nim
@@ -1,4 +1,5 @@
 import pkg/chronicles
+import ../salesagent
 import ../statemachine
 import ./errorhandling
 import ./errored
@@ -14,5 +15,18 @@ type
 method `$`*(state: SaleCancelled): string = "SaleCancelled"
 
 method run*(state: SaleCancelled, machine: Machine): Future[?State] {.async.} =
+  let data = SalesAgent(machine).data
+  let market = SalesAgent(machine).context.market
+
+  without request =? data.request:
+    raiseAssert "no sale request"
+
+  without slotIndex =? data.slotIndex:
+    raiseAssert("no slot index assigned")
+
+  let slot = Slot(request: request, slotIndex: slotIndex)
+  debug "Collecting collateral and partial payout",  requestId = $data.requestId, slotIndex
+  await market.freeSlot(slot.id)
+
   let error = newException(SaleTimeoutError, "Sale cancelled due to timeout")
   return some State(SaleErrored(error: error))

--- a/codex/sales/states/failed.nim
+++ b/codex/sales/states/failed.nim
@@ -1,4 +1,5 @@
 import pkg/chronicles
+import ../salesagent
 import ../statemachine
 import ./errorhandling
 import ./errored
@@ -13,5 +14,18 @@ type
 method `$`*(state: SaleFailed): string = "SaleFailed"
 
 method run*(state: SaleFailed, machine: Machine): Future[?State] {.async.} =
+  let data = SalesAgent(machine).data
+  let market = SalesAgent(machine).context.market
+
+  without request =? data.request:
+    raiseAssert "no sale request"
+
+  without slotIndex =? data.slotIndex:
+    raiseAssert("no slot index assigned")
+
+  let slot = Slot(request: request, slotIndex: slotIndex)
+  debug "Removing slot from mySlots",  requestId = $data.requestId, slotIndex
+  await market.freeSlot(slot.id)
+
   let error = newException(SaleFailedError, "Sale failed")
   return some State(SaleErrored(error: error))

--- a/codex/sales/states/unknown.nim
+++ b/codex/sales/states/unknown.nim
@@ -55,4 +55,4 @@ method run*(state: SaleUnknown, machine: Machine): Future[?State] {.async.} =
   of SlotState.Failed:
     return some State(SaleFailed())
   of SlotState.Cancelled:
-    return some State(SalePayout())
+    return some State(SaleCancelled())

--- a/codex/sales/states/unknown.nim
+++ b/codex/sales/states/unknown.nim
@@ -54,3 +54,5 @@ method run*(state: SaleUnknown, machine: Machine): Future[?State] {.async.} =
     return some State(SaleFinished())
   of SlotState.Failed:
     return some State(SaleFailed())
+  of SlotState.Cancelled:
+    return some State(SalePayout())

--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -453,10 +453,34 @@ asyncchecksuite "Sales":
       return success()
     createAvailability()
     await market.requestStorage(request)
+
+    # If we would not await, then the `clock.set` would run "too fast" as the `subscribeCancellation()`
+    # would otherwise not set the timeout early enough as it uses `clock.now` in the deadline calculation.
+    await sleepAsync(chronos.milliseconds(100))
     market.requestState[request.id]=RequestState.Cancelled
     clock.set(request.expiry.truncate(int64)+1)
     check eventually (await reservations.all(Availability)).get == @[availability]
     check getAvailability().size == origSize
+
+  test "verifies that request is indeed expired from onchain before firing onCancelled":
+    let origSize = availability.size
+    sales.onStore = proc(request: StorageRequest,
+                         slot: UInt256,
+                         onBatch: BatchProc): Future[?!void] {.async.} =
+      await sleepAsync(chronos.hours(1))
+      return success()
+    createAvailability()
+    await market.requestStorage(request)
+    market.requestState[request.id]=RequestState.New # "On-chain" is the request still ongoing even after local expiration
+
+    # If we would not await, then the `clock.set` would run "too fast" as the `subscribeCancellation()`
+    # would otherwise not set the timeout early enough as it uses `clock.now` in the deadline calculation.
+    await sleepAsync(chronos.milliseconds(100))
+    clock.set(request.expiry.truncate(int64)+1)
+    check getAvailability().size == 0
+
+    market.requestState[request.id]=RequestState.Cancelled # Now "on-chain" is also expired
+    check eventually getAvailability().size == origSize
 
   test "loads active slots from market":
     let me = await market.getSigner()

--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -453,7 +453,8 @@ asyncchecksuite "Sales":
       return success()
     createAvailability()
     await market.requestStorage(request)
-    clock.set(request.expiry.truncate(int64))
+    market.requestState[request.id]=RequestState.Cancelled
+    clock.set(request.expiry.truncate(int64)+1)
     check eventually (await reservations.all(Availability)).get == @[availability]
     check getAvailability().size == origSize
 

--- a/tests/codex/testpurchasing.nim
+++ b/tests/codex/testpurchasing.nim
@@ -105,7 +105,7 @@ asyncchecksuite "Purchasing":
     let purchase = await purchasing.purchase(request)
     check eventually market.requested.len > 0
     let request = market.requested[0]
-    clock.set(request.expiry.truncate(int64))
+    clock.set(request.expiry.truncate(int64) + 1)
     expect PurchaseTimeout:
       await purchase.wait()
 
@@ -113,7 +113,7 @@ asyncchecksuite "Purchasing":
     let purchase = await purchasing.purchase(request)
     check eventually market.requested.len > 0
     let request = market.requested[0]
-    clock.set(request.expiry.truncate(int64))
+    clock.set(request.expiry.truncate(int64) + 1)
     expect PurchaseTimeout:
       await purchase.wait()
     check market.withdrawn == @[request.id]

--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -1,10 +1,17 @@
 import std/random
+import std/strutils
 import std/sequtils
 import std/times
 import std/typetraits
 import pkg/codex/contracts/requests
 import pkg/codex/sales/slotqueue
 import pkg/stint
+
+proc exampleString*(length: int): string =
+  let chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  result = newString(length) # Create a new empty string with a given length
+  for i in 0..<length:
+    result[i] = chars[rand(chars.len-1)] # Generate a random index and set the string's character
 
 proc example*[T: SomeInteger](_: type T): T =
   rand(T)

--- a/tests/integration/codexclient.nim
+++ b/tests/integration/codexclient.nim
@@ -64,10 +64,11 @@ proc getPurchase*(client: CodexClient, purchaseId: PurchaseId): ?!RestPurchase =
   let json = ? parseJson(body).catch
   RestPurchase.fromJson(json)
 
-proc getSlots*(client: CodexClient): JsonNode =
+proc getSlots*(client: CodexClient): ?!seq[Slot] =
   let url = client.baseurl & "/sales/slots"
   let body = client.http.getContent(url)
-  parseJson(body).catch |? nil
+  let json = ? parseJson(body).catch
+  seq[Slot].fromJson(json)
 
 proc postAvailability*(
     client: CodexClient,

--- a/tests/integration/testIntegration.nim
+++ b/tests/integration/testIntegration.nim
@@ -10,6 +10,7 @@ import pkg/codex/utils/stintutils
 import ../contracts/time
 import ../contracts/deployment
 import ../codex/helpers
+import ../examples
 import ./twonodes
 
 
@@ -174,12 +175,12 @@ twonodessuite "Integration tests", debug1 = false, debug2 = false:
 
     # client 2 makes storage available
     let startBalanceClient2 = await token.balanceOf(account2)
-    discard client2.postAvailability(size=0xFFFFF.u256, duration=200.u256, minPrice=300.u256, maxCollateral=300.u256).get
+    discard client2.postAvailability(size=140000.u256, duration=200.u256, minPrice=300.u256, maxCollateral=300.u256).get
 
     # client 1 requests storage but requires two nodes to host the content
     let startBalanceClient1 = await token.balanceOf(account1)
     let expiry = (await provider.currentTime()) + 10
-    let cid = client1.upload("some file contents").get
+    let cid = client1.upload(exampleString(100000)).get
     let id = client1.requestStorage(cid, duration=duration, reward=reward, proofProbability=3.u256, expiry=expiry, collateral=200.u256, nodes=2).get
 
     check eventually(client1.purchaseStateIs(id, "errored"), 20000)


### PR DESCRIPTION
Adds support for partial payouts of canceled requests.

Also closes #556 and fixes off-by-one bug for calling `withdrawFunds()` contract function for canceled requests which leads to errors "Request is not expired yet".

The integration test is failing, though, because of the Hardhat's mining mode - automine. The time needs to be advanced (eq. mined block) before calling the `withdrawFunds()` function for the canceled request, but I have not figured out any way how to do it in the test's code. I have tried switching the Hardhat's mining mode into mining block every second and for that the test worked. Maybe we should consider changing the mining mode? It had brought us more problems recently 😳

The PR is blocked by the contract's PR: https://github.com/codex-storage/codex-contracts-eth/pull/69

Also closes https://github.com/codex-storage/codex-contracts-eth/issues/57