### PR TITLE
refactor: move expiry update from fetchBatched

### DIFF
--- a/codex/errors.nim
+++ b/codex/errors.nim
@@ -8,6 +8,8 @@
 ## those terms.
 
 import pkg/stew/results
+import pkg/chronos
+import pkg/questionable/results
 
 export results
 
@@ -26,3 +28,13 @@ template mapFailure*[T, V, E](
 
 template mapFailure*[T, V](exp: Result[T, V]): Result[T, ref CatchableError] =
   mapFailure(exp, CodexError)
+
+proc allFutureResult*[T](fut: seq[Future[T]]): Future[?!void] {.async.} =
+  try:
+    await allFuturesThrowing(fut)
+  except CancelledError as exc:
+    raise exc
+  except CatchableError as exc:
+    return failure(exc.msg)
+
+  return success()

--- a/codex/node/batch.nim
+++ b/codex/node/batch.nim
@@ -1,6 +1,7 @@
 import pkg/chronos
+import pkg/questionable/results
 import pkg/upraises
 import ../blocktype as bt
 
 type
-  BatchProc* = proc(blocks: seq[bt.Block]): Future[void] {.gcsafe, upraises:[].}
+  BatchProc* = proc(blocks: seq[bt.Block]): Future[?!void] {.gcsafe, upraises:[].}

--- a/tests/codex/testnode.nim
+++ b/tests/codex/testnode.nim
@@ -133,21 +133,6 @@ asyncchecksuite "Test Node":
           check blocks.len > 0 and blocks.len <= batchSize
       )).tryGet()
 
-  test "Block Batching with expiry":
-    let
-      manifest = await Manifest.fetch(chunker)
-      # The blocks have set default TTL, so in order to update it we have to have larger TTL
-      expectedExpiry: SecondsSince1970 = clock.now + DefaultBlockTtl.seconds + 123
-
-    (await node.fetchBatched(manifest, expiry=some expectedExpiry)).tryGet()
-
-    for index in 0..<manifest.blocksCount:
-      let blk = (await localStore.getBlock(manifest.treeCid, index)).tryGet
-      let expiryKey = (createBlockExpirationMetadataKey(blk.cid)).tryGet
-      let expiry = await localStoreMetaDs.get(expiryKey)
-
-      check (expiry.tryGet).toSecondsSince1970 == expectedExpiry
-
   test "Store and retrieve Data Stream":
     let
       stream = BufferStream.new()
@@ -306,3 +291,9 @@ asyncchecksuite "Test Node - host contracts":
 
     check fetchedBytes == 2291520
 
+    for index in 0..<manifest.blocksCount:
+      let blk = (await localStore.getBlock(manifest.treeCid, index)).tryGet
+      let expiryKey = (createBlockExpirationMetadataKey(blk.cid)).tryGet
+      let expiry = await localStoreMetaDs.get(expiryKey)
+
+      check (expiry.tryGet).toSecondsSince1970 == request.expiry.toSecondsSince1970

--- a/tests/codex/testnode.nim
+++ b/tests/codex/testnode.nim
@@ -1,6 +1,7 @@
 import std/os
 import std/options
 import std/math
+import std/times
 
 import pkg/asynctest
 import pkg/chronos
@@ -28,6 +29,9 @@ import ../examples
 import ./helpers
 import ./helpers/mockmarket
 import ./helpers/mockclock
+
+proc toTimesDuration(d: chronos.Duration): times.Duration =
+  initDuration(seconds=d.seconds)
 
 asyncchecksuite "Test Node":
   let
@@ -281,6 +285,7 @@ asyncchecksuite "Test Node - host contracts":
     let onStore = !sales.onStore
     var request = StorageRequest.example
     request.content.cid = manifestCid
+    request.expiry = (getTime() + DefaultBlockTtl.toTimesDuration + 1.hours).toUnix.u256
     var fetchedBytes: uint = 0
 
     let onBatch = proc(blocks: seq[bt.Block]) {.async.} =

--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -2,9 +2,16 @@ import std/random
 import std/sequtils
 import std/times
 import std/typetraits
+
 import pkg/codex/contracts/requests
 import pkg/codex/sales/slotqueue
+import pkg/codex/stores
+
 import pkg/stint
+import pkg/chronos
+
+proc toTimesDuration(d: chronos.Duration): times.Duration =
+  initDuration(seconds=d.seconds)
 
 proc exampleString*(length: int): string =
   let chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -46,7 +53,7 @@ proc example*(_: type StorageRequest): StorageRequest =
       cid: "zb2rhheVmk3bLks5MgzTqyznLu1zqGH5jrfTA1eAZXrjx7Vob",
       merkleRoot: array[32, byte].example
     ),
-    expiry: (getTime() + initDuration(hours=1)).toUnix.u256,
+    expiry: (getTime() + 1.hours + DefaultBlockTtl.toTimesDuration).toUnix.u256,
     nonce: Nonce.example
   )
 

--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -8,11 +8,6 @@ import pkg/codex/sales/slotqueue
 import pkg/codex/stores
 
 import pkg/stint
-import pkg/chronos
-
-proc toTimesDuration(d: chronos.Duration): times.Duration =
-  initDuration(seconds=d.seconds)
-
 proc exampleString*(length: int): string =
   let chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
   result = newString(length) # Create a new empty string with a given length
@@ -53,7 +48,7 @@ proc example*(_: type StorageRequest): StorageRequest =
       cid: "zb2rhheVmk3bLks5MgzTqyznLu1zqGH5jrfTA1eAZXrjx7Vob",
       merkleRoot: array[32, byte].example
     ),
-    expiry: (getTime() + 1.hours + DefaultBlockTtl.toTimesDuration).toUnix.u256,
+    expiry: (getTime() + 1.hours).toUnix.u256,
     nonce: Nonce.example
   )
 


### PR DESCRIPTION
This is follow up PR after #619 which refactors the updating expiry part, moving it from `fetchBatched` into separate `onBatch` wrapper.