### PR TITLE
fix: prevent partial payout underflow

### DIFF
--- a/codex/units.nim
+++ b/codex/units.nim
@@ -14,6 +14,7 @@ import std/strutils
 import pkg/upraises
 import pkg/json_serialization
 import pkg/json_serialization/std/options
+import pkg/stint
 
 type
   NBytes* = distinct Natural
@@ -45,8 +46,10 @@ proc `'nb`*(n: string): NBytes = parseInt(n).NBytes
 
 const
   MiB = 1024.NBytes * 1024.NBytes # ByteSz, 1 mebibyte = 1,048,576 ByteSz
+  GiB = MiB * 1024.NBytes # ByteSz, 1 gigabyte = 1,073,741,824 ByteSz
 
 proc MiBs*(v: Natural): NBytes = v.NBytes * MiB
+proc GiBs*(v: Natural): NBytes = v.NBytes * GiB
 
 func divUp*[T: NBytes](a, b : T): int =
   ## Division with result rounded up (rather than truncated as in 'div')
@@ -64,6 +67,9 @@ proc readValue*(
     value: var NBytes
 ) {.upraises: [SerializationError, IOError].} =
   value = NBytes reader.readValue(int)
+
+func u256*(nbytes: NBytes): UInt256 =
+  Natural(nbytes).u256
 
 when isMainModule:
 

--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -2,12 +2,15 @@ import std/random
 import std/sequtils
 import std/times
 import std/typetraits
-
+import pkg/chronos
 import pkg/codex/contracts/requests
+import pkg/codex/rng
 import pkg/codex/sales/slotqueue
 import pkg/codex/stores
 
 import pkg/stint
+import ./codex/helpers/randomchunker
+
 proc exampleString*(length: int): string =
   let chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
   result = newString(length) # Create a new empty string with a given length
@@ -67,3 +70,11 @@ proc exampleProof*(): seq[byte] =
   while proof.len == 0:
     proof = seq[byte].example
   return proof
+
+proc exampleData*(size: NBytes): Future[seq[byte]] {.async.} =
+  let rng = rng.Rng.instance()
+  let chunker = RandomChunker.new(rng, size = size, chunkSize = DefaultBlockSize * 2)
+  return await chunker.getBytes()
+
+proc exampleData*(): Future[seq[byte]] {.async.} =
+  await exampleData(DefaultBlockSize * 2)

--- a/tests/integration/codexclient.nim
+++ b/tests/integration/codexclient.nim
@@ -102,9 +102,12 @@ proc requestStorage*(
 
 proc getPurchase*(client: CodexClient, purchaseId: PurchaseId): ?!RestPurchase =
   let url = client.baseurl & "/storage/purchases/" & purchaseId.toHex
-  let body = client.http.getContent(url)
-  let json = ? parseJson(body).catch
-  RestPurchase.fromJson(json)
+  try:
+    let body = client.http.getContent(url)
+    let json = ? parseJson(body).catch
+    return RestPurchase.fromJson(json)
+  except CatchableError as e:
+    return failure e.msg
 
 proc getSlots*(client: CodexClient): ?!seq[Slot] =
   let url = client.baseurl & "/sales/slots"


### PR DESCRIPTION
- Bump codex-contracts-eth to prevent an underflow from occurring when calculating partial payout amounts during fillSlot.

- catch 404 in CodexClient.getPurchase and return a failure instead of letting the exception bubble

These changes are also used in a larger PR (https://github.com/codex-storage/nim-codex/pull/607) and are being introduced to break up the PR.