### PR TITLE
Install Rust during Docker builds

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -27,7 +27,6 @@ jobs:
     name: '${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.nim_version }}-${{ matrix.tests }}'
     runs-on: ${{ matrix.builder }}
     timeout-minutes: 80
-    continue-on-error: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/docker/codex.Dockerfile
+++ b/docker/codex.Dockerfile
@@ -14,8 +14,8 @@ ARG MAKE_PARALLEL
 ARG NIMFLAGS
 
 RUN apt-get update && apt-get install -y git cmake curl make bash lcov build-essential nim
-RUN echo 'export NIMBLE_DIR="${HOME}/.nimble"' >> "${HOME}/.bash_env"
-RUN echo 'export PATH="${NIMBLE_DIR}/bin:${PATH}"' >> "${HOME}/.bash_env"
+RUN curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR ${BUILD_HOME}
 COPY . .


### PR DESCRIPTION
PR install Rust for Docker builds.

Also, `NIMBLE_DIR` was removed from `PATH` via `"${HOME}/.bash_env"` - not sure how this is intended to work.

Was [tested manually](https://github.com/codex-storage/nim-codex/actions/runs/7854380843).

```shell
docker run codexstorage/nim-codex:sha-a0761bb-dist-tests codex --version

Codex version:  untagged build
Codex revision: a0761bb
Nim Compiler Version 1.6.14 [Linux: arm64]
```