### PR TITLE
Smart contracts update: Groth16Proof instead of bytes

### DIFF
--- a/codex/contracts/config.nim
+++ b/codex/contracts/config.nim
@@ -17,13 +17,15 @@ type
     period*: UInt256 # proofs requirements are calculated per period (in seconds)
     timeout*: UInt256 # mark proofs as missing before the timeout (in seconds)
     downtime*: uint8 # ignore this much recent blocks for proof requirements
+    zkeyHash*: string # hash of the zkey file which is linked to the verifier
 
 
 func fromTuple(_: type ProofConfig, tupl: tuple): ProofConfig =
   ProofConfig(
     period: tupl[0],
     timeout: tupl[1],
-    downtime: tupl[2]
+    downtime: tupl[2],
+    zkeyHash: tupl[3]
   )
 
 func fromTuple(_: type CollateralConfig, tupl: tuple): CollateralConfig =

--- a/codex/contracts/deployment.nim
+++ b/codex/contracts/deployment.nim
@@ -14,7 +14,10 @@ type Deployment* = ref object
 const knownAddresses = {
  # Hardhat localhost network
  "31337": {
-  "Marketplace": Address.init("0x59b670e9fA9D0A427751Af201D676719a970857b")
+  # TODO: This is currently the address of the marketplace with a dummy
+  # verifier. Replace with "0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44" once we
+  # can generate actual Groth16 ZK proofs
+  "Marketplace": Address.init("0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f"),
  }.toTable,
  # Taiko Alpha-3 Testnet
  "167005": {

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -8,6 +8,7 @@ import pkg/questionable
 import ../logutils
 import ../market
 import ./marketplace
+import ./proofs
 
 export market
 
@@ -120,7 +121,7 @@ method getActiveSlot*(market: OnChainMarket,
 method fillSlot(market: OnChainMarket,
                 requestId: RequestId,
                 slotIndex: UInt256,
-                proof: seq[byte],
+                proof: Groth16Proof,
                 collateral: UInt256) {.async.} =
   await market.approveFunds(collateral)
   await market.contract.fillSlot(requestId, slotIndex, proof)
@@ -155,7 +156,7 @@ method getChallenge*(market: OnChainMarket, id: SlotId): Future[ProofChallenge] 
 
 method submitProof*(market: OnChainMarket,
                     id: SlotId,
-                    proof: seq[byte]) {.async.} =
+                    proof: Groth16Proof) {.async.} =
   await market.contract.submitProof(id, proof)
 
 method markProofAsMissing*(market: OnChainMarket,
@@ -272,7 +273,7 @@ method subscribeProofSubmission*(market: OnChainMarket,
                                  callback: OnProofSubmitted):
                                 Future[MarketSubscription] {.async.} =
   proc onEvent(event: ProofSubmitted) {.upraises: [].} =
-    callback(event.id, event.proof)
+    callback(event.id)
   let subscription = await market.contract.subscribe(ProofSubmitted, onEvent)
   return OnChainMarketSubscription(eventSubscription: subscription)
 

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -39,6 +39,11 @@ proc approveFunds(market: OnChainMarket, amount: UInt256) {.async.} =
 
   discard await token.increaseAllowance(market.contract.address(), amount).confirm(1)
 
+method getZkeyHash*(market: Market): Future[?string] {.async.} =
+  let config = await market.contract.config()
+  let period = config.proofs.period
+  return
+
 method getSigner*(market: OnChainMarket): Future[Address] {.async.} =
   return await market.signer.getAddress()
 

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -39,10 +39,9 @@ proc approveFunds(market: OnChainMarket, amount: UInt256) {.async.} =
 
   discard await token.increaseAllowance(market.contract.address(), amount).confirm(1)
 
-method getZkeyHash*(market: Market): Future[?string] {.async.} =
+method getZkeyHash*(market: OnChainMarket): Future[?string] {.async.} =
   let config = await market.contract.config()
-  let period = config.proofs.period
-  return
+  return some config.proofs.zkeyHash
 
 method getSigner*(market: OnChainMarket): Future[Address] {.async.} =
   return await market.signer.getAddress()

--- a/codex/contracts/marketplace.nim
+++ b/codex/contracts/marketplace.nim
@@ -5,6 +5,7 @@ import pkg/stint
 import pkg/chronos
 import ../clock
 import ./requests
+import ./proofs
 import ./config
 
 export stint
@@ -33,7 +34,6 @@ type
     requestId* {.indexed.}: RequestId
   ProofSubmitted* = object of Event
     id*: SlotId
-    proof*: seq[byte]
 
 
 proc config*(marketplace: Marketplace): MarketplaceConfig {.contract, view.}
@@ -43,7 +43,7 @@ proc slashPercentage*(marketplace: Marketplace): UInt256 {.contract, view.}
 proc minCollateralThreshold*(marketplace: Marketplace): UInt256 {.contract, view.}
 
 proc requestStorage*(marketplace: Marketplace, request: StorageRequest) {.contract.}
-proc fillSlot*(marketplace: Marketplace, requestId: RequestId, slotIndex: UInt256, proof: seq[byte]) {.contract.}
+proc fillSlot*(marketplace: Marketplace, requestId: RequestId, slotIndex: UInt256, proof: Groth16Proof) {.contract.}
 proc withdrawFunds*(marketplace: Marketplace, requestId: RequestId) {.contract.}
 proc freeSlot*(marketplace: Marketplace, id: SlotId) {.contract.}
 proc getRequest*(marketplace: Marketplace, id: RequestId): StorageRequest {.contract, view.}
@@ -65,5 +65,5 @@ proc willProofBeRequired*(marketplace: Marketplace, id: SlotId): bool {.contract
 proc getChallenge*(marketplace: Marketplace, id: SlotId): array[32, byte] {.contract, view.}
 proc getPointer*(marketplace: Marketplace, id: SlotId): uint8 {.contract, view.}
 
-proc submitProof*(marketplace: Marketplace, id: SlotId, proof: seq[byte]) {.contract.}
+proc submitProof*(marketplace: Marketplace, id: SlotId, proof: Groth16Proof) {.contract.}
 proc markProofAsMissing*(marketplace: Marketplace, id: SlotId, period: UInt256) {.contract.}

--- a/codex/contracts/proofs.nim
+++ b/codex/contracts/proofs.nim
@@ -1,0 +1,33 @@
+import pkg/stint
+import pkg/contractabi
+import pkg/ethers/fields
+
+type
+  Groth16Proof* = object
+    a*: G1Point
+    b*: G2Point
+    c*: G1Point
+  G1Point* = object
+    x*: UInt256
+    y*: UInt256
+  G2Point* = object
+    x*: array[2, UInt256]
+    y*: array[2, UInt256]
+
+func solidityType*(_: type G1Point): string =
+  solidityType(G1Point.fieldTypes)
+
+func solidityType*(_: type G2Point): string =
+  solidityType(G2Point.fieldTypes)
+
+func solidityType*(_: type Groth16Proof): string =
+  solidityType(Groth16Proof.fieldTypes)
+
+func encode*(encoder: var AbiEncoder, point: G1Point) =
+  encoder.write(point.fieldValues)
+
+func encode*(encoder: var AbiEncoder, point: G2Point) =
+  encoder.write(point.fieldValues)
+
+func encode*(encoder: var AbiEncoder, proof: Groth16Proof) =
+  encoder.write(proof.fieldValues)

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -3,12 +3,14 @@ import pkg/upraises
 import pkg/questionable
 import pkg/ethers/erc20
 import ./contracts/requests
+import ./contracts/proofs
 import ./clock
 import ./periods
 
 export chronos
 export questionable
 export requests
+export proofs
 export SecondsSince1970
 export periods
 
@@ -23,7 +25,7 @@ type
   OnSlotFreed* = proc(requestId: RequestId, slotIndex: UInt256) {.gcsafe, upraises: [].}
   OnRequestCancelled* = proc(requestId: RequestId) {.gcsafe, upraises:[].}
   OnRequestFailed* = proc(requestId: RequestId) {.gcsafe, upraises:[].}
-  OnProofSubmitted* = proc(id: SlotId, proof: seq[byte]) {.gcsafe, upraises:[].}
+  OnProofSubmitted* = proc(id: SlotId) {.gcsafe, upraises:[].}
   PastStorageRequest* = object
     requestId*: RequestId
     ask*: StorageAsk
@@ -91,7 +93,7 @@ method getActiveSlot*(
 method fillSlot*(market: Market,
                  requestId: RequestId,
                  slotIndex: UInt256,
-                 proof: seq[byte],
+                 proof: Groth16Proof,
                  collateral: UInt256) {.base, async.} =
   raiseAssert("not implemented")
 
@@ -120,7 +122,7 @@ method getChallenge*(market: Market, id: SlotId): Future[ProofChallenge] {.base,
 
 method submitProof*(market: Market,
                     id: SlotId,
-                    proof: seq[byte]) {.base, async.} =
+                    proof: Groth16Proof) {.base, async.} =
   raiseAssert("not implemented")
 
 method markProofAsMissing*(market: Market,

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -32,6 +32,9 @@ type
     expiry*: UInt256
   ProofChallenge* = array[32, byte]
 
+method getZkeyHash*(market: Market): Future[?string] {.base, async.} =
+  raiseAssert("not implemented")
+
 method getSigner*(market: Market): Future[Address] {.base, async.} =
   raiseAssert("not implemented")
 

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -549,7 +549,7 @@ proc onStore(
 proc onProve(
   self: CodexNodeRef,
   slot: Slot,
-  challenge: ProofChallenge): Future[?!seq[byte]] {.async.} =
+  challenge: ProofChallenge): Future[?!Groth16Proof] {.async.} =
   ## Generats a proof for a given slot and challenge
   ##
 
@@ -585,7 +585,7 @@ proc onProve(
     return failure(err)
 
   # Todo: send proofInput to circuit. Get proof. (Profit, repeat.)
-  success(@[42'u8])
+  success(Groth16Proof.default)
 
 proc onExpiryUpdate(
   self: CodexNodeRef,
@@ -635,7 +635,7 @@ proc start*(self: CodexNodeRef) {.async.} =
       self.onClear(request, slotIndex)
 
     hostContracts.sales.onProve =
-      proc(slot: Slot, challenge: ProofChallenge): Future[?!seq[byte]] =
+      proc(slot: Slot, challenge: ProofChallenge): Future[?!Groth16Proof] =
         # TODO: generate proof
         self.onProve(slot, challenge)
 

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -585,7 +585,12 @@ proc onProve(
     return failure(err)
 
   # Todo: send proofInput to circuit. Get proof. (Profit, repeat.)
-  success(Groth16Proof.default)
+
+  # For now: dummy proof that is not all zero's, so that it is accepted by the
+  # dummy verifier:
+  var proof = Groth16Proof.default
+  proof.a.x = 42.u256
+  success(proof)
 
 proc onExpiryUpdate(
   self: CodexNodeRef,

--- a/codex/sales/salescontext.nim
+++ b/codex/sales/salescontext.nim
@@ -27,7 +27,7 @@ type
   OnStore* = proc(request: StorageRequest,
                   slot: UInt256,
                   blocksCb: BlocksCb): Future[?!void] {.gcsafe, upraises: [].}
-  OnProve* = proc(slot: Slot, challenge: ProofChallenge): Future[?!seq[byte]] {.gcsafe, upraises: [].}
+  OnProve* = proc(slot: Slot, challenge: ProofChallenge): Future[?!Groth16Proof] {.gcsafe, upraises: [].}
   OnExpiryUpdate* = proc(rootCid: string, expiry: SecondsSince1970): Future[?!void] {.gcsafe, upraises: [].}
   OnClear* = proc(request: StorageRequest,
                   slotIndex: UInt256) {.gcsafe, upraises: [].}

--- a/codex/sales/states/filling.nim
+++ b/codex/sales/states/filling.nim
@@ -12,7 +12,7 @@ logScope:
 
 type
   SaleFilling* = ref object of ErrorHandlingState
-    proof*: seq[byte]
+    proof*: Groth16Proof
 
 method `$`*(state: SaleFilling): string = "SaleFilling"
 

--- a/codex/sales/states/proving.nim
+++ b/codex/sales/states/proving.nim
@@ -2,6 +2,7 @@ import std/options
 import pkg/questionable/results
 import ../../clock
 import ../../logutils
+import ../../utils/exceptions
 import ../statemachine
 import ../salesagent
 import ../salescontext
@@ -35,7 +36,7 @@ method prove*(
     debug "Submitting proof", currentPeriod = currentPeriod, slotId = slot.id
     await market.submitProof(slot.id, proof)
   except CatchableError as e:
-    error "Submitting proof failed", msg = e.msg
+    error "Submitting proof failed", msg = e.msgDetail
 
 proc proveLoop(
   state: SaleProving,

--- a/codex/sales/states/provingsimulated.nim
+++ b/codex/sales/states/provingsimulated.nim
@@ -31,7 +31,7 @@ when codex_enable_proof_failures:
 
       try:
         warn "Submitting INVALID proof", period = currentPeriod, slotId = slot.id
-        await market.submitProof(slot.id, newSeq[byte](0))
+        await market.submitProof(slot.id, Groth16Proof.default)
       except ProviderError as e:
         if not e.revertReason.contains("Invalid proof"):
           onSubmitProofError(e, currentPeriod, slot.id)

--- a/tests/codex/sales/states/testfilled.nim
+++ b/tests/codex/sales/states/testfilled.nim
@@ -31,7 +31,7 @@ checksuite "sales state 'filled'":
     slot = MockSlot(requestId: request.id,
                     host: Address.example,
                     slotIndex: slotIndex,
-                    proof: @[])
+                    proof: Groth16Proof.default)
 
     market.requestEnds[request.id] = 321
     onExpiryUpdatePassedExpiry = -1

--- a/tests/codex/sales/states/testinitialproving.nim
+++ b/tests/codex/sales/states/testinitialproving.nim
@@ -16,7 +16,7 @@ import ../../helpers
 import ../../helpers/mockmarket
 
 asyncchecksuite "sales state 'initialproving'":
-  let proof = exampleProof()
+  let proof = Groth16Proof.example
   let request = StorageRequest.example
   let slotIndex = (request.ask.slots div 2).u256
   let market = MockMarket.new()
@@ -26,7 +26,7 @@ asyncchecksuite "sales state 'initialproving'":
   var receivedChallenge: ProofChallenge
 
   setup:
-    let onProve = proc (slot: Slot, challenge: ProofChallenge): Future[?!seq[byte]] {.async.} =
+    let onProve = proc (slot: Slot, challenge: ProofChallenge): Future[?!Groth16Proof] {.async.} =
                           receivedChallenge = challenge
                           return success(proof)
     let context = SalesContext(
@@ -60,7 +60,7 @@ asyncchecksuite "sales state 'initialproving'":
     check receivedChallenge == market.proofChallenge
 
   test "switches to errored state when onProve callback fails":
-    let onProveFailed: OnProve = proc(slot: Slot, challenge: ProofChallenge): Future[?!seq[byte]] {.async.} =
+    let onProveFailed: OnProve = proc(slot: Slot, challenge: ProofChallenge): Future[?!Groth16Proof] {.async.} =
       return failure("oh no!")
 
     let proofFailedContext = SalesContext(

--- a/tests/codex/testvalidation.nim
+++ b/tests/codex/testvalidation.nim
@@ -14,6 +14,7 @@ asyncchecksuite "validation":
   let timeout = 5
   let maxSlots = 100
   let slot = Slot.example
+  let proof = Groth16Proof.example
   let collateral = slot.request.ask.collateral
 
   var validation: Validation
@@ -41,25 +42,25 @@ asyncchecksuite "validation":
     check validation.slots.len == 0
 
   test "when a slot is filled on chain, it is added to the list":
-    await market.fillSlot(slot.request.id, slot.slotIndex, @[], collateral)
+    await market.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
     check validation.slots == @[slot.id]
 
   for state in [SlotState.Finished, SlotState.Failed]:
     test "when slot state changes, it is removed from the list":
-      await market.fillSlot(slot.request.id, slot.slotIndex, @[], collateral)
+      await market.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
       market.slotState[slot.id] = state
       advanceToNextPeriod()
       check eventually validation.slots.len == 0
 
   test "when a proof is missed, it is marked as missing":
-    await market.fillSlot(slot.request.id, slot.slotIndex, @[], collateral)
+    await market.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
     market.setCanProofBeMarkedAsMissing(slot.id, true)
     advanceToNextPeriod()
     await sleepAsync(1.millis)
     check market.markedAsMissingProofs.contains(slot.id)
 
   test "when a proof can not be marked as missing, it will not be marked":
-    await market.fillSlot(slot.request.id, slot.slotIndex, @[], collateral)
+    await market.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
     market.setCanProofBeMarkedAsMissing(slot.id, false)
     advanceToNextPeriod()
     await sleepAsync(1.millis)
@@ -68,5 +69,5 @@ asyncchecksuite "validation":
   test "it does not monitor more than the maximum number of slots":
     for _ in 0..<maxSlots + 1:
       let slot = Slot.example
-      await market.fillSlot(slot.request.id, slot.slotIndex, @[], collateral)
+      await market.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
     check validation.slots.len == maxSlots

--- a/tests/contracts/deployment.nim
+++ b/tests/contracts/deployment.nim
@@ -3,15 +3,21 @@ import std/options
 import pkg/ethers
 import pkg/codex/contracts/marketplace
 
-const hardhatMarketAddress = Address.init("0x59b670e9fA9D0A427751Af201D676719a970857b").get()
+const hardhatMarketAddress =
+  Address.init("0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44").get()
+const hardhatMarketWithDummyVerifier =
+  Address.init("0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f").get()
 const marketAddressEnvName = "CODEX_MARKET_ADDRESS"
 
-proc address*(_: type Marketplace): Address =
+proc address*(_: type Marketplace, dummyVerifier = false): Address =
   if existsEnv(marketAddressEnvName):
     without address =? Address.init(getEnv(marketAddressEnvName)):
       raiseAssert "Invalid env. variable marketplace contract address"
 
     return address
 
-  hardhatMarketAddress
+  if dummyVerifier:
+    hardhatMarketWithDummyVerifier
+  else:
+    hardhatMarketAddress
 

--- a/tests/contracts/testContracts.nim
+++ b/tests/contracts/testContracts.nim
@@ -25,7 +25,8 @@ ethersuite "Marketplace contracts":
     client = ethProvider.getSigner(accounts[0])
     host = ethProvider.getSigner(accounts[1])
 
-    marketplace = Marketplace.new(Marketplace.address, ethProvider.getSigner())
+    let address = Marketplace.address(dummyVerifier = true)
+    marketplace = Marketplace.new(address, ethProvider.getSigner())
 
     let tokenAddress = await marketplace.token()
     token = Erc20Token.new(tokenAddress, ethProvider.getSigner())

--- a/tests/contracts/testContracts.nim
+++ b/tests/contracts/testContracts.nim
@@ -8,7 +8,7 @@ import ./time
 import ./deployment
 
 ethersuite "Marketplace contracts":
-  let proof = exampleProof()
+  let proof = Groth16Proof.example
 
   var client, host: Signer
   var marketplace: Marketplace

--- a/tests/contracts/testDeployment.nim
+++ b/tests/contracts/testDeployment.nim
@@ -31,11 +31,11 @@ asyncchecksuite "Deployment":
 
   test "uses chainId hardcoded values as fallback":
     let deployment = Deployment.new(provider, configFactory())
-    provider.chainId = 31337.u256
+    provider.chainId = 167005.u256
 
     let address = await deployment.address(Marketplace)
     check address.isSome
-    check $(!address) == "0x59b670e9fa9d0a427751af201d676719a970857b"
+    check $(!address) == "0x948cf9291b77bd7ad84781b9047129addf1b894f"
 
   test "return none for unknown networks":
     let deployment = Deployment.new(provider, configFactory())

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -111,6 +111,9 @@ ethersuite "On-Chain Market":
     check (await market.willProofBeRequired(slotId(request.id, slotIndex))) == false
 
   test "submits proofs":
+    await market.requestStorage(request)
+    await market.fillSlot(request.id, slotIndex, proof, request.ask.collateral)
+    await advanceToNextPeriod()
     await market.submitProof(slotId(request.id, slotIndex), proof)
 
   test "marks a proof as missing":
@@ -260,6 +263,9 @@ ethersuite "On-Chain Market":
     await subscription.unsubscribe()
 
   test "supports proof submission subscriptions":
+    await market.requestStorage(request)
+    await market.fillSlot(request.id, slotIndex, proof, request.ask.collateral)
+    await advanceToNextPeriod()
     var receivedIds: seq[SlotId]
     proc onProofSubmission(id: SlotId) =
       receivedIds.add(id)

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -16,7 +16,8 @@ ethersuite "On-Chain Market":
   var periodicity: Periodicity
 
   setup:
-    marketplace = Marketplace.new(Marketplace.address, ethProvider.getSigner())
+    let address = Marketplace.address(dummyVerifier = true)
+    marketplace = Marketplace.new(address, ethProvider.getSigner())
     let config = await marketplace.config()
 
     market = OnChainMarket.new(marketplace)

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -1,6 +1,5 @@
 import std/options
 import pkg/chronos
-import pkg/stew/byteutils
 import codex/contracts
 import ../ethertest
 import ./examples
@@ -8,7 +7,7 @@ import ./time
 import ./deployment
 
 ethersuite "On-Chain Market":
-  let proof = exampleProof()
+  let proof = Groth16Proof.example
 
   var market: OnChainMarket
   var marketplace: Marketplace
@@ -261,19 +260,11 @@ ethersuite "On-Chain Market":
 
   test "supports proof submission subscriptions":
     var receivedIds: seq[SlotId]
-    var receivedProofs: seq[seq[byte]]
-
-    proc onProofSubmission(id: SlotId, proof: seq[byte]) =
+    proc onProofSubmission(id: SlotId) =
       receivedIds.add(id)
-      receivedProofs.add(proof)
-
     let subscription = await market.subscribeProofSubmission(onProofSubmission)
-
     await market.submitProof(slotId(request.id, slotIndex), proof)
-
     check receivedIds == @[slotId(request.id, slotIndex)]
-    check receivedProofs == @[proof]
-
     await subscription.unsubscribe()
 
   test "request is none when unknown":

--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -4,6 +4,7 @@ import std/times
 import std/typetraits
 
 import pkg/codex/contracts/requests
+import pkg/codex/contracts/proofs
 import pkg/codex/sales/slotqueue
 import pkg/codex/stores
 
@@ -62,8 +63,18 @@ proc example*(_: type SlotQueueItem): SlotQueueItem =
   let slot = Slot.example
   SlotQueueItem.init(request, slot.slotIndex.truncate(uint16))
 
-proc exampleProof*(): seq[byte] =
-  var proof: seq[byte]
-  while proof.len == 0:
-    proof = seq[byte].example
-  return proof
+proc example(_: type G1Point): G1Point =
+  G1Point(x: UInt256.example, y: UInt256.example)
+
+proc example(_: type G2Point): G2Point =
+  G2Point(
+    x: [UInt256.example, UInt256.example],
+    y: [UInt256.example, UInt256.example]
+  )
+
+proc example*(_: type Groth16Proof): Groth16Proof =
+  Groth16Proof(
+    a: G1Point.example,
+    b: G2Point.example,
+    c: G1Point.example
+  )

--- a/tests/integration/multinodes.nim
+++ b/tests/integration/multinodes.nim
@@ -23,7 +23,7 @@ type
     validators*: uint
   DebugNodes* = object
     client*: bool
-    ethProvider*: bool
+    provider*: bool
     validator*: bool
     topics*: string
   Role* {.pure.} = enum
@@ -48,15 +48,15 @@ proc init*(_: type StartNodes,
   StartNodes(clients: clients, providers: providers, validators: validators)
 
 proc init*(_: type DebugNodes,
-          client, ethProvider, validator: bool,
+          client, provider, validator: bool,
           topics: string = "validator,proving,market"): DebugNodes =
-  DebugNodes(client: client, ethProvider: ethProvider, validator: validator,
+  DebugNodes(client: client, provider: provider, validator: validator,
              topics: topics)
 
 template multinodesuite*(name: string,
   startNodes: StartNodes, debugNodes: DebugNodes, body: untyped) =
 
-  if (debugNodes.client or debugNodes.ethProvider) and
+  if (debugNodes.client or debugNodes.provider) and
       (enabledLogLevel > LogLevel.TRACE or
       enabledLogLevel == LogLevel.NONE):
     echo ""
@@ -115,12 +115,12 @@ template multinodesuite*(name: string,
         "--bootstrap-node=" & bootstrap,
         "--persistence",
         "--simulate-proof-failures=" & $failEveryNProofs],
-        debugNodes.ethProvider)
+        debugNodes.provider)
       let restClient = newCodexClient(index)
       running.add RunningNode.new(Role.Provider, node, restClient, datadir,
                                   account)
-      if debugNodes.ethProvider:
-        debug "started new ethProvider node and codex client",
+      if debugNodes.provider:
+        debug "started new provider node and codex client",
           restApiPort = 8080 + index, discPort = 8090 + index, account
 
     proc startValidatorNode() =

--- a/tests/integration/testproofs.nim
+++ b/tests/integration/testproofs.nim
@@ -12,6 +12,11 @@ import ./multinodes
 logScope:
   topics = "test proofs"
 
+# TODO: This is currently the address of the marketplace with a dummy
+# verifier. Use real marketplace address once we can generate actual
+# Groth16 ZK proofs.
+let marketplaceAddress = Marketplace.address(dummyVerifier = true)
+
 twonodessuite "Proving integration test", debug1=false, debug2=false:
   let validatorDir = getTempDir() / "CodexValidator"
 
@@ -22,7 +27,7 @@ twonodessuite "Proving integration test", debug1=false, debug2=false:
     client.getPurchase(id).option.?state == some state
 
   setup:
-    marketplace = Marketplace.new(Marketplace.address, ethProvider)
+    marketplace = Marketplace.new(marketplaceAddress, ethProvider)
     period = (await marketplace.config()).proofs.period.truncate(uint64)
 
     # Our Hardhat configuration does use automine, which means that time tracked by `ethProvider.currentTime()` is not
@@ -120,7 +125,7 @@ multinodesuite "Simulate invalid proofs",
   var slotId: SlotId
 
   setup:
-    marketplace = Marketplace.new(Marketplace.address, ethProvider)
+    marketplace = Marketplace.new(marketplaceAddress, ethProvider)
     let config = await marketplace.config()
     period = config.proofs.period.truncate(uint64)
     slotId = SlotId(array[32, byte].default) # ensure we aren't reusing from prev test

--- a/tests/integration/testproofs.nim
+++ b/tests/integration/testproofs.nim
@@ -115,7 +115,7 @@ twonodessuite "Proving integration test", debug1=false, debug2=false:
 
 multinodesuite "Simulate invalid proofs",
   StartNodes.init(clients=1'u, providers=0'u, validators=1'u),
-  DebugNodes.init(client=false, ethProvider=false, validator=false):
+  DebugNodes.init(client=false, provider=false, validator=false):
 
   proc purchaseStateIs(client: CodexClient, id: PurchaseId, state: string): bool =
     client.getPurchase(id).option.?state == some state


### PR DESCRIPTION
Updates the smart contracts to use the ZK verifier. Proof is now modeled as a Groth16Proof struct instead of a sequence of bytes.

- [x] Depends on https://github.com/codex-storage/codex-contracts-eth/pull/79
- [x] Depends on https://github.com/codex-storage/codex-contracts-eth/pull/82
- [x] Depends on https://github.com/codex-storage/codex-contracts-eth/pull/85

Closes #684