### PR TITLE
ci: update actions to the latest major versions

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload integration tests log files
         uses: actions/upload-artifact@v4
-        if: always()
+        if: (matrix.tests == 'integration' || matrix.tests == 'all') && always()
         with:
           name: ${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.nim_version }}-integration-tests-logs
           path: tests/integration/logs/

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -71,7 +71,7 @@ jobs:
         run: make -j${ncpu} testIntegration
 
       - name: Upload integration tests log files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: integration-tests-logs

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ matrix.os }}-integration-tests-logs
+          name: ${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.nim_version }}-integration-tests-logs
           path: tests/integration/logs/
           retention-days: 1
 

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: integration-tests-logs
+          name: ${{ matrix.os }}-integration-tests-logs
           path: tests/integration/logs/
           retention-days: 1
 


### PR DESCRIPTION
This is a follow up of the #688.

In #662 we introduced one more actions with a [deprecation warning](https://github.com/codex-storage/nim-codex/actions/runs/7954945496).