### PR TITLE
Fix Docker entrypoint NAT helper variables

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,27 +1,38 @@
 #!/bin/bash
 
 # Parameters
-if [[ "${NAT_IP_AUTO}" == "true" && -z "${NAT_PUBLIC_IP_AUTO}" ]]; then
-  export CODEX_NAT=$(hostname --ip-address)
-  echo "Internal: Set CODEX_NAT: ${CODEX_NAT}"
+if [[ -z "${CODEX_NAT}" ]]; then
+  if [[ "${NAT_IP_AUTO}" == "true" && -z "${NAT_PUBLIC_IP_AUTO}" ]]; then
+    export CODEX_NAT=$(hostname --ip-address)
+    echo "Private: CODEX_NAT=${CODEX_NAT}"
+  elif [[ -n "${NAT_PUBLIC_IP_AUTO}" ]]; then
+    # Run for 60 seconds if fail
+    WAIT=120
+    SECONDS=0
+    SLEEP=5
+    while (( SECONDS < WAIT )); do
+      export CODEX_NAT=$(curl -s -f -m 5 "${NAT_PUBLIC_IP_AUTO}")
+      # Check if exit code is 0 and returned value is not empty
+      if [[ $? -eq 0 && -n "${CODEX_NAT}" ]]; then
+        echo "Public: CODEX_NAT=${CODEX_NAT}"
+        break
+      else
+        # Sleep and check again
+        echo "Can't get Public IP - Retry in $SLEEP seconds / $((WAIT - SECONDS))"
+        sleep $SLEEP
+      fi
+    done
+  fi
 fi
 
-if [[ -n "${NAT_PUBLIC_IP_AUTO}" ]]; then
-  # Run for 60 seconds if fail
-  WAIT=60
-  SECONDS=0
-  SLEEP=5
-  while (( SECONDS < WAIT )); do
-    export CODEX_NAT=$(curl -s -f -m 5 "${NAT_PUBLIC_IP_AUTO}")
-    # Check if exit code is 0 and returned value is not empty
-    [[ $? -eq 0 && -n "${CODEX_NAT}" ]] && { echo "Public: Set CODEX_NAT: ${CODEX_NAT}"; break; } || { echo "Can't get Public IP - Retry in $SLEEP seconds / $((WAIT - SECONDS))"; }
-    # Sleep and check again
-    sleep $SLEEP
-  done
+# Stop Codex run if can't get NAT IP when requested
+if [[ "${NAT_IP_AUTO}" == "true" && -z "${CODEX_NAT}" ]]; then
+  echo "Can't get Private IP - Stop Codex run"
+  exit 1
+elif [[ -n "${NAT_PUBLIC_IP_AUTO}" && -z "${CODEX_NAT}" ]]; then
+  echo "Can't get Public IP in $WAIT seconds - Stop Codex run"
+  exit 1
 fi
-
-# Stop Codex run if can't get Public IP
-[[ -z "${CODEX_NAT}" ]] && { echo "Can't get Public IP in $WAIT seconds - Stop Codex run"; exit 1; }
 
 # If marketplace is enabled from the testing environment,
 # The file has to be written before Codex starts.


### PR DESCRIPTION
This is a quick fix for existing Docker entrypoint

Since we've introduced [`NAT_PUBLIC_IP_AUTO`](https://github.com/codex-storage/nim-codex/commit/750fe2392feb57e6043b824e8e939a99d866e30a) helper variable in Docker entrypoint, we broke image run with default values
```shell
docker run codexstorage/nim-codex:latest

# Can't get Public IP in  seconds - Stop Codex run

# And we need to workaround that
docker run -e NAT_IP_AUTO=true codexstorage/nim-codex:latest
docker run -e NAT_PUBLIC_IP_AUTO=ip.codex.storage codexstorage/nim-codex:latest
```
In this PR, we use slightly different logic
1. When `CODEX_NAT` is passed - use it
2. `NAT_PUBLIC_IP_AUTO` (Public IP) have priority over `NAT_IP_AUTO`(Private IP)
3. Show separate error for `NAT_PUBLIC_IP_AUTO` and `NAT_IP_AUTO` when can't get IP address