### PR TITLE
Fixes active cancellation for pending want requests

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -274,9 +274,8 @@ proc issueCancellations(b: BlockExcEngine, addrs: seq[BlockAddress]) {.async.} =
   trace "Sending block request cancellations to peers", addrs = addrs.len
 
   let sends = b.peers.mapIt(
-    (peer: it, request: b.network.request.sendWantList(id = it.id,
-      addresses = addrs, cancel = true))
-  )
+    (peer: it, request: b.network.request.sendWantCancellations(peer = it.id,
+      addresses = addrs)))
 
   discard await allFinished(sends.mapIt(it.request))
 

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -281,7 +281,7 @@ proc cancelBlocks(b: BlockExcEngine, addrs: seq[BlockAddress]) {.async.} =
 
   let failed = sends.filterIt(it.request.failed).mapIt(it.peer.id)
   if failed.len > 0:
-    warn "Failed to send block request cancellations to peers", failed = $failed
+    trace "Failed to send block request cancellations to peers", failed = $failed
 
 proc resolveBlocks*(b: BlockExcEngine, blocksDelivery: seq[BlockDelivery]) {.async.} =
   trace "Resolving blocks", blocks = blocksDelivery.len

--- a/tests/codex/blockexchange/engine/testengine.nim
+++ b/tests/codex/blockexchange/engine/testengine.nim
@@ -142,7 +142,7 @@ asyncchecksuite "NetworkStore engine handlers":
     localStore: BlockStore
     blocks: seq[Block]
 
-  const NOP_SEND_WANT_LIST = proc(
+  const NopSendWantListProc = proc(
     id: PeerId,
     addresses: seq[BlockAddress],
     priority: int32 = 0,
@@ -286,7 +286,7 @@ asyncchecksuite "NetworkStore engine handlers":
 
     # Install NOP for want list sends so cancellations don't cause a crash
     engine.network = BlockExcNetwork(
-      request: BlockExcRequest(sendWantList: NOP_SEND_WANT_LIST))
+      request: BlockExcRequest(sendWantList: NopSendWantListProc))
 
     await engine.blocksDeliveryHandler(peerId, blocksDelivery)
     let resolved = await allFinished(pending)
@@ -322,7 +322,7 @@ asyncchecksuite "NetworkStore engine handlers":
           done.complete(),
 
         # Install NOP for want list sends so cancellations don't cause a crash
-        sendWantList: NOP_SEND_WANT_LIST
+        sendWantList: NopSendWantListProc
     ))
 
     await engine.blocksDeliveryHandler(peerId, blocks.mapIt(

--- a/tests/codex/helpers.nim
+++ b/tests/codex/helpers.nim
@@ -106,6 +106,19 @@ proc storeDataGetManifest*(store: BlockStore, chunker: Chunker): Future[Manifest
 
   return manifest
 
+proc makeRandomBlocks*(
+  datasetSize: int, blockSize: NBytes): Future[seq[Block]] {.async.} =
+
+  var chunker = RandomChunker.new(Rng.instance(), size = datasetSize,
+    chunkSize = blockSize)
+
+  while true:
+    let chunk = await chunker.getBytes()
+    if chunk.len <= 0:
+      break
+
+    result.add(Block.new(chunk).tryGet())
+
 proc corruptBlocks*(
   store: BlockStore,
   manifest: Manifest,

--- a/tests/codex/helpers/nodeutils.nim
+++ b/tests/codex/helpers/nodeutils.nim
@@ -62,3 +62,6 @@ proc connectNodes*(nodes: seq[Switch]) {.async.} =
     for node in nodes:
       if dialer.peerInfo.peerId != node.peerInfo.peerId:
         await dialer.connect(node.peerInfo.peerId, node.peerInfo.addrs)
+
+proc connectNodes*(nodes: seq[NodesComponents]) {.async.} =
+  await connectNodes(nodes.mapIt( it.switch ))

--- a/tests/codex/utils/testutils.nim
+++ b/tests/codex/utils/testutils.nim
@@ -1,0 +1,36 @@
+import std/unittest
+
+import pkg/codex/utils
+
+suite "findIt":
+
+  setup:
+    type AnObject = object
+      attribute1*: int
+
+    var objList = @[
+      AnObject(attribute1: 1),
+      AnObject(attribute1: 3),
+      AnObject(attribute1: 5),
+      AnObject(attribute1: 3),
+    ]
+
+  test "should retur index of first object matching predicate":
+    assert objList.findIt(it.attribute1 == 3) == 1
+
+  test "should return -1 when no object matches predicate":
+    assert objList.findIt(it.attribute1 == 15) == -1
+
+suite "parseDuration":
+
+  test "should parse durations":
+    var res: Duration  # caller must still know if 'b' refers to bytes|bits
+    check parseDuration("10Hr", res) == 3
+    check res == hours(10)
+    check parseDuration("64min", res) == 3
+    check res == minutes(64)
+    check parseDuration("7m/block", res) == 2 # '/' stops parse
+    check res == minutes(7)  # 1 shl 30, forced binary metric
+    check parseDuration("3d", res) == 2 # '/' stops parse
+    check res == days(3)  # 1 shl 30, forced binary metric
+


### PR DESCRIPTION
This PR fixes the active cancellation of pending want requests by adding the actual want list sends with the `cancel` flag set to true as part of block delivery, with accompanying tests.