### PR TITLE
fix: sales module never marked as running, causing a hang

### DIFF
--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -503,6 +503,7 @@ proc start*(sales: Sales) {.async.} =
   await sales.load()
   await sales.startSlotQueue()
   await sales.subscribe()
+  sales.running = true
 
 proc stop*(sales: Sales) {.async.} =
   trace "stopping sales"


### PR DESCRIPTION
The Sales module was not marked as `running`, causing a hang in [multi node integration tests](https://github.com/codex-storage/nim-codex/pull/607).

This PR is to help break up a much larger PR (https://github.com/codex-storage/nim-codex/pull/607)