### PR TITLE
Update Docker files and building Codex docs

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -24,7 +24,7 @@ Other approaches may be viable. On macOS, some users may prefer [MacPorts](https
 
 ### Rust
 
-The current implementation of Codex's zero-knowledge proving circuit requires the installation of rust v1.76.0 or greater. Be sure to install it for your OS and add it to your terminal's path such that the command `cargo --version` gives a compatible version.
+The current implementation of Codex's zero-knowledge proving circuit requires the installation of rust v1.74.0 or greater. Be sure to install it for your OS and add it to your terminal's path such that the command `cargo --version` gives a compatible version.
 
 ### Linux
 
@@ -32,35 +32,36 @@ The current implementation of Codex's zero-knowledge proving circuit requires th
 
 On a bare bones installation of Debian (or a distribution derived from Debian, such as Ubuntu), run
 
-```text
-$ apt-get update && apt-get install build-essential cmake curl git
+```shell
+apt-get update && apt-get install build-essential cmake curl git rustc cargo
 ```
 
 Non-Debian distributions have different package managers: `apk`, `dnf`, `pacman`, `rpm`, `yum`, etc.
 
 For example, on a bare bones installation of Fedora, run
 
-```text
-$ dnf install @development-tools cmake gcc-c++ which
+```shell
+dnf install @development-tools cmake gcc-c++ rust cargo
 ```
 
 ### macOS
 
 Install the [Xcode Command Line Tools](https://mac.install.guide/commandlinetools/index.html) by opening a terminal and running
-```text
-$ xcode-select --install
+```shell
+xcode-select --install
 ```
 
 Install [Homebrew (`brew`)](https://brew.sh/) and in a new terminal run
-```text
-$ brew install bash cmake
+```shell
+brew install bash cmake rust
 ```
 
 Check that `PATH` is setup correctly
-```text
-$ which bash cmake
-/usr/local/bin/bash
-/usr/local/bin/cmake
+```shell
+which bash cmake
+
+# /usr/local/bin/bash
+# /usr/local/bin/cmake
 ```
 
 ### Windows + MSYS2
@@ -72,9 +73,9 @@ Download and run the installer from [msys2.org](https://www.msys2.org/).
 Launch an MSYS2 [environment](https://www.msys2.org/docs/environments/). UCRT64 is generally recommended: from the Windows *Start menu* select `MSYS2 MinGW UCRT x64`.
 
 Assuming a UCRT64 environment, in Bash run
-```text
-$ pacman -Suy
-$ pacman -S base-devel git unzip mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-rust
+```shell
+pacman -Suy
+pacman -S base-devel git unzip mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-rust
 ```
 
 <!-- #### Headless Windows container -->
@@ -113,27 +114,27 @@ It is possible that nim-codex can be built and run on other platforms supported 
 ## Repository
 
 In Bash run
-```text
-$ git clone https://github.com/codex-storage/nim-codex.git repos/nim-codex && cd repos/nim-codex
+```shell
+git clone https://github.com/codex-storage/nim-codex.git repos/nim-codex && cd repos/nim-codex
 ```
 
-nim-codex uses the [nimbus-build-system](https://github.com/status-im/nimbus-build-system#readme), so next run
-```text
-$ make update
+nim-codex uses the [nimbus-build-system](https://github.com/status-im/nimbus-build-system), so next run
+```shell
+make update
 ```
 
 This step can take a while to complete because by default it builds the [Nim compiler](https://nim-lang.org/docs/nimc.html).
 
 To see more output from `make` pass `V=1`. This works for all `make` targets in projects using the nimbus-build-system
-```text
-$ make V=1 update
+```shell
+make V=1 update
 ```
 
 ## Executable
 
 In Bash run
-```text
-$ make
+```shell
+make
 ```
 
 The default `make` target creates the `build/codex` executable.
@@ -145,8 +146,8 @@ See the [instructions](README.md#cli-options) in the main readme.
 ## Tests
 
 In Bash run
-```text
-$ make test
+```shell
+make test
 ```
 
 ### testAll
@@ -156,9 +157,11 @@ $ make test
 To run the integration tests, an Ethereum test node is required. Follow these instructions to set it up.
 
 ##### Windows (do this before 'All platforms')
+
 1. Download and install Visual Studio 2017 or newer. (Not VSCode!) In the Workloads overview, enable `Desktop development with C++`. ( https://visualstudio.microsoft.com )
 
 ##### All platforms
+
 1. Install NodeJS (tested with v18.14.0), consider using NVM as a version manager. [Node Version Manager (`nvm`)](https://github.com/nvm-sh/nvm#readme)
 1. Open a terminal
 1. Go to the vendor/codex-contracts-eth folder: `cd /<git-root>/vendor/codex-contracts-eth/`
@@ -177,6 +180,6 @@ The `testAll` target runs the same tests as `make test` and also runs tests for 
 To run `make testAll`.
 
 Use a new terminal to run:
-```text
-$ make testAll
+```shell
+make testAll
 ```

--- a/docker/codex.Dockerfile
+++ b/docker/codex.Dockerfile
@@ -1,5 +1,5 @@
 # Variables
-ARG BUILDER=ubuntu:lunar-20230415
+ARG BUILDER=ubuntu:22.04
 ARG IMAGE=${BUILDER}
 ARG BUILD_HOME=/src
 ARG MAKE_PARALLEL=${MAKE_PARALLEL:-4}
@@ -13,9 +13,7 @@ ARG BUILD_HOME
 ARG MAKE_PARALLEL
 ARG NIMFLAGS
 
-RUN apt-get update && apt-get install -y git cmake curl make bash lcov build-essential nim
-RUN curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+RUN apt-get update && apt-get install -y git cmake curl make bash lcov build-essential rustc cargo
 
 WORKDIR ${BUILD_HOME}
 COPY . .
@@ -32,7 +30,7 @@ ARG NAT_IP_AUTO
 WORKDIR ${APP_HOME}
 COPY --from=builder ${BUILD_HOME}/build/codex /usr/local/bin
 COPY --chmod=0755 docker/docker-entrypoint.sh /
-RUN apt-get update && apt-get install -y libgomp1 bash curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libgomp1 bash curl jq && rm -rf /var/lib/apt/lists/*
 ENV NAT_IP_AUTO=${NAT_IP_AUTO}
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["codex"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,9 @@
 
 # Environment variables from files
 if [[ -n "${ENV_PATH}" ]]; then
-  [[ -f ${ENV_PATH} ]] && source ${ENV_PATH} || for f in ${ENV_PATH}/*; do source $f; done
+  set -a
+  [[ -f "${ENV_PATH}" ]] && source "${ENV_PATH}" || for f in "${ENV_PATH}"/*; do source "$f"; done
+  set +a
 fi
 
 # Parameters


### PR DESCRIPTION
**BUILDING.md** - [preview](https://github.com/codex-storage/nim-codex/blob/docs/update-building-codex/BUILDING.md)
 - Prettify documentation
 - Make documentation copy/paste friendly
 - Add rust related packages for Linux/macOS

**docker/docker-entrypoint.sh**
 - Add auto-export
 - Unify variables enclosure

**docker/codex.Dockerfile**
 - Switch to `ubuntu:22.04` image, because
    - we use same version on GitHub Actions CI
    - the previous one is `ubuntu:lunar-20230415` - [Ubuntu 23.04 is EOL](https://wiki.ubuntu.com/Releases) on 25 January 2024
 - We do not need to install `nim` - `nimbus-build-system` will take care about that
 - Install `rust` and `cargo` via package manager
 - Install `jq` to be used with already installed `curl`
