### PR TITLE
remove waitFor cancelAndWait in proving state

### DIFF
--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -373,7 +373,7 @@ proc subscribeCancellation(sales: Sales) {.async.} =
   let queue = context.slotQueue
 
   proc onCancelled(requestId: RequestId) =
-    trace "request cancelled, removing all request slots from queue"
+    trace "request cancelled (via contract RequestCancelled event), removing all request slots from queue"
     queue.delete(requestId)
 
   try:

--- a/codex/sales/states/proving.nim
+++ b/codex/sales/states/proving.nim
@@ -79,27 +79,13 @@ proc proveLoop(
 method `$`*(state: SaleProving): string = "SaleProving"
 
 method onCancelled*(state: SaleProving, request: StorageRequest): ?State =
-  if not state.loop.isNil:
-    if not state.loop.finished:
-      try:
-        waitFor state.loop.cancelAndWait()
-      except CatchableError as e:
-        error "Error during cancelation of prooving loop", msg = e.msg
-
-    state.loop = nil
-
+  # state.loop cancellation happens automatically when run is cancelled due to
+  # state change
   return some State(SaleCancelled())
 
 method onFailed*(state: SaleProving, request: StorageRequest): ?State =
-  if not state.loop.isNil:
-    if not state.loop.finished:
-      try:
-        waitFor state.loop.cancelAndWait()
-      except CatchableError as e:
-        error "Error during cancelation of prooving loop", msg = e.msg
-
-    state.loop = nil
-
+  # state.loop cancellation happens automatically when run is cancelled due to
+  # state change
   return some State(SaleFailed())
 
 method run*(state: SaleProving, machine: Machine): Future[?State] {.async.} =


### PR DESCRIPTION
In proving.onCancelled, the `waitFor state.loop.cancelAndWait()` was never completing. Turns out this was not needed, because when changing states, the current state's run is cancelled, which automatically cancels the state prove loop, because it is a child of proving.run. Therefore, the logic to cancelAndWait the prove loop was removed as it was not needed.

This is a PR that is a smaller chunk of https://github.com/codex-storage/nim-codex/pull/607 to attempt to make it smaller and more digestible. 