### PR TITLE
Set environment variables from files in Docker

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Environment variables from files
+if [[ -n "${ENV_PATH}" ]]; then
+  [[ -f ${ENV_PATH} ]] && source ${ENV_PATH} || for f in ${ENV_PATH}/*; do source $f; done
+fi
+
 # Parameters
 if [[ -z "${CODEX_NAT}" ]]; then
   if [[ "${NAT_IP_AUTO}" == "true" && -z "${NAT_PUBLIC_IP_AUTO}" ]]; then


### PR DESCRIPTION
This PR adds a way to set environment variables from file(s) in Docker.

This is especially useful for Kubernetes when we run multiple replicas and need to set different variables for each replica.
For example
```shell
CODEX_LISTEN_ADDRS=/ipv4/0.0.0.0/30100
CODEX_LISTEN_ADDRS=/ipv4/0.0.0.0/30200
```

It works for a single or multiple files
```shell
# Single
/opt/env/env.sh

# Multiple
/opt/env/*
```

File is a simple shell file
`/opt/env/env.sh`
```shell
CODEX_ETH_PROVIDER=https://mainnet.infura.io/v3/...
CODEX_ETH_ACCOUNT=0x...
CODEX_ETH_PRIVATE_KEY=0x...
CODEX_MARKETPLACE_ADDRESS=0x...
```