### PR TITLE
Abort Codex when startup sequence fails

### DIFF
--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -46,7 +46,6 @@ logScope:
 
 type
   CodexServer* = ref object
-    runHandle: Future[void]
     config: CodexConf
     restServer: RestServerRef
     codexNode: CodexNodeRef
@@ -183,9 +182,6 @@ proc start*(s: CodexServer) {.async.} =
   await s.codexNode.start()
   s.restServer.start()
 
-  s.runHandle = newFuture[void]("codex.runHandle")
-  await s.runHandle
-
 proc stop*(s: CodexServer) {.async.} =
   notice "Stopping codex node"
 
@@ -195,8 +191,6 @@ proc stop*(s: CodexServer) {.async.} =
     s.codexNode.stop(),
     s.repoStore.stop(),
     s.maintenance.stop())
-
-  s.runHandle.complete()
 
 proc new*(
   T: type CodexServer,


### PR DESCRIPTION
fixes #726 
fixes #725 (in part)
fixes #705 
fixes #640 

This PR fixes Codex's startup sequence so it does proper error handling and doesn't simply hang when something goes wrong. It essentially deals with the errors in the main module, making it effectively the supervisor for these ops. As a sidenote, all service loops (and critical ops) should be supervised - there's still plenty of opportunity for us to go into zombie mode as internal services crash with no-one to see or deal with the failures.