### PR TITLE
Fix sales agent

### DIFF
--- a/codex/purchasing/states/started.nim
+++ b/codex/purchasing/states/started.nim
@@ -29,6 +29,7 @@ method run*(state: PurchaseStarted, machine: Machine): Future[?State] {.async.} 
     failed.complete()
   let subscription = await market.subscribeRequestFailed(purchase.requestId, callback)
 
+  # Ensure that we're past the request end by waiting an additional second
   let ended = clock.waitUntil((await market.getRequestEnd(purchase.requestId)) + 1)
   let fut = await one(ended, failed)
   await subscription.unsubscribe()

--- a/codex/purchasing/states/started.nim
+++ b/codex/purchasing/states/started.nim
@@ -29,7 +29,7 @@ method run*(state: PurchaseStarted, machine: Machine): Future[?State] {.async.} 
     failed.complete()
   let subscription = await market.subscribeRequestFailed(purchase.requestId, callback)
 
-  let ended = clock.waitUntil(await market.getRequestEnd(purchase.requestId))
+  let ended = clock.waitUntil((await market.getRequestEnd(purchase.requestId)) + 1)
   let fut = await one(ended, failed)
   await subscription.unsubscribe()
   if fut.id == failed.id:

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -81,8 +81,13 @@ proc subscribeCancellation(agent: SalesAgent) {.async.} =
         error "Uknown request", requestId = data.requestId
         return
 
-      if state == RequestState.Cancelled:
+      case state
+      of New:
+        discard
+      of RequestState.Cancelled:
         agent.schedule(cancelledEvent(request))
+        break
+      of RequestState.Started, RequestState.Finished, RequestState.Failed:
         break
 
       debug "The request is not yet canceled, even though it should be. Waiting for some more time.", currentState = state, now=clock.now

--- a/codex/sales/states/proving.nim
+++ b/codex/sales/states/proving.nim
@@ -62,6 +62,7 @@ proc proveLoop(
 
   proc waitUntilPeriod(period: Period) {.async.} =
     let periodicity = await market.periodicity()
+    # Ensure that we're past the period boundary by waiting an additional second
     await clock.waitUntil(periodicity.periodStart(period).truncate(int64) + 1)
 
   while true:

--- a/codex/sales/states/proving.nim
+++ b/codex/sales/states/proving.nim
@@ -62,7 +62,7 @@ proc proveLoop(
 
   proc waitUntilPeriod(period: Period) {.async.} =
     let periodicity = await market.periodicity()
-    await clock.waitUntil(periodicity.periodStart(period).truncate(int64))
+    await clock.waitUntil(periodicity.periodStart(period).truncate(int64) + 1)
 
   while true:
     let currentPeriod = await getCurrentPeriod()

--- a/tests/codex/sales/states/testproving.nim
+++ b/tests/codex/sales/states/testproving.nim
@@ -42,7 +42,9 @@ asyncchecksuite "sales state 'proving'":
 
   proc advanceToNextPeriod(market: Market) {.async.} =
     let periodicity = await market.periodicity()
-    clock.advance(periodicity.seconds.truncate(int64))
+    let current = periodicity.periodOf(clock.now().u256)
+    let periodEnd = periodicity.periodEnd(current)
+    clock.set(periodEnd.truncate(int64) + 1)
 
   test "switches to cancelled state when request expires":
     let next = state.onCancelled(request)

--- a/tests/codex/sales/states/testproving.nim
+++ b/tests/codex/sales/states/testproving.nim
@@ -5,6 +5,7 @@ import pkg/codex/sales/states/proving
 import pkg/codex/sales/states/cancelled
 import pkg/codex/sales/states/failed
 import pkg/codex/sales/states/payout
+import pkg/codex/sales/states/errored
 import pkg/codex/sales/salesagent
 import pkg/codex/sales/salescontext
 
@@ -80,6 +81,17 @@ asyncchecksuite "sales state 'proving'":
 
     check eventually future.finished
     check !(future.read()) of SalePayout
+
+  test "switches to error state when slot is no longer filled":
+    market.slotState[slot.id] = SlotState.Filled
+
+    let future = state.run(agent)
+
+    market.slotState[slot.id] = SlotState.Free
+    await market.advanceToNextPeriod()
+
+    check eventually future.finished
+    check !(future.read()) of SaleErrored
 
   test "onProve callback provides proof challenge":
     market.proofChallenge = ProofChallenge.example

--- a/tests/codex/sales/states/testproving.nim
+++ b/tests/codex/sales/states/testproving.nim
@@ -66,7 +66,7 @@ asyncchecksuite "sales state 'proving'":
     market.setProofRequired(slot.id, true)
     await market.advanceToNextPeriod()
 
-    check eventually receivedIds == @[slot.id]
+    check eventually receivedIds.contains(slot.id)
 
     await future.cancelAndWait()
     await subscription.unsubscribe()
@@ -100,4 +100,6 @@ asyncchecksuite "sales state 'proving'":
 
     let future = state.run(agent)
 
-    check receivedChallenge == market.proofChallenge
+    check eventually receivedChallenge == market.proofChallenge
+
+    await future.cancelAndWait()

--- a/tests/codex/sales/states/testsimulatedproving.nim
+++ b/tests/codex/sales/states/testsimulatedproving.nim
@@ -58,7 +58,9 @@ asyncchecksuite "sales state 'simulated-proving'":
 
   proc advanceToNextPeriod(market: Market) {.async.} =
     let periodicity = await market.periodicity()
-    clock.advance(periodicity.seconds.truncate(int64))
+    let current = periodicity.periodOf(clock.now().u256)
+    let periodEnd = periodicity.periodEnd(current)
+    clock.set(periodEnd.truncate(int64) + 1)
 
   proc waitForProvingRounds(market: Market, rounds: int) {.async.} =
     var rnds = rounds - 1 # proof round runs prior to advancing

--- a/tests/codex/sales/testsalesagent.nim
+++ b/tests/codex/sales/testsalesagent.nim
@@ -5,7 +5,6 @@ import pkg/codex/sales/salesagent
 import pkg/codex/sales/salescontext
 import pkg/codex/sales/statemachine
 import pkg/codex/sales/states/errorhandling
-import pkg/codex/proving
 
 import ../../asynctest
 import ../helpers/mockmarket
@@ -73,7 +72,6 @@ asyncchecksuite "Sales agent":
                           request.id,
                           slotIndex,
                           some request)
-    request.expiry = (getTime() + initDuration(hours=1)).toUnix.u256
 
   teardown:
     await agent.stop()
@@ -108,10 +106,10 @@ asyncchecksuite "Sales agent":
     await agent.unsubscribe()
 
   test "current state onCancelled called when cancel emitted":
-    let state = MockState.new()
-    agent.start(state)
+    agent.start(MockState.new())
     await agent.subscribe()
-    clock.set(request.expiry.truncate(int64))
+    market.requestState[request.id] = RequestState.Cancelled
+    clock.set(request.expiry.truncate(int64) + 1)
     check eventually onCancelCalled
 
   test "cancelled future is finished (cancelled) when onFulfilled called":

--- a/tests/codex/testpurchasing.nim
+++ b/tests/codex/testpurchasing.nim
@@ -98,7 +98,7 @@ asyncchecksuite "Purchasing":
     let requestEnd = getTime().toUnix() + 42
     market.requestEnds[request.id] = requestEnd
     market.emitRequestFulfilled(request.id)
-    clock.set(requestEnd)
+    clock.set(requestEnd + 1)
     await purchase.wait()
     check purchase.error.isNone
 
@@ -229,7 +229,7 @@ checksuite "Purchasing state machine":
     market.requestEnds[request.id] = clock.now() + request.ask.duration.truncate(int64)
     let future = PurchaseStarted().run(purchase)
 
-    clock.advance(request.ask.duration.truncate(int64))
+    clock.advance(request.ask.duration.truncate(int64) + 1)
 
     let next = await future
     check !next of PurchaseFinished

--- a/tests/codex/testsales.nim
+++ b/tests/codex/testsales.nim
@@ -2,5 +2,6 @@ import ./sales/testsales
 import ./sales/teststates
 import ./sales/testreservations
 import ./sales/testslotqueue
+import ./sales/testsalesagent
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
Fixes a number of things in the sales agent:
- only act upon timeouts when really inside a new period (period start + 1 second)
- fixes issue with onCancelled and onFailed not being called
- fixes issue where the cancellation loop would continue running when request starts
- fixes the salesagent tests, which weren't being run 

Extracted from #702 
Depends on #732 