### PR TITLE
chore: improve log information

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -50,6 +50,13 @@ method proofTimeout*(market: OnChainMarket): Future[UInt256] {.async.} =
   let config = await market.contract.config()
   return config.proofs.timeout
 
+method proofDowntime*(market: OnChainMarket): Future[uint8] {.async.} =
+  let config = await market.contract.config()
+  return config.proofs.downtime
+
+method getPointer*(market: OnChainMarket, slotId: SlotId): Future[uint8] {.async.} =
+  return await market.contract.getPointer(slotId)
+
 method myRequests*(market: OnChainMarket): Future[seq[RequestId]] {.async.} =
   return await market.contract.myRequests
 

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -39,6 +39,17 @@ method periodicity*(market: Market): Future[Periodicity] {.base, async.} =
 method proofTimeout*(market: Market): Future[UInt256] {.base, async.} =
   raiseAssert("not implemented")
 
+method proofDowntime*(market: Market): Future[uint8] {.base, async.} =
+  raiseAssert("not implemented")
+
+method getPointer*(market: Market, slotId: SlotId): Future[uint8] {.base, async.} =
+  raiseAssert("not implemented")
+
+proc inDowntime*(market: Market, slotId: SlotId): Future[bool] {.async.} =
+  let downtime = await market.proofDowntime
+  let pntr = await market.getPointer(slotId)
+  return pntr < downtime
+
 method requestStorage*(market: Market,
                        request: StorageRequest) {.base, async.} =
   raiseAssert("not implemented")

--- a/codex/utils/asyncstatemachine.nim
+++ b/codex/utils/asyncstatemachine.nim
@@ -73,8 +73,9 @@ proc scheduler(machine: Machine) {.async.} =
       if next =? event(machine.state):
         if not running.isNil and not running.finished:
           await running.cancelAndWait()
+        let fromState = if machine.state.isNil: "<none>" else: $machine.state
         machine.state = next
-        debug "enter state", state = machine.state
+        debug "enter state", state = machine.state, fromState
         running = machine.run(machine.state)
         running
           .track(machine)

--- a/codex/validation.nim
+++ b/codex/validation.nim
@@ -72,7 +72,9 @@ proc markProofAsMissing(validation: Validation,
     if await validation.market.canProofBeMarkedAsMissing(slotId, period):
       trace "Marking proof as missing", slotId = $slotId, periodProofMissed = period
       await validation.market.markProofAsMissing(slotId, period)
-    else: trace "Proof not missing", checkedPeriod = period
+    else:
+      let inDowntime {.used.} = await validation.market.inDowntime(slotId)
+      trace "Proof not missing", checkedPeriod = period, inDowntime
   except CancelledError:
     raise
   except CatchableError as e:

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -111,6 +111,12 @@ method periodicity*(mock: MockMarket): Future[Periodicity] {.async.} =
 method proofTimeout*(market: MockMarket): Future[UInt256] {.async.} =
   return market.config.proofs.timeout
 
+method proofDowntime*(market: MockMarket): Future[uint8] {.async.} =
+  return market.config.proofs.downtime
+
+method getPointer*(market: MockMarket, slotId: SlotId): Future[uint8] {.async.} =
+  return 0 # TODO
+
 method requestStorage*(market: MockMarket, request: StorageRequest) {.async.} =
   market.requested.add(request)
   var subscriptions = market.subscriptions.onRequest


### PR DESCRIPTION
1. Add downtime information to the validator logs that provides information that proofs were not marked as missing due to being in downtime. This can help understand why proofs were not marked as missing.
2. Add previous state to the state machine transition log. This helps when debugging, particularly when entering the errored state, eg `SaleErrored`.

This PR is part of reducing the size of a much larger PR: https://github.com/codex-storage/nim-codex/pull/607
