### PR TITLE
Use token for coverage data upload to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,4 +118,5 @@ jobs:
           files: ./coverage/coverage.f.info
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
### Description

This is an attempt to fix the issue reported by @tbekas with the Codecov data upload - [Upload coverage data to Codecov](https://github.com/codex-storage/nim-codex/actions/runs/6558809503/job/17814929442).

The issue is discussed here - ["Unable to locate build via Github Actions API" for the public repository #837](https://github.com/codecov/codecov-action/issues/837) and per [description](https://github.com/codecov/codecov-action/issues/837#issuecomment-1453877750) is related to the `GitHub's rate-limiting policy`.

Also discussion started on the Community board - [Upload Issues (`Unable to locate build via Github Actions API`)](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954), but it is archived.

Current solution is to use token for Codecov data upload, but it will not work for PR's from forks. Currently, we run workflow on PR's as well
https://github.com/codex-storage/nim-codex/blob/5f4218ba1c8f53ecc050a3a214000bd946ce6965/.github/workflows/ci.yml#L2-L7

Codecov action [v4.0.0-beta.1](https://github.com/codecov/codecov-action/releases/tag/v4.0.0-beta.1) introduces breaking changes
> Tokenless uploading is unsuported

And this is one more argument to switch off tokenless upload


### Proposal
1. We've added a Repository upload token to GitHub Actions secrets
2. Updated workflow to use token for upload
