### PR TITLE
CI update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
 
       - name: Upload coverage data to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ./coverage/
           fail_ci_if_error: true

--- a/.github/workflows/nim-matrix.yml
+++ b/.github/workflows/nim-matrix.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
-  nim_version: v1.6.14, v1.6.16, v1.6.18, v2.0.0, v2.0.2
+  nim_version: v1.6.14, v1.6.16, v1.6.18
 
 jobs:
   matrix:


### PR DESCRIPTION
This is a quick fix to address recent changes
- https://github.com/codex-storage/nim-codex/pull/693 - Nim v2 builds fail, let's skip them for now
- https://github.com/codex-storage/nim-codex/pull/689 - Codecov was updated just [recently](https://github.com/codecov/codecov-action/releases)