### PR TITLE
Add Nim-matrix workflow to run on merge queue

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -1,0 +1,79 @@
+name: Reusable -  CI
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        type: string
+      cache_nonce:
+        default: '0'
+        description: Allows for easily busting actions/cache caches
+        required: false
+        type: string
+
+env:
+  cache_nonce: ${{ inputs.cache_nonce }}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include: ${{ fromJson(inputs.matrix) }}
+
+    defaults:
+      run:
+        shell: ${{ matrix.shell }} {0}
+
+    name: '${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.nim_version }}-${{ matrix.tests }}'
+    runs-on: ${{ matrix.builder }}
+    timeout-minutes: 80
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Nimbus Build System
+        uses: ./.github/actions/nimbus-build-system
+        with:
+          os: ${{ matrix.os }}
+          shell: ${{ matrix.shell }}
+          nim_version: ${{ matrix.nim_version }}
+
+      ## Part 1 Tests ##
+      - name: Unit tests
+        if: matrix.tests == 'unittest' || matrix.tests == 'all'
+        run: make -j${ncpu} test
+
+      # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.15
+
+      - name: Start Ethereum node with Codex contracts
+        if: matrix.tests == 'contract' || matrix.tests == 'integration' || matrix.tests == 'all'
+        working-directory: vendor/codex-contracts-eth
+        env:
+          MSYS2_PATH_TYPE: inherit
+        run: |
+          npm install
+          npm start &
+
+      ## Part 2 Tests ##
+      - name: Contract tests
+        if: matrix.tests == 'contract' || matrix.tests == 'all'
+        run: make -j${ncpu} testContracts
+
+      ## Part 3 Tests ##
+      - name: Integration tests
+        if: matrix.tests == 'integration' || matrix.tests == 'all'
+        run: make -j${ncpu} testIntegration
+
+  status:
+    if: always()
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')  || contains(needs.*.result, 'skipped') }}
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,96 +1,45 @@
 name: CI
+
 on:
   push:
     branches:
       - master
   pull_request:
   workflow_dispatch:
+
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
   nim_version: v1.6.14
+    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
+
 jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - os: linux
-            cpu: amd64
-            builder: ubuntu-latest
-            shell: bash --noprofile --norc -e -o pipefail
-            tests: all
-          - os: macos
-            cpu: amd64
-            builder: macos-latest
-            shell: bash --noprofile --norc -e -o pipefail
-            tests: all
-          - os: windows
-            cpu: amd64
-            builder: windows-latest
-            shell: msys2
-            tests: unittest
-          - os: windows
-            cpu: amd64
-            builder: windows-latest
-            shell: msys2
-            tests: contract
-          - os: windows
-            cpu: amd64
-            builder: windows-latest
-            shell: msys2
-            tests: integration
-
-    defaults:
-      run:
-        shell: ${{ matrix.shell }} {0}
-
-    name: '${{ matrix.os }}-${{ matrix.cpu }}-tests-${{ matrix.tests }}'
-    runs-on: ${{ matrix.builder }}
-    timeout-minutes: 80
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      cache_nonce: ${{ env.cache_nonce }}
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+    - name: Compute matrix
+      id: matrix
+      uses: fabiocaccamo/create-matrix-action@v4
+      with:
+        matrix: |
+          os {linux},   cpu {amd64}, builder {ubuntu-latest},  tests {all},         nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {macos},   cpu {amd64}, builder {macos-latest},   tests {all},         nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {windows}, cpu {amd64}, builder {windows-latest}, tests {unittest},    nim_version {${{ env.nim_version }}}, shell {msys2}
+          os {windows}, cpu {amd64}, builder {windows-latest}, tests {contract},    nim_version {${{ env.nim_version }}}, shell {msys2}
+          os {windows}, cpu {amd64}, builder {windows-latest}, tests {integration}, nim_version {${{ env.nim_version }}}, shell {msys2}
 
-      - name: Setup Nimbus Build System
-        uses: ./.github/actions/nimbus-build-system
-        with:
-          os: ${{ matrix.os }}
-          shell: ${{ matrix.shell }}
-          nim_version: ${{ env.nim_version }}
-
-      ## Part 1 Tests ##
-      - name: Unit tests
-        if: matrix.tests == 'unittest' || matrix.tests == 'all'
-        run: make -j${ncpu} test
-
-      # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.15
-
-      - name: Start Ethereum node with Codex contracts
-        if: matrix.tests == 'contract' || matrix.tests == 'integration' || matrix.tests == 'all'
-        working-directory: vendor/codex-contracts-eth
-        env:
-          MSYS2_PATH_TYPE: inherit
-        run: |
-          npm install
-          npm start &
-
-      ## Part 2 Tests ##
-      - name: Contract tests
-        if: matrix.tests == 'contract' || matrix.tests == 'all'
-        run: make -j${ncpu} testContracts
-
-      ## Part 3 Tests ##
-      - name: Integration tests
-        if: matrix.tests == 'integration' || matrix.tests == 'all'
-        run: make -j${ncpu} testIntegration
+  build:
+    needs: matrix
+    uses: ./.github/workflows/ci-reusable.yml
+    with:
+      matrix: ${{ needs.matrix.outputs.matrix }}
+      cache_nonce: ${{ needs.matrix.outputs.cache_nonce }}
 
   coverage:
     continue-on-error: true
@@ -123,11 +72,3 @@ jobs:
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
-
-  build-status:
-    if: always()
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')  || contains(needs.*.result, 'skipped') }}
-        run: exit 1

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -1,4 +1,4 @@
-name: Docker - Reusable
+name: Reusable - Docker
 
 
 on:

--- a/.github/workflows/nim-matrix.yml
+++ b/.github/workflows/nim-matrix.yml
@@ -1,76 +1,30 @@
 name: Nim matrix
+
 on:
   merge_group:
   workflow_dispatch:
+
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
+  nim_version: v1.6.14, v1.6.16, v1.6.18, v2.0.0, v2.0.2
+
 jobs:
-  build:
-    strategy:
-      matrix:
-        nim_version: [v1.6.14, v1.6.16, v1.6.18, v2.0.0, v2.0.2]
-        include:
-          - os: linux
-            cpu: amd64
-            builder: ubuntu-latest
-            # builder: buildjet-4vcpu-ubuntu-2204
-            shell: bash --noprofile --norc -e -o pipefail
-            tests: all
-
-    defaults:
-      run:
-        shell: ${{ matrix.shell }} {0}
-
-    name: '${{ matrix.nim_version }}-${{ matrix.os }}-${{ matrix.cpu }}-tests-${{ matrix.tests }}'
-    runs-on: ${{ matrix.builder }}
-    timeout-minutes: 80
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup Nimbus Build System
-        uses: ./.github/actions/nimbus-build-system
-        with:
-          os: ${{ matrix.os }}
-          shell: ${{ matrix.shell }}
-          nim_version: ${{ env.nim_version }}
-
-      ## Part 1 Tests ##
-      - name: Unit tests
-        if: matrix.tests == 'unittest' || matrix.tests == 'all'
-        run: make -j${ncpu} test
-
-      # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.15
-
-      - name: Start Ethereum node with Codex contracts
-        if: matrix.tests == 'contract' || matrix.tests == 'integration' || matrix.tests == 'all'
-        working-directory: vendor/codex-contracts-eth
-        env:
-          MSYS2_PATH_TYPE: inherit
-        run: |
-          npm install
-          npm start &
-
-      ## Part 2 Tests ##
-      - name: Contract tests
-        if: matrix.tests == 'contract' || matrix.tests == 'all'
-        run: make -j${ncpu} testContracts
-
-      ## Part 3 Tests ##
-      - name: Integration tests
-        if: matrix.tests == 'integration' || matrix.tests == 'all'
-        run: make -j${ncpu} testIntegration
-
-  build-status:
-    if: always()
-    needs: [build]
+  matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      cache_nonce: ${{ env.cache_nonce }}
     steps:
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')  || contains(needs.*.result, 'skipped') }}
-        run: exit 1
+    - name: Compute matrix
+      id: matrix
+      uses: fabiocaccamo/create-matrix-action@v4
+      with:
+        matrix: |
+          os {linux}, cpu {amd64}, builder {ubuntu-latest}, tests {all}, nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+
+  build:
+    needs: matrix
+    uses: ./.github/workflows/ci-reusable.yml
+    with:
+      matrix: ${{ needs.matrix.outputs.matrix }}
+      cache_nonce: ${{ needs.matrix.outputs.cache_nonce }}

--- a/.github/workflows/nim-matrix.yml
+++ b/.github/workflows/nim-matrix.yml
@@ -1,52 +1,27 @@
-name: CI
+name: Nim matrix
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  merge_group:
   workflow_dispatch:
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
-  nim_version: v1.6.14
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
 jobs:
   build:
     strategy:
       matrix:
+        nim_version: [v1.6.14, v1.6.16, v1.6.18, v2.0.0, v2.0.2]
         include:
           - os: linux
             cpu: amd64
             builder: ubuntu-latest
+            # builder: buildjet-4vcpu-ubuntu-2204
             shell: bash --noprofile --norc -e -o pipefail
             tests: all
-          - os: macos
-            cpu: amd64
-            builder: macos-latest
-            shell: bash --noprofile --norc -e -o pipefail
-            tests: all
-          - os: windows
-            cpu: amd64
-            builder: windows-latest
-            shell: msys2
-            tests: unittest
-          - os: windows
-            cpu: amd64
-            builder: windows-latest
-            shell: msys2
-            tests: contract
-          - os: windows
-            cpu: amd64
-            builder: windows-latest
-            shell: msys2
-            tests: integration
 
     defaults:
       run:
         shell: ${{ matrix.shell }} {0}
 
-    name: '${{ matrix.os }}-${{ matrix.cpu }}-tests-${{ matrix.tests }}'
+    name: '${{ matrix.nim_version }}-${{ matrix.os }}-${{ matrix.cpu }}-tests-${{ matrix.tests }}'
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
     steps:
@@ -91,38 +66,6 @@ jobs:
       - name: Integration tests
         if: matrix.tests == 'integration' || matrix.tests == 'all'
         run: make -j${ncpu} testIntegration
-
-  coverage:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup Nimbus Build System
-        uses: ./.github/actions/nimbus-build-system
-        with:
-          os: linux
-          nim_version: ${{ env.nim_version }}
-
-      - name: Generate coverage data
-        run: |
-          # make -j${ncpu} coverage
-          make -j${ncpu} coverage-script
-        shell: bash
-
-      - name: Upload coverage data to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          directory: ./coverage/
-          fail_ci_if_error: true
-          files: ./coverage/coverage.f.info
-          flags: unittests
-          name: codecov-umbrella
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
 
   build-status:
     if: always()


### PR DESCRIPTION
### Context

In PR [Build improvements #680](680), we raised the question about building Codex using different Nim versions, but **only before the merge** to not slow-down existing PR flow and to not waste resources on every push.

We can try to use [GitHub merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) to implement that.


### PR

 - Add `build-status` job to `CI` workflow to check matrix execution status - will use it in branch rule
 - Add `Nim-matrix` workflow to **run only on merge queue** and only on Linux
 - [Using concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) for `CI` workflow to cancel previous run at PR next commits


### Next steps

 - Are we ready for experiments ? 😄
 - Merge
 - Update `branch rules` with **just** `build / status` job
 - Enable `merge queue` in `branch rules`

-- Not ready? Just not enable `merge queue` and then run `Nim-matrix` workflow manually.

### Known issues

 - [There is no way to set different checks for `PR` and `merge queue`](https://github.com/orgs/community/discussions/46757?sort=old#discussioncomment-4909336) and this is why we use single `build-status` job name for both workflows
 - When merge queue checks fail we should press merge button again they will re-run them from scratch
 - [Jumping to the top of a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#jumping-to-the-top-of-the-queue) will cause a full rebuild of all in-progress pull requests
 - By running multiple additional jobs in `Nim-matrix` workflow we consume GitHub Org [`Total concurrent jobs`](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits) limit
 - `Nim-matrix` workflow fail very often on BuildJet runners at tests - we use GitHub ones for now
 - By adding an additional step before the merge, we will **delay merge up to 20 minutes**

<details>
<summary>More details</summary>


### Implementation

In the [current merge queue implementation](https://github.com/orgs/community/discussions/46757) we can't set branch rules separately for `PR` and `merge queue` checks and this is very confusing. In that way, both workflows should be run on `PR` and `merge queue` and we would need to run steps conditionally and that adds some ambiguity.

This is why we workaround that by using a single `build-status` job name for both workflows and run them separately. In that way, `PR` and `merge queue` checks will pass at their own stages.

Basically, flow will be the following

**PR**
 1. PR is created
 2. `CI` workflow will be triggered
 3. At next push, p.2 will be repeated
 4. When `CI` workflow will be finished successfully and auto-merge is enabled, PR will be moved into the merge queue

**Merge queue**
 1. `Nim-matrix` workflow will be triggered
 2. `Nim-matrix` workflow will mark branch as protected (push is not permitted) and will
     - create a temporary branch and merge a current one with the `master`
     - run build over merged code
     - report build status
 4. If `Nim-matrix` workflow will fail we should press auto-merge button again or start from PR-p.3
 5. When `Nim-matrix` checks will pass, PR will be merged automatically


More information can be found in [How merge queues work](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#how-merge-queues-work).


### Speed

Merge queue will add an additional matrix of jobs to build over different Nim versions. Because they will run in parallel, max merge delay will be equal to the job  max execution time.

| Runner                        | Duration, max | Costs, job    | Costs, matrix |
| ----------------------------- | ------------- | ------------- | ------------- |
| `ubuntu-latest`               | `19m 23s`     | `Free`        | `Free`        |
| `buildjet-4vcpu-ubuntu-2204`  | `15m 33s`     | `0.128 $/job` | `0.64 $/run`  |
| `buildjet-8vcpu-ubuntu-2204`  | `13m 14s`     | `0.224 $/job` | `1.12 $/run`  |
| `buildjet-16vcpu-ubuntu-2204` | `13m 00s`     | `0.416 $/job` | `2.08 $/run`  |

</details>
