### PR TITLE
fixes double lookups when block does not exist

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -198,12 +198,12 @@ proc requestBlock*(
       await b.sendWantHave(address, @[peer], toSeq(b.peers))
       codex_block_exchange_want_have_lists_sent.inc()
 
-    # Don't let timeouts bubble up. We can't be to broad here or we break
-    # cancellations.
-    try:
-      success await blockFuture
-    except AsyncTimeoutError as err:
-      failure err
+  # Don't let timeouts bubble up. We can't be too broad here or we break
+  # cancellations.
+  try:
+    success await blockFuture
+  except AsyncTimeoutError as err:
+    failure err
 
 proc requestBlock*(
   b: BlockExcEngine,

--- a/tests/codex/node/helpers.nim
+++ b/tests/codex/node/helpers.nim
@@ -1,4 +1,4 @@
-
+import std/tables
 import std/times
 
 import pkg/libp2p
@@ -6,8 +6,23 @@ import pkg/chronos
 
 import pkg/codex/codextypes
 import pkg/codex/chunker
+import pkg/codex/stores
 
 import ../../asynctest
+
+type CountingStore* = ref object of NetworkStore
+  lookups*: Table[Cid, int]
+
+proc new*(T: type CountingStore,
+  engine: BlockExcEngine, localStore: BlockStore): CountingStore =
+  # XXX this works cause NetworkStore.new is trivial
+  result = CountingStore(engine: engine, localStore: localStore)
+
+method getBlock*(self: CountingStore,
+  address: BlockAddress): Future[?!Block] {.async.} =
+
+  self.lookups.mgetOrPut(address.cid, 0).inc
+  await procCall getBlock(NetworkStore(self), address)
 
 proc toTimesDuration*(d: chronos.Duration): times.Duration =
   initDuration(seconds = d.seconds)

--- a/tests/codex/node/testnode.nim
+++ b/tests/codex/node/testnode.nim
@@ -62,6 +62,21 @@ asyncchecksuite "Test Node - Basic":
     check:
       fetched == manifest
 
+  test "should not lookup non-existing blocks twice":
+    # https://github.com/codex-storage/nim-codex/issues/699
+    let
+      cstore = CountingStore.new(engine, localStore)
+      node = CodexNodeRef.new(switch, cstore, engine, blockDiscovery)
+      missingCid = Cid.init(
+        "zDvZRwzmCvtiyubW9AecnxgLnXK8GrBvpQJBDzToxmzDN6Nrc2CZ").get()
+
+    engine.blockFetchTimeout = timer.milliseconds(100)
+
+    discard await node.retrieve(missingCid, local = false)
+
+    let lookupCount = cstore.lookups.getOrDefault(missingCid)
+    check lookupCount == 1
+
   test "Block Batching":
     let manifest = await storeDataGetManifest(localStore, chunker)
 

--- a/tests/codex/node/testnode.nim
+++ b/tests/codex/node/testnode.nim
@@ -62,7 +62,7 @@ asyncchecksuite "Test Node - Basic":
     check:
       fetched == manifest
 
-  test "should not lookup non-existing blocks twice":
+  test "Should not lookup non-existing blocks twice":
     # https://github.com/codex-storage/nim-codex/issues/699
     let
       cstore = CountingStore.new(engine, localStore)


### PR DESCRIPTION
fixes #699 

`CodexNodeRef.retrieve` always tried to refetch manifests for which `fetchManifest` fails, even if these failures were not due to decoding errors (which would indicate that the CID was pointing to a block which was not a manifest) but timeouts (which would indicate that the CID does not exist, and we should just return with a failure).

This means that, if the CID does not exist, we had to wait for twice the timeout (currently 20 minutes) before getting an error. This PR fixes that, so that we lookup only once and the actual timeout is respected.