### PR TITLE
Fix Docker workflow after actions update

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Docker - Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ matrix.target.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -182,7 +182,8 @@ jobs:
       - name: Docker - Download digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
+          pattern: digests-*
+          merge-multiple: true
           path: /tmp/digests
 
       - name: Docker - Set up Buildx


### PR DESCRIPTION
This is a fix for the https://github.com/codex-storage/nim-codex/pull/688, where `actions/upload-artifact@v4` can't upload anymore artifacts under the same path.

Docker workflow is triggered only on master merge and the issue was not observed initially.

Tested by [manual run](https://github.com/codex-storage/nim-codex/actions/runs/7699072349) and Docker image was created
```
docker pull codexstorage/nim-codex:sha-bab1a5d-dist-tests
```