### PR TITLE
feat: zkey-hash from chain

### DIFF
--- a/codex/contracts/config.nim
+++ b/codex/contracts/config.nim
@@ -17,13 +17,15 @@ type
     period*: UInt256 # proofs requirements are calculated per period (in seconds)
     timeout*: UInt256 # mark proofs as missing before the timeout (in seconds)
     downtime*: uint8 # ignore this much recent blocks for proof requirements
+    zkeyHash*: string # hash of the zkey file which is linked to the verifier
 
 
 func fromTuple(_: type ProofConfig, tupl: tuple): ProofConfig =
   ProofConfig(
     period: tupl[0],
     timeout: tupl[1],
-    downtime: tupl[2]
+    downtime: tupl[2],
+    zkeyHash: tupl[3]
   )
 
 func fromTuple(_: type CollateralConfig, tupl: tuple): CollateralConfig =

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -38,6 +38,11 @@ proc approveFunds(market: OnChainMarket, amount: UInt256) {.async.} =
 
   discard await token.increaseAllowance(market.contract.address(), amount).confirm(1)
 
+method getZkeyHash*(market: Market): Future[?string] {.async.} =
+  let config = await market.contract.config()
+  let period = config.proofs.period
+  return
+
 method getSigner*(market: OnChainMarket): Future[Address] {.async.} =
   return await market.signer.getAddress()
 

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -30,6 +30,9 @@ type
     expiry*: UInt256
   ProofChallenge* = array[32, byte]
 
+method getZkeyHash*(market: Market): Future[?string] {.base, async.} =
+  raiseAssert("not implemented")
+
 method getSigner*(market: Market): Future[Address] {.base, async.} =
   raiseAssert("not implemented")
 


### PR DESCRIPTION
This PR adds support for retrieving Zkey hash from Contract's configuration. 

The PR is blocked until the Verifier integration work from Mark is finished as until then the tests won't be passing.