### PR TITLE
feat: cleanup returning availability

### DIFF
--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -109,6 +109,7 @@ proc remove(sales: Sales, agent: SalesAgent) {.async.} =
 
 proc cleanUp(sales: Sales,
              agent: SalesAgent,
+             returnBytes: bool,
              processing: Future[void]) {.async.} =
 
   let data = agent.data
@@ -119,9 +120,19 @@ proc cleanUp(sales: Sales,
     reservationId = data.reservation.?id |? ReservationId.default,
     availabilityId = data.reservation.?availabilityId |? AvailabilityId.default
 
-  # TODO: return bytes that were used in the request back to the availability
-  # as well, which will require removing the bytes from disk (perhaps via
-  # setting blockTTL to -1 and then running block maintainer?)
+  # if reservation for the SalesAgent was not created, then it means
+  # that the cleanUp was called before the sales process really started, so
+  # there are not really any bytes to be returned
+  if returnBytes and request =? data.request and reservation =? data.reservation:
+    if returnErr =? (await sales.context.reservations.returnBytes(
+                        reservation.availabilityId,
+                        reservation.id,
+                        request.ask.slotSize
+                      )).errorOption:
+          error "failure returning bytes",
+            error = returnErr.msg,
+            availabilityId = reservation.availabilityId,
+            bytes = request.ask.slotSize
 
   # delete reservation and return reservation bytes back to the availability
   if reservation =? data.reservation and
@@ -164,8 +175,8 @@ proc processSlot(sales: Sales, item: SlotQueueItem, done: Future[void]) =
     none StorageRequest
   )
 
-  agent.onCleanUp = proc {.async.} =
-    await sales.cleanUp(agent, done)
+  agent.onCleanUp = proc (returnBytes = false) {.async.} =
+    await sales.cleanUp(agent, returnBytes, done)
 
   agent.onFilled = some proc(request: StorageRequest, slotIndex: UInt256) =
     sales.filled(request, slotIndex, done)
@@ -229,9 +240,9 @@ proc load*(sales: Sales) {.async.} =
       slot.slotIndex,
       some slot.request)
 
-    agent.onCleanUp = proc {.async.} =
+    agent.onCleanUp = proc(returnBytes = false) {.async.} =
       let done = newFuture[void]("onCleanUp_Dummy")
-      await sales.cleanUp(agent, done)
+      await sales.cleanUp(agent, returnBytes, done)
       await done # completed in sales.cleanUp
 
     agent.start(SaleUnknown())

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -124,7 +124,7 @@ proc cleanUp(sales: Sales,
   # that the cleanUp was called before the sales process really started, so
   # there are not really any bytes to be returned
   if returnBytes and request =? data.request and reservation =? data.reservation:
-    if returnErr =? (await sales.context.reservations.returnBytes(
+    if returnErr =? (await sales.context.reservations.returnBytesToAvailability(
                         reservation.availabilityId,
                         reservation.id,
                         request.ask.slotSize

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -25,7 +25,7 @@ type
     onCleanUp*: OnCleanUp
     onFilled*: ?OnFilled
 
-  OnCleanUp* = proc: Future[void] {.gcsafe, upraises: [].}
+  OnCleanUp* = proc (returnBytes = false): Future[void] {.gcsafe, upraises: [].}
   OnFilled* = proc(request: StorageRequest,
                    slotIndex: UInt256) {.gcsafe, upraises: [].}
 

--- a/codex/sales/states/cancelled.nim
+++ b/codex/sales/states/cancelled.nim
@@ -29,6 +29,6 @@ method run*(state: SaleCancelled, machine: Machine): Future[?State] {.async.} =
     onClear(request, data.slotIndex)
 
   if onCleanUp =? agent.onCleanUp:
-    await onCleanUp(true)
+    await onCleanUp(returnBytes = true)
 
   warn "Sale cancelled due to timeout",  requestId = $data.requestId, slotIndex = $data.slotIndex

--- a/codex/sales/states/cancelled.nim
+++ b/codex/sales/states/cancelled.nim
@@ -29,6 +29,6 @@ method run*(state: SaleCancelled, machine: Machine): Future[?State] {.async.} =
     onClear(request, data.slotIndex)
 
   if onCleanUp =? agent.onCleanUp:
-    await onCleanUp()
+    await onCleanUp(true)
 
   warn "Sale cancelled due to timeout",  requestId = $data.requestId, slotIndex = $data.slotIndex

--- a/codex/sales/states/errored.nim
+++ b/codex/sales/states/errored.nim
@@ -29,5 +29,5 @@ method run*(state: SaleErrored, machine: Machine): Future[?State] {.async.} =
     onClear(request, data.slotIndex)
 
   if onCleanUp =? agent.onCleanUp:
-    await onCleanUp()
+    await onCleanUp(true)
 

--- a/codex/sales/states/errored.nim
+++ b/codex/sales/states/errored.nim
@@ -29,5 +29,5 @@ method run*(state: SaleErrored, machine: Machine): Future[?State] {.async.} =
     onClear(request, data.slotIndex)
 
   if onCleanUp =? agent.onCleanUp:
-    await onCleanUp(true)
+    await onCleanUp(returnBytes = true)
 

--- a/tests/codex/sales/testreservations.nim
+++ b/tests/codex/sales/testreservations.nim
@@ -175,6 +175,34 @@ asyncchecksuite "Reservations module":
     let updated = !(await reservations.get(key, Availability))
     check updated.size == orig
 
+  test "calling returnBytes returns bytes back to availability":
+    let availability = createAvailability()
+    let reservation = createReservation(availability)
+    let orig = availability.size - reservation.size
+    let returnedBytes = reservation.size + 200.u256
+
+    check isOk await reservations.returnBytes(
+      reservation.availabilityId, reservation.id, returnedBytes
+    )
+
+    let key = availability.key.get
+    let updated = !(await reservations.get(key, Availability))
+
+    check updated.size > orig
+    check (updated.size - orig) == returnedBytes
+
+  test "calling returnBytes reserves only bytes not belonging reservation":
+    let availability = createAvailability()
+    let reservation = createReservation(availability)
+    let origQuota = repo.quotaReservedBytes
+    let returnedBytes = reservation.size + 200.u256
+
+    check isOk await reservations.returnBytes(
+      reservation.availabilityId, reservation.id, returnedBytes
+    )
+
+    check (repo.quotaReservedBytes - origQuota) == 200
+
   test "reservation can be partially released":
     let availability = createAvailability()
     let reservation = createReservation(availability)

--- a/tests/codex/sales/testreservations.nim
+++ b/tests/codex/sales/testreservations.nim
@@ -175,13 +175,14 @@ asyncchecksuite "Reservations module":
     let updated = !(await reservations.get(key, Availability))
     check updated.size == orig
 
-  test "calling returnBytes returns bytes back to availability":
+  test "calling returnBytesToAvailability returns bytes back to availability":
     let availability = createAvailability()
     let reservation = createReservation(availability)
     let orig = availability.size - reservation.size
+    let origQuota = repo.quotaReservedBytes
     let returnedBytes = reservation.size + 200.u256
 
-    check isOk await reservations.returnBytes(
+    check isOk await reservations.returnBytesToAvailability(
       reservation.availabilityId, reservation.id, returnedBytes
     )
 
@@ -189,18 +190,7 @@ asyncchecksuite "Reservations module":
     let updated = !(await reservations.get(key, Availability))
 
     check updated.size > orig
-    check (updated.size - orig) == returnedBytes
-
-  test "calling returnBytes reserves only bytes not belonging reservation":
-    let availability = createAvailability()
-    let reservation = createReservation(availability)
-    let origQuota = repo.quotaReservedBytes
-    let returnedBytes = reservation.size + 200.u256
-
-    check isOk await reservations.returnBytes(
-      reservation.availabilityId, reservation.id, returnedBytes
-    )
-
+    check (updated.size - orig) == 200.u256
     check (repo.quotaReservedBytes - origQuota) == 200
 
   test "reservation can be partially released":

--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -149,6 +149,7 @@ asyncchecksuite "Sales":
 
     let me = await market.getSigner()
     market.activeSlots[me] = @[]
+    market.requestEnds[request.id] = request.expiry.toSecondsSince1970
 
     clock = MockClock.new()
     let repoDs = SQLiteDatastore.new(Memory).tryGet()
@@ -169,7 +170,6 @@ asyncchecksuite "Sales":
     sales.onProve = proc(slot: Slot, challenge: ProofChallenge): Future[seq[byte]] {.async.} =
       return proof
     await sales.start()
-    request.expiry = (clock.now() + 42).u256
     itemsProcessed = @[]
 
   teardown:


### PR DESCRIPTION
This pull request brings the final piece to close issue #411 with a naive implementation. It introduces the concept of "returning bytes to availability," which is done for failed sales. This is achieved by attempting to re-reserve the required bytes from the Repo store. If successful, the bytes are returned; otherwise, an error is logged and the availability is lost.

I am unsure about the API of the `returnBytes` function, so please let me know in the review if you prefer it as it is.

There will be follow-up work later on that will intelligently handle the returning of bytes using a currently non-existing mechanism in RepoStore. This mechanism will clean up space for us when it is full, in order to avoid losing availability. This is partially addressed in the following link: [https://github.com/codex-storage/nim-codex/issues/626](https://github.com/codex-storage/nim-codex/issues/626)

Closes #411.