### PR TITLE
fix: require expiry from api

### DIFF
--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -65,7 +65,6 @@ proc bootstrapInteractions(
     config = s.config
     repo = s.repoStore
 
-  s.codexNode.clock = SystemClock()
 
   if not config.persistence and not config.validator:
     if config.ethAccount.isSome or config.ethPrivateKey.isSome:
@@ -113,6 +112,8 @@ proc bootstrapInteractions(
 
   if config.validator or config.persistence:
     s.codexNode.clock = clock
+  else:
+    s.codexNode.clock = SystemClock()
 
   if config.persistence:
     # This is used for simulation purposes. Normal nodes won't be compiled with this flag

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -34,6 +34,7 @@ import ./utils/fileutils
 import ./erasure
 import ./discovery
 import ./contracts
+import ./systemclock
 import ./contracts/clock
 import ./contracts/deployment
 import ./utils/addrutils
@@ -55,12 +56,16 @@ type
   EthWallet = ethers.Wallet
 
 proc bootstrapInteractions(
-    config: CodexConf,
-    repo: RepoStore
-): Future[Contracts] {.async.} =
+    s: CodexServer
+): Future[void] {.async.} =
   ## bootstrap interactions and return contracts
   ## using clients, hosts, validators pairings
   ##
+  let
+    config = s.config
+    repo = s.repoStore
+
+  s.codexNode.clock = SystemClock()
 
   if not config.persistence and not config.validator:
     if config.ethAccount.isSome or config.ethPrivateKey.isSome:
@@ -106,6 +111,9 @@ proc bootstrapInteractions(
   var host: ?HostInteractions
   var validator: ?ValidatorInteractions
 
+  if config.validator or config.persistence:
+    s.codexNode.clock = clock
+
   if config.persistence:
     # This is used for simulation purposes. Normal nodes won't be compiled with this flag
     # and hence the proof failure will always be 0.
@@ -126,7 +134,7 @@ proc bootstrapInteractions(
     let validation = Validation.new(clock, market, config.validatorMaxSlots)
     validator = some ValidatorInteractions.new(clock, validation)
 
-  return (client, host, validator)
+  s.codexNode.contracts = (client, host, validator)
 
 proc start*(s: CodexServer) {.async.} =
   trace "Starting codex node", config = $s.config
@@ -161,7 +169,7 @@ proc start*(s: CodexServer) {.async.} =
   s.codexNode.discovery.updateAnnounceRecord(announceAddrs)
   s.codexNode.discovery.updateDhtRecord(s.config.nat, s.config.discoveryPort)
 
-  s.codexNode.contracts = await bootstrapInteractions(s.config, s.repoStore)
+  await s.bootstrapInteractions()
   await s.codexNode.start()
   s.restServer.start()
 

--- a/codex/contracts/interactions/interactions.nim
+++ b/codex/contracts/interactions/interactions.nim
@@ -10,7 +10,7 @@ type
     clock*: Clock
 
 method start*(self: ContractInteractions) {.async, base.} =
-  await self.clock.start()
+  discard
 
 method stop*(self: ContractInteractions) {.async, base.} =
-  await self.clock.stop()
+  discard

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -26,6 +26,7 @@ import pkg/libp2p/routing_record
 import pkg/libp2p/signed_envelope
 
 import ./chunker
+import ./clock
 import ./blocktype as bt
 import ./manifest
 import ./merkletree
@@ -62,6 +63,7 @@ type
     erasure*: Erasure
     discovery*: Discovery
     contracts*: Contracts
+    clock*: Clock
 
   OnManifest* = proc(cid: Cid, manifest: Manifest): void {.gcsafe, closure.}
 
@@ -418,6 +420,9 @@ proc start*(node: CodexNodeRef) {.async.} =
   if not node.discovery.isNil:
     await node.discovery.start()
 
+  if not node.clock.isNil:
+    await node.clock.start()
+
   if hostContracts =? node.contracts.host:
     # TODO: remove Sales callbacks, pass BlockStore and StorageProofs instead
     hostContracts.sales.onStore = proc(request: StorageRequest,
@@ -498,6 +503,9 @@ proc stop*(node: CodexNodeRef) {.async.} =
 
   if not node.discovery.isNil:
     await node.discovery.stop()
+
+  if not node.clock.isNil:
+    await node.clock.stop()
 
   if clientContracts =? node.contracts.client:
     await clientContracts.stop()

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -320,7 +320,7 @@ proc requestStorage*(
   tolerance: uint,
   reward: UInt256,
   collateral: UInt256,
-  expiry = UInt256.none): Future[?!PurchaseId] {.async.} =
+  expiry:  UInt256): Future[?!PurchaseId] {.async.} =
   ## Initiate a request for storage sequence, this might
   ## be a multistep procedure.
   ##
@@ -384,7 +384,7 @@ proc requestStorage*(
         name: @[]       # TODO: PoR setup
       )
     ),
-    expiry: expiry |? 0.u256
+    expiry: expiry
   )
 
   let purchase = await contracts.purchasing.purchase(request)

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -13,7 +13,6 @@ push: {.upraises: [].}
 
 
 import std/sequtils
-import std/times
 
 import pkg/questionable
 import pkg/questionable/results

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -135,6 +135,7 @@ components:
         - duration
         - proofProbability
         - collateral
+        - expiry
       properties:
         duration:
           $ref: "#/components/schemas/Duration"

--- a/tests/integration/codexclient.nim
+++ b/tests/integration/codexclient.nim
@@ -3,7 +3,6 @@ import std/strutils
 import std/sequtils
 
 from pkg/libp2p import Cid, `$`, init
-# from std/json import `[]=`
 import pkg/chronicles
 import pkg/stint
 import pkg/questionable/results
@@ -76,7 +75,6 @@ proc requestStorageRaw*(
       "proofProbability": proofProbability,
       "collateral": collateral,
       "nodes": nodes,
-      # "expiry": expiry,
       "tolerance": tolerance
     }
 


### PR DESCRIPTION
This PR makes the `expiry` parameter of the `requestStorage` API call mandatory, as it is not trivial to estimate it so we are "offloading" this to the user.

As I wanted to check that the "expiry is in future", I had to refactor `node.nim` to have the `clock` instance directly there and available in the API handler.

The branch is based on the `feat/set-ttl-for-requests-expiry` because of the changes to the `Clock` interface there.

Closes #611 