### PR TITLE
test: integration tests listen on localhost

### DIFF
--- a/tests/integration/multinodes.nim
+++ b/tests/integration/multinodes.nim
@@ -86,6 +86,7 @@ template multinodesuite*(name: string,
         "--api-port=" & $(8080 + index),
         "--data-dir=" & datadir,
         "--nat=127.0.0.1",
+        "--listen-addrs=/ip4/127.0.0.1/tcp/0",
         "--disc-ip=127.0.0.1",
         "--disc-port=" & $(8090 + index),
         "--eth-account=" & $accounts[index]]

--- a/tests/integration/testblockexpiration.nim
+++ b/tests/integration/testblockexpiration.nim
@@ -26,6 +26,7 @@ ethersuite "Node block expiration tests":
       "--api-port=8080",
       "--data-dir=" & dataDir,
       "--nat=127.0.0.1",
+      "--listen-addrs=/ip4/127.0.0.1/tcp/0",
       "--disc-ip=127.0.0.1",
       "--disc-port=8090",
       "--block-ttl=" & $blockTtlSeconds,

--- a/tests/integration/testproofs.nim
+++ b/tests/integration/testproofs.nim
@@ -63,6 +63,7 @@ twonodessuite "Proving integration test", debug1=false, debug2=false:
         "--data-dir=" & validatorDir,
         "--api-port=8089",
         "--disc-port=8099",
+        "--listen-addrs=/ip4/127.0.0.1/tcp/0",
         "--validator",
         "--eth-account=" & $accounts[2]
       ], debug = false

--- a/tests/integration/twonodes.nim
+++ b/tests/integration/twonodes.nim
@@ -38,6 +38,7 @@ template twonodessuite*(name: string, debug1, debug2: string, body) =
         "--nat=127.0.0.1",
         "--disc-ip=127.0.0.1",
         "--disc-port=8090",
+        "--listen-addrs=/ip4/127.0.0.1/tcp/0",
         "--persistence",
         "--eth-account=" & $account1
       ]
@@ -56,6 +57,7 @@ template twonodessuite*(name: string, debug1, debug2: string, body) =
         "--nat=127.0.0.1",
         "--disc-ip=127.0.0.1",
         "--disc-port=8091",
+        "--listen-addrs=/ip4/127.0.0.1/tcp/0",
         "--bootstrap-node=" & bootstrap,
         "--persistence",
         "--eth-account=" & $account2


### PR DESCRIPTION
When I run integration tests on my Mac with some security enabled I get:

![image](https://github.com/codex-storage/nim-codex/assets/6072250/eec8e7fb-1df5-44cc-8075-cc770ae18ff7)

This fixes it by listening on localhost instead of `0.0.0.0` which is a no-no for macOS 😅