### PR TITLE
fix: rename `provider` to `ethProvider` in tests

### DIFF
--- a/tests/contracts/testClock.nim
+++ b/tests/contracts/testClock.nim
@@ -8,21 +8,21 @@ ethersuite "On-Chain Clock":
   var clock: OnChainClock
 
   setup:
-    clock = OnChainClock.new(provider)
+    clock = OnChainClock.new(ethProvider)
     await clock.start()
 
   teardown:
     await clock.stop()
 
   test "returns the current time of the EVM":
-    let latestBlock = (!await provider.getBlock(BlockTag.latest))
+    let latestBlock = (!await ethProvider.getBlock(BlockTag.latest))
     let timestamp = latestBlock.timestamp.truncate(int64)
     check clock.now() == timestamp
 
   test "updates time with timestamp of new blocks":
     let future = (getTime() + 42.years).toUnix
-    discard await provider.send("evm_setNextBlockTimestamp", @[%future])
-    discard await provider.send("evm_mine")
+    discard await ethProvider.send("evm_setNextBlockTimestamp", @[%future])
+    discard await ethProvider.send("evm_mine")
     check clock.now() == future
 
   test "updates time using wall-clock in-between blocks":
@@ -33,8 +33,8 @@ ethersuite "On-Chain Clock":
   test "can wait until a certain time is reached by the chain":
     let future = clock.now() + 42 # seconds
     let waiting = clock.waitUntil(future)
-    discard await provider.send("evm_setNextBlockTimestamp", @[%future])
-    discard await provider.send("evm_mine")
+    discard await ethProvider.send("evm_setNextBlockTimestamp", @[%future])
+    discard await ethProvider.send("evm_mine")
     check await waiting.withTimeout(chronos.milliseconds(100))
 
   test "can wait until a certain time is reached by the wall-clock":
@@ -44,7 +44,7 @@ ethersuite "On-Chain Clock":
 
   test "raises when not started":
     expect AssertionDefect:
-      discard OnChainClock.new(provider).now()
+      discard OnChainClock.new(ethProvider).now()
 
   test "raises when stopped":
     await clock.stop()

--- a/tests/contracts/testContracts.nim
+++ b/tests/contracts/testContracts.nim
@@ -23,13 +23,13 @@ ethersuite "Marketplace contracts":
     token = token.connect(account)
 
   setup:
-    client = provider.getSigner(accounts[0])
-    host = provider.getSigner(accounts[1])
+    client = ethProvider.getSigner(accounts[0])
+    host = ethProvider.getSigner(accounts[1])
 
-    marketplace = Marketplace.new(Marketplace.address, provider.getSigner())
+    marketplace = Marketplace.new(Marketplace.address, ethProvider.getSigner())
 
     let tokenAddress = await marketplace.token()
-    token = Erc20Token.new(tokenAddress, provider.getSigner())
+    token = Erc20Token.new(tokenAddress, ethProvider.getSigner())
 
     let config = await marketplace.config()
     periodicity = Periodicity(seconds: config.proofs.period)
@@ -46,13 +46,13 @@ ethersuite "Marketplace contracts":
     slotId = request.slotId(0.u256)
 
   proc waitUntilProofRequired(slotId: SlotId) {.async.} =
-    let currentPeriod = periodicity.periodOf(await provider.currentTime())
-    await provider.advanceTimeTo(periodicity.periodEnd(currentPeriod))
+    let currentPeriod = periodicity.periodOf(await ethProvider.currentTime())
+    await ethProvider.advanceTimeTo(periodicity.periodEnd(currentPeriod))
     while not (
       (await marketplace.isProofRequired(slotId)) and
       (await marketplace.getPointer(slotId)) < 250
     ):
-      await provider.advanceTime(periodicity.seconds)
+      await ethProvider.advanceTime(periodicity.seconds)
 
   proc startContract() {.async.} =
     for slotIndex in 1..<request.ask.slots:
@@ -67,9 +67,9 @@ ethersuite "Marketplace contracts":
   test "can mark missing proofs":
     switchAccount(host)
     await waitUntilProofRequired(slotId)
-    let missingPeriod = periodicity.periodOf(await provider.currentTime())
+    let missingPeriod = periodicity.periodOf(await ethProvider.currentTime())
     let endOfPeriod = periodicity.periodEnd(missingPeriod)
-    await provider.advanceTimeTo(endOfPeriod + 1)
+    await ethProvider.advanceTimeTo(endOfPeriod + 1)
     switchAccount(client)
     await marketplace.markProofAsMissing(slotId, missingPeriod)
 
@@ -78,17 +78,17 @@ ethersuite "Marketplace contracts":
     let address = await host.getAddress()
     await startContract()
     let requestEnd = await marketplace.requestEnd(request.id)
-    await provider.advanceTimeTo(requestEnd.u256 + 1)
+    await ethProvider.advanceTimeTo(requestEnd.u256 + 1)
     let startBalance = await token.balanceOf(address)
     await marketplace.freeSlot(slotId)
     let endBalance = await token.balanceOf(address)
     check endBalance == (startBalance + request.ask.duration * request.ask.reward + request.ask.collateral)
 
   test "cannot mark proofs missing for cancelled request":
-    await provider.advanceTimeTo(request.expiry + 1)
+    await ethProvider.advanceTimeTo(request.expiry + 1)
     switchAccount(client)
-    let missingPeriod = periodicity.periodOf(await provider.currentTime())
-    await provider.advanceTime(periodicity.seconds)
+    let missingPeriod = periodicity.periodOf(await ethProvider.currentTime())
+    await ethProvider.advanceTime(periodicity.seconds)
     check await marketplace
       .markProofAsMissing(slotId, missingPeriod)
       .reverts("Slot not accepting proofs")

--- a/tests/ethertest.nim
+++ b/tests/ethertest.nim
@@ -5,23 +5,23 @@ import pkg/ethers
 import ./checktest
 
 ## Unit testing suite that sets up an Ethereum testing environment.
-## Injects a `provider` instance, and a list of `accounts`.
+## Injects a `ethProvider` instance, and a list of `accounts`.
 ## Calls the `evm_snapshot` and `evm_revert` methods to ensure that any
 ## changes to the blockchain do not persist.
 template ethersuite*(name, body) =
   asyncchecksuite name:
 
-    var provider {.inject, used.}: JsonRpcProvider
+    var ethProvider {.inject, used.}: JsonRpcProvider
     var accounts {.inject, used.}: seq[Address]
     var snapshot: JsonNode
 
     setup:
-      provider = JsonRpcProvider.new("ws://localhost:8545")
-      snapshot = await send(provider, "evm_snapshot")
-      accounts = await provider.listAccounts()
+      ethProvider = JsonRpcProvider.new("ws://localhost:8545")
+      snapshot = await send(ethProvider, "evm_snapshot")
+      accounts = await ethProvider.listAccounts()
 
     teardown:
-      discard await send(provider, "evm_revert", @[snapshot])
+      discard await send(ethProvider, "evm_revert", @[snapshot])
 
     body
 

--- a/tests/integration/multinodes.nim
+++ b/tests/integration/multinodes.nim
@@ -24,7 +24,7 @@ type
     validators*: uint
   DebugNodes* = object
     client*: bool
-    provider*: bool
+    ethProvider*: bool
     validator*: bool
     topics*: string
   Role* {.pure.} = enum
@@ -49,15 +49,15 @@ proc init*(_: type StartNodes,
   StartNodes(clients: clients, providers: providers, validators: validators)
 
 proc init*(_: type DebugNodes,
-          client, provider, validator: bool,
+          client, ethProvider, validator: bool,
           topics: string = "validator,proving,market"): DebugNodes =
-  DebugNodes(client: client, provider: provider, validator: validator,
+  DebugNodes(client: client, ethProvider: ethProvider, validator: validator,
              topics: topics)
 
 template multinodesuite*(name: string,
   startNodes: StartNodes, debugNodes: DebugNodes, body: untyped) =
 
-  if (debugNodes.client or debugNodes.provider) and
+  if (debugNodes.client or debugNodes.ethProvider) and
       (enabledLogLevel > LogLevel.TRACE or
       enabledLogLevel == LogLevel.NONE):
     echo ""
@@ -116,12 +116,12 @@ template multinodesuite*(name: string,
         "--bootstrap-node=" & bootstrap,
         "--persistence",
         "--simulate-proof-failures=" & $failEveryNProofs],
-        debugNodes.provider)
+        debugNodes.ethProvider)
       let restClient = newCodexClient(index)
       running.add RunningNode.new(Role.Provider, node, restClient, datadir,
                                   account)
-      if debugNodes.provider:
-        debug "started new provider node and codex client",
+      if debugNodes.ethProvider:
+        debug "started new ethProvider node and codex client",
           restApiPort = 8080 + index, discPort = 8090 + index, account
 
     proc startValidatorNode() =


### PR DESCRIPTION
To support more than two levels of integration test suite template nesting, `provider` had to be renamed to `ethProvider`, otherwise the compiler would complain that the `provider` symbol was unidentified in the top-most level of the nested test suites.

Eg
- `ethersuite`: declares `provider`
  - `multinodesuite`
    - `marketplacesuite` (`provider` symbol can't be found)
 
Note:
1. `marketplacesuite` does not exist yet; it is introduced in https://github.com/codex-storage/nim-codex/pull/607.
2. This PR is part of reducing the size of a much larger PR https://github.com/codex-storage/nim-codex/pull/607.