### PR TITLE
ci: use latest amd64 macos runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         matrix: |
           os {linux},   cpu {amd64}, builder {ubuntu-latest},  tests {all},         nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
-          os {macos},   cpu {amd64}, builder {macos-latest},   tests {all},         nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {macos},   cpu {amd64}, builder {macos-13},       tests {all},         nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
           os {windows}, cpu {amd64}, builder {windows-latest}, tests {unittest},    nim_version {${{ env.nim_version }}}, shell {msys2}
           os {windows}, cpu {amd64}, builder {windows-latest}, tests {contract},    nim_version {${{ env.nim_version }}}, shell {msys2}
           os {windows}, cpu {amd64}, builder {windows-latest}, tests {integration}, nim_version {${{ env.nim_version }}}, shell {msys2}


### PR DESCRIPTION
PR update macOS runner to the latest amd64 version, which is `macos-13`. Previous one is `macos-latest = macOS 12`.

[GitHub Actions: macOS 14 (Sonoma) is now available](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/)
> The macOS 12 runner image will remain `latest` until migration of the latest YAML workflow label to macOS 14 in Q2 FY24 (April – June 2024). While macOS 13 is now generally available under the `macos-13` label, this image **will not be migrated to `latest`**.

Experiments shows, that `macos-13` probably is faster than `macos-latest` (4 vs 3 CPU) and at least not slower than Windows integrations tests. If it will help us to save 10 minutes per run, it is not so bad.

<details>
<summary>details</summary>

[Standard GitHub-hosted runners for Public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
<img width="733" alt="Screenshot 2024-02-21 at 23 20 29" src="https://github.com/codex-storage/nim-codex/assets/20563034/1bfbc0c3-4320-4af4-ab6a-568bceebeb3a">

**`macos-13`**
<img width="307" alt="Screenshot 2024-02-21 at 23 30 16" src="https://github.com/codex-storage/nim-codex/assets/20563034/5cfc0f15-286a-4cec-818b-a103766af853">
<img width="303" alt="Screenshot 2024-02-21 at 23 30 34" src="https://github.com/codex-storage/nim-codex/assets/20563034/6c663756-b41a-4ca3-a44e-e94075313052">
<img width="305" alt="Screenshot 2024-02-21 at 23 30 46" src="https://github.com/codex-storage/nim-codex/assets/20563034/17c025c5-ab7c-4eea-83f7-0e579246e366">

</details>