### PR TITLE
Include openapi yaml in docker image

### DIFF
--- a/docker/codex.Dockerfile
+++ b/docker/codex.Dockerfile
@@ -30,6 +30,7 @@ ARG NAT_IP_AUTO
 WORKDIR ${APP_HOME}
 COPY --from=builder ${BUILD_HOME}/build/codex /usr/local/bin
 COPY --chmod=0755 docker/docker-entrypoint.sh /
+COPY ./openapi.yaml .
 RUN apt-get update && apt-get install -y libgomp1 bash curl jq && rm -rf /var/lib/apt/lists/*
 ENV NAT_IP_AUTO=${NAT_IP_AUTO}
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
This PR includes the openapi.yaml in our docker images.
This makes it so that each docker image contains the machine-readable documentation for how to use that image.

This enables some convenient automation:
- Client-code to be generated from the yaml
- Guaranteed compatibility or compatibility checking when using docker images of different versions of Codex
