### PR TITLE
fix: use default short commit length for codex revision

### DIFF
--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -293,7 +293,6 @@ proc getCodexVersion(): string =
 proc getCodexRevision(): string =
   # using a slice in a static context breaks nimsuggest for some reason
   var res = strip(staticExec("git rev-parse --short HEAD"))
-  res.setLen(6)
   return res
 
 proc getNimBanner(): string =


### PR DESCRIPTION
We already discussed that for consistency it make sense to use the same length for the `Codex revision` as GitHub short commit. Currently we short it to the 6 characters (for some reason?) and GitHub shows 7.
```shell
codex --version

Codex version:  untagged build
Codex revision: ae61c2
Nim Compiler Version 1.6.14 [Linux: amd64]
```


We use [`git rev-parse --short HEAD`](https://github.com/codex-storage/nim-codex/blob/master/codex/conf.nim#L293-L297) and accordingly to the [documentation](https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---shortlength)
> `--short[=length]`
> Same as `--verify` but shortens the object name to a unique prefix with at least `length` characters. The minimum length is 4, the default is the effective value of the `core.abbrev` configuration variable (see [git-config[1]](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev)).

> `core.abbrev`
> Set the length object names are abbreviated to. If unspecified or set to "auto", an appropriate value is computed based on the approximate number of packed objects in your repository, which hopefully is enough for abbreviated object names to stay unique for some time. If set to "no", no abbreviation is made and the object names are shown in their full length. The minimum length is 4.

So, it make sense to use a default value which will correspond to the GitHub value and in case of need we can set the length as a parameter
```shell
git rev-parse --short HEAD
git rev-parse --short=7 HEAD
```

Result will look the following
```shell
codex --version
Codex version:  untagged build
Codex revision: ae61c29
Nim Compiler Version 1.6.14 [Linux: amd64]
```