### PR TITLE
Updates reference to continuous tests workflow in cs-codex-dist-tests

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -254,7 +254,7 @@ jobs:
       max-parallel: 1
       matrix:
         tests: ${{ fromJSON(needs.compute-tests-inputs.outputs.continuous_tests_list) }}
-    uses: codex-storage/cs-codex-dist-tests/.github/workflows/continuous-tests.yaml@master
+    uses: codex-storage/cs-codex-dist-tests/.github/workflows/run-continuous-tests.yaml@master
     with:
       source: ${{ needs.compute-tests-inputs.outputs.source }}
       branch: ${{ needs.compute-tests-inputs.outputs.branch }}


### PR DESCRIPTION
`codex-storage/cs-codex-dist-tests/.github/workflows/continuous-tests.yaml` was renamed to `codex-storage/cs-codex-dist-tests/.github/workflows/run-continuous-tests.yaml` on master.