### PR TITLE
feat[marketplace]: add slot queue pausing

### DIFF
--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -257,13 +257,13 @@ proc load*(sales: Sales) {.async.} =
     agent.onCleanUp = proc(returnBytes = false, reprocessSlot = false) {.async.} =
       # since workers are not being dispatched, this future has not been created
       # by a worker. Create a dummy one here so we can call sales.cleanUp
-      let done = newFuture[void]("onCleanUp_Dummy")
+      let done: Future[void] = nil
       await sales.cleanUp(agent, returnBytes, reprocessSlot, done)
 
     # TODO: this seemed to be missing during load, but unknown if it was
     # intentionally left out for some unknown reason?
     agent.onFilled = some proc(request: StorageRequest, slotIndex: UInt256) =
-      let done = newFuture[void]("onFilled_Dummy")
+      let done: Future[void] = nil
       sales.filled(request, slotIndex, done)
 
     agent.start(SaleUnknown())

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -283,6 +283,7 @@ proc onAvailabilityAdded(sales: Sales, availability: Availability) {.async.} =
 
   queue.clearSeenFlags()
   if queue.paused:
+    trace "unpausing queue after new availability added"
     queue.unpause()
 
 proc onStorageRequested(sales: Sales,

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -269,12 +269,6 @@ proc load*(sales: Sales) {.async.} =
     agent.start(SaleUnknown())
     sales.agents.add agent
 
-proc onAvailabilitiesEmptied(sales: Sales) {.async.} =
-  ## When there are no availabilities remaining, the queue should be paused
-  let queue = sales.context.slotQueue
-
-  queue.pause()
-
 proc onAvailabilityAdded(sales: Sales, availability: Availability) {.async.} =
   ## When availabilities are modified or added, the queue should be unpaused if
   ## it was paused and any slots in the queue should have their `seen` flag
@@ -483,11 +477,7 @@ proc startSlotQueue(sales: Sales) {.async.} =
   proc onAvailabilityAdded(availability: Availability) {.async.} =
     await sales.onAvailabilityAdded(availability)
 
-  proc onAvailabilitiesEmptied() {.async.} =
-    await sales.onAvailabilitiesEmptied()
-
   reservations.onAvailabilityAdded = onAvailabilityAdded
-  reservations.onAvailabilitiesEmptied = onAvailabilitiesEmptied
 
 proc subscribe(sales: Sales) {.async.} =
   await sales.subscribeRequested()

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -268,7 +268,7 @@ proc load*(sales: Sales) {.async.} =
     agent.start(SaleUnknown())
     sales.agents.add agent
 
-proc onAvailabilitiesEmptied(sales: Sales, availability: Availability) {.async.} =
+proc onAvailabilitiesEmptied(sales: Sales) {.async.} =
   ## When there are no availabilities remaining, the queue should be paused
   let queue = sales.context.slotQueue
 
@@ -480,8 +480,8 @@ proc startSlotQueue(sales: Sales) {.async.} =
   proc onAvailabilityAdded(availability: Availability) {.async.} =
     await sales.onAvailabilityAdded(availability)
 
-  proc onAvailabilitiesEmptied(availability: Availability) {.async.} =
-    await sales.onAvailabilitiesEmptied(availability)
+  proc onAvailabilitiesEmptied() {.async.} =
+    await sales.onAvailabilitiesEmptied()
 
   reservations.onAvailabilityAdded = onAvailabilityAdded
   reservations.onAvailabilitiesEmptied = onAvailabilitiesEmptied

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -303,9 +303,7 @@ proc onStorageRequested(sales: Sales,
   for item in items:
     # continue on failure
     if err =? slotQueue.push(item).errorOption:
-      if err of NoMatchingAvailabilityError:
-        info "slot in queue had no matching availabilities, ignoring"
-      elif err of SlotQueueItemExistsError:
+      if err of SlotQueueItemExistsError:
         error "Failed to push item to queue becaue it already exists"
       elif err of QueueNotRunningError:
         warn "Failed to push item to queue becaue queue is not running"
@@ -346,9 +344,7 @@ proc onSlotFreed(sales: Sales,
   addSlotToQueue()
     .track(sales)
     .catch(proc(err: ref CatchableError) =
-      if err of NoMatchingAvailabilityError:
-        info "slot in queue had no matching availabilities, ignoring"
-      elif err of SlotQueueItemExistsError:
+      if err of SlotQueueItemExistsError:
         error "Failed to push item to queue becaue it already exists"
       elif err of QueueNotRunningError:
         warn "Failed to push item to queue becaue queue is not running"

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -260,11 +260,9 @@ proc load*(sales: Sales) {.async.} =
       let done: Future[void] = nil
       await sales.cleanUp(agent, returnBytes, reprocessSlot, done)
 
-    # TODO: this seemed to be missing during load, but unknown if it was
-    # intentionally left out for some unknown reason?
-    agent.onFilled = some proc(request: StorageRequest, slotIndex: UInt256) =
-      let done: Future[void] = nil
-      sales.filled(request, slotIndex, done)
+    # There is no need to assign agent.onFilled as slots loaded from `mySlots`
+    # are inherently already filled and so assigning agent.onFilled would be
+    # superfluous.
 
     agent.start(SaleUnknown())
     sales.agents.add agent

--- a/codex/sales/reservations.nim
+++ b/codex/sales/reservations.nim
@@ -77,7 +77,7 @@ type
     onAvailabilitiesEmptied: ?OnAvailabilitiesEmptied
   GetNext* = proc(): Future[?seq[byte]] {.upraises: [], gcsafe, closure.}
   OnAvailabilityAdded* = proc(availability: Availability): Future[void] {.upraises: [], gcsafe.}
-  OnAvailabilitiesEmptied* = proc(availability: Availability): Future[void] {.upraises: [], gcsafe.}
+  OnAvailabilitiesEmptied* = proc: Future[void] {.upraises: [], gcsafe.}
   StorableIter* = ref object
     finished*: bool
     next*: GetNext

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -25,7 +25,7 @@ type
     onCleanUp*: OnCleanUp
     onFilled*: ?OnFilled
 
-  OnCleanUp* = proc (returnBytes = false): Future[void] {.gcsafe, upraises: [].}
+  OnCleanUp* = proc (returnBytes = false, reprocessSlot = false): Future[void] {.gcsafe, upraises: [].}
   OnFilled* = proc(request: StorageRequest,
                    slotIndex: UInt256) {.gcsafe, upraises: [].}
 

--- a/codex/sales/slotqueue.nim
+++ b/codex/sales/slotqueue.nim
@@ -36,6 +36,7 @@ type
     reward: UInt256
     collateral: UInt256
     expiry: UInt256
+    seen: bool
 
   # don't need to -1 to prevent overflow when adding 1 (to always allow push)
   # because AsyncHeapQueue size is of type `int`, which is larger than `uint16`
@@ -83,6 +84,9 @@ proc `<`*(a, b: SlotQueueItem): bool =
   proc addIf(score: var uint8, condition: bool, addition: int) =
     if condition:
       score += 1'u8 shl addition
+
+  scoreA.addIf(a.seen > b.seen, 4)
+  scoreB.addIf(a.seen < b.seen, 4)
 
   scoreA.addIf(a.profitability > b.profitability, 3)
   scoreB.addIf(a.profitability < b.profitability, 3)

--- a/codex/sales/slotqueue.nim
+++ b/codex/sales/slotqueue.nim
@@ -266,7 +266,7 @@ proc push*(self: SlotQueue, item: SlotQueueItem): ?!void =
 
   # when slots are pushed to the queue, the queue should be unpaused if it was
   # paused
-  if self.paused:
+  if self.paused and not item.seen:
     trace "unpausing queue after new slots pushed"
     self.unpause()
 

--- a/codex/sales/slotqueue.nim
+++ b/codex/sales/slotqueue.nim
@@ -55,7 +55,6 @@ type
   SlotQueueItemExistsError* = object of SlotQueueError
   SlotQueueItemNotExistsError* = object of SlotQueueError
   SlotsOutOfRangeError* = object of SlotQueueError
-  NoMatchingAvailabilityError* = object of SlotQueueError
   QueueNotRunningError* = object of SlotQueueError
 
 # Number of concurrent workers used for processing SlotQueueItems

--- a/codex/sales/slotqueue.nim
+++ b/codex/sales/slotqueue.nim
@@ -268,7 +268,7 @@ proc push*(self: SlotQueue, item: SlotQueueItem): ?!void =
   # paused
   if self.paused:
     trace "unpausing queue after new slots pushed"
-  self.unpause()
+    self.unpause()
 
   return success()
 
@@ -360,7 +360,8 @@ proc dispatch(self: SlotQueue,
 proc clearSeenFlags*(self: SlotQueue) =
   # To avoid issues with new queue items being pushed to the queue while all
   # items are being iterated (eg if a new storage request comes in and pushes
-  # new slots to the queue), first pop all items in the queue off and
+  # new slots to the queue), enumerate the items in the queue using random
+  # access, overwriting each item with `seen = true`
   for i in 0..<self.len:
     var item = self[i]
     item.seen = false

--- a/codex/sales/slotqueue.nim
+++ b/codex/sales/slotqueue.nim
@@ -220,7 +220,7 @@ proc pause*(self: SlotQueue) =
   self.unpaused.clear()
 
 proc unpause*(self: SlotQueue) =
-  # set unpaused flag to true -- blocks coroutines waiting on unpaused.wait()
+  # set unpaused flag to true -- coroutines will block on unpaused.wait()
   self.unpaused.fire()
 
 proc populateItem*(self: SlotQueue,
@@ -407,7 +407,7 @@ proc start*(self: SlotQueue) {.async.} =
           reqId = item.requestId, slotIdx = item.slotIndex
         self.pause()
 
-      # block until unpaused is true/cleared, ie wait for queue to be unpaused
+      # block until unpaused is false/cleared, ie wait for queue to be unpaused
       if self.paused:
         trace "Queue is paused, waiting for new slots or availabilities to be modified/added"
       await self.unpaused.wait()

--- a/codex/sales/slotqueue.nim
+++ b/codex/sales/slotqueue.nim
@@ -85,8 +85,8 @@ proc `<`*(a, b: SlotQueueItem): bool =
     if condition:
       score += 1'u8 shl addition
 
-  scoreA.addIf(a.seen > b.seen, 4)
-  scoreB.addIf(a.seen < b.seen, 4)
+  scoreA.addIf(a.seen < b.seen, 4)
+  scoreB.addIf(a.seen > b.seen, 4)
 
   scoreA.addIf(a.profitability > b.profitability, 3)
   scoreB.addIf(a.profitability < b.profitability, 3)
@@ -126,7 +126,7 @@ proc new*(_: type SlotQueue,
   # avoid instantiating `workers` in constructor to avoid side effects in
   # `newAsyncQueue` procedure
 
-proc init*(_: type SlotQueueWorker): SlotQueueWorker =
+proc init(_: type SlotQueueWorker): SlotQueueWorker =
   SlotQueueWorker(
     doneProcessing: newFuture[void]("slotqueue.worker.processing")
   )
@@ -135,7 +135,8 @@ proc init*(_: type SlotQueueItem,
           requestId: RequestId,
           slotIndex: uint16,
           ask: StorageAsk,
-          expiry: UInt256): SlotQueueItem =
+          expiry: UInt256,
+          seen = false): SlotQueueItem =
 
   SlotQueueItem(
     requestId: requestId,
@@ -144,7 +145,8 @@ proc init*(_: type SlotQueueItem,
     duration: ask.duration,
     reward: ask.reward,
     collateral: ask.collateral,
-    expiry: expiry
+    expiry: expiry,
+    seen: seen
   )
 
 proc init*(_: type SlotQueueItem,

--- a/codex/sales/states/cancelled.nim
+++ b/codex/sales/states/cancelled.nim
@@ -28,6 +28,6 @@ method run*(state: SaleCancelled, machine: Machine): Future[?State] {.async.} =
     onClear(request, data.slotIndex)
 
   if onCleanUp =? agent.onCleanUp:
-    await onCleanUp(returnBytes = true)
+    await onCleanUp(returnBytes = true, reprocessSlot = false)
 
   warn "Sale cancelled due to timeout",  requestId = data.requestId, slotIndex = data.slotIndex

--- a/codex/sales/states/downloading.nim
+++ b/codex/sales/states/downloading.nim
@@ -31,11 +31,6 @@ method onSlotFilled*(state: SaleDownloading, requestId: RequestId,
                      slotIndex: UInt256): ?State =
   return some State(SaleFilled())
 
-# override onError so that the slot is reprocess in the case of an unhandled
-# exception
-method onError*(state: SaleDownloading, error: ref CatchableError): ?State =
-  return some State(SaleErrored(error: error, reprocessSlot: true))
-
 method run*(state: SaleDownloading, machine: Machine): Future[?State] {.async.} =
   let agent = SalesAgent(machine)
   let data = agent.data
@@ -74,7 +69,7 @@ method run*(state: SaleDownloading, machine: Machine): Future[?State] {.async.} 
   if err =? (await onStore(request,
                            data.slotIndex,
                            onBlocks)).errorOption:
-    return some State(SaleErrored(error: err, reprocessSlot: true))
+    return some State(SaleErrored(error: err, reprocessSlot: false))
 
   trace "Download complete"
   return some State(SaleInitialProving())

--- a/codex/sales/states/errored.nim
+++ b/codex/sales/states/errored.nim
@@ -30,5 +30,5 @@ method run*(state: SaleErrored, machine: Machine): Future[?State] {.async.} =
     onClear(request, data.slotIndex)
 
   if onCleanUp =? agent.onCleanUp:
-    await onCleanUp(returnBytes = true)
+    await onCleanUp(returnBytes = true, reprocessSlot = true)
 

--- a/codex/sales/states/errored.nim
+++ b/codex/sales/states/errored.nim
@@ -12,6 +12,7 @@ logScope:
 
 type SaleErrored* = ref object of SaleState
   error*: ref CatchableError
+  reprocessSlot*: bool
 
 method `$`*(state: SaleErrored): string = "SaleErrored"
 
@@ -30,5 +31,5 @@ method run*(state: SaleErrored, machine: Machine): Future[?State] {.async.} =
     onClear(request, data.slotIndex)
 
   if onCleanUp =? agent.onCleanUp:
-    await onCleanUp(returnBytes = true, reprocessSlot = true)
+    await onCleanUp(returnBytes = true, reprocessSlot = state.reprocessSlot)
 

--- a/codex/sales/states/ignored.nim
+++ b/codex/sales/states/ignored.nim
@@ -17,4 +17,7 @@ method run*(state: SaleIgnored, machine: Machine): Future[?State] {.async.} =
   let agent = SalesAgent(machine)
 
   if onCleanUp =? agent.onCleanUp:
-    await onCleanUp()
+    # Ignored slots mean there was no availability. In order to prevent small
+    # availabilities from draining the queue, mark this slot as seen and re-add
+    # back into the queue.
+    await onCleanUp(reprocessSlot = true)

--- a/codex/utils/asyncheapqueue.nim
+++ b/codex/utils/asyncheapqueue.nim
@@ -225,6 +225,20 @@ proc update*[T](heap: AsyncHeapQueue[T], item: T): bool =
     heap.siftup(0)
     return true
 
+proc update*[T](heap: AsyncHeapQueue[T], index: int, item: T) =
+  ## Overwrites an entry in the heap at index. The heap is then reshuffled to
+  ## maintain the heap invariant. This is like doing an update without the find,
+  ## and can be useful in situations where iterating the entire heap (to find
+  ## the item) could cause issues with new items being added to the heap while
+  ## iterating
+
+  # replace item with new one in case it's a copy
+  heap.queue[index] = item
+  # re-establish heap order
+  # TODO: don't start at 0 to avoid reshuffling
+  # entire heap
+  heap.siftup(0)
+
 proc pushOrUpdateNoWait*[T](heap: AsyncHeapQueue[T], item: T): Result[void, AsyncHQErrors] =
   ## Update an item if it exists or push a new one
   ##

--- a/codex/utils/asyncheapqueue.nim
+++ b/codex/utils/asyncheapqueue.nim
@@ -225,20 +225,6 @@ proc update*[T](heap: AsyncHeapQueue[T], item: T): bool =
     heap.siftup(0)
     return true
 
-proc update*[T](heap: AsyncHeapQueue[T], index: int, item: T) =
-  ## Overwrites an entry in the heap at index. The heap is then reshuffled to
-  ## maintain the heap invariant. This is like doing an update without the find,
-  ## and can be useful in situations where iterating the entire heap (to find
-  ## the item) could cause issues with new items being added to the heap while
-  ## iterating
-
-  # replace item with new one in case it's a copy
-  heap.queue[index] = item
-  # re-establish heap order
-  # TODO: don't start at 0 to avoid reshuffling
-  # entire heap
-  heap.siftup(0)
-
 proc pushOrUpdateNoWait*[T](heap: AsyncHeapQueue[T], item: T): Result[void, AsyncHQErrors] =
   ## Update an item if it exists or push a new one
   ##

--- a/tests/codex/helpers/mockslotqueueitem.nim
+++ b/tests/codex/helpers/mockslotqueueitem.nim
@@ -12,7 +12,7 @@ type MockSlotQueueItem* = object
   seen*: bool
 
 proc toSlotQueueItem*(item: MockSlotQueueItem): SlotQueueItem =
-  var qitem = SlotQueueItem.init(
+  SlotQueueItem.init(
     requestId = item.requestId,
     slotIndex = item.slotIndex,
     ask = StorageAsk(
@@ -21,35 +21,6 @@ proc toSlotQueueItem*(item: MockSlotQueueItem): SlotQueueItem =
             reward: item.reward,
             collateral: item.collateral
           ),
-    expiry = item.expiry
+    expiry = item.expiry,
+    seen = item.seen
   )
-  qitem.seen = item.seen
-  return qitem
-
-# proc requestId*(item: MockSlotQueueItem): RequestId = item.requestId
-# proc `requestId=`*(item: var MockSlotQueueItem, requestId: RequestId) =
-#   item.requestId = requestId
-
-# proc slotIndex*(item: MockSlotQueueItem): uint16 = item.slotIndex
-# proc `slotIndex=`*(item: var MockSlotQueueItem, slotIndex: uint16) =
-#   item.slotIndex = slotIndex
-
-# proc slotSize*(item: MockSlotQueueItem): UInt256 = item.slotSize
-# proc `slotSize=`*(item: MockSlotQueueItem, slotSize: UInt256) =
-#   item.slotSize = slotSize
-
-# proc duration*(item: MockSlotQueueItem): UInt256 = item.duration
-# proc `duration=`*(item: MockSlotQueueItem, duration: UInt256) =
-#   item.duration = duration
-
-# proc reward*(item: MockSlotQueueItem): UInt256 = item.reward
-# proc `reward=`*(item: MockSlotQueueItem, reward: UInt256) =
-#   item.reward = reward
-
-# proc collateral*(item: MockSlotQueueItem): UInt256 = item.collateral
-# proc `collateral=`*(item: MockSlotQueueItem, collateral: UInt256) =
-#   item.collateral = collateral
-
-# proc expiry*(item: MockSlotQueueItem): UInt256 = item.expiry
-# proc `expiry=`*(item: MockSlotQueueItem, expiry: UInt256) =
-#   item.collateral = expiry

--- a/tests/codex/helpers/mockslotqueueitem.nim
+++ b/tests/codex/helpers/mockslotqueueitem.nim
@@ -1,0 +1,55 @@
+import pkg/codex/contracts/requests
+import pkg/codex/sales/slotqueue
+
+type MockSlotQueueItem* = object
+  requestId*: RequestId
+  slotIndex*: uint16
+  slotSize*: UInt256
+  duration*: UInt256
+  reward*: UInt256
+  collateral*: UInt256
+  expiry*: UInt256
+  seen*: bool
+
+proc toSlotQueueItem*(item: MockSlotQueueItem): SlotQueueItem =
+  var qitem = SlotQueueItem.init(
+    requestId = item.requestId,
+    slotIndex = item.slotIndex,
+    ask = StorageAsk(
+            slotSize: item.slotSize,
+            duration: item.duration,
+            reward: item.reward,
+            collateral: item.collateral
+          ),
+    expiry = item.expiry
+  )
+  qitem.seen = item.seen
+  return qitem
+
+# proc requestId*(item: MockSlotQueueItem): RequestId = item.requestId
+# proc `requestId=`*(item: var MockSlotQueueItem, requestId: RequestId) =
+#   item.requestId = requestId
+
+# proc slotIndex*(item: MockSlotQueueItem): uint16 = item.slotIndex
+# proc `slotIndex=`*(item: var MockSlotQueueItem, slotIndex: uint16) =
+#   item.slotIndex = slotIndex
+
+# proc slotSize*(item: MockSlotQueueItem): UInt256 = item.slotSize
+# proc `slotSize=`*(item: MockSlotQueueItem, slotSize: UInt256) =
+#   item.slotSize = slotSize
+
+# proc duration*(item: MockSlotQueueItem): UInt256 = item.duration
+# proc `duration=`*(item: MockSlotQueueItem, duration: UInt256) =
+#   item.duration = duration
+
+# proc reward*(item: MockSlotQueueItem): UInt256 = item.reward
+# proc `reward=`*(item: MockSlotQueueItem, reward: UInt256) =
+#   item.reward = reward
+
+# proc collateral*(item: MockSlotQueueItem): UInt256 = item.collateral
+# proc `collateral=`*(item: MockSlotQueueItem, collateral: UInt256) =
+#   item.collateral = collateral
+
+# proc expiry*(item: MockSlotQueueItem): UInt256 = item.expiry
+# proc `expiry=`*(item: MockSlotQueueItem, expiry: UInt256) =
+#   item.collateral = expiry

--- a/tests/codex/sales/states/testcancelled.nim
+++ b/tests/codex/sales/states/testcancelled.nim
@@ -1,0 +1,45 @@
+import pkg/questionable
+import pkg/chronos
+import pkg/codex/contracts/requests
+import pkg/codex/sales/states/cancelled
+import pkg/codex/sales/salesagent
+import pkg/codex/sales/salescontext
+import pkg/codex/market
+
+import ../../../asynctest
+import ../../examples
+import ../../helpers
+import ../../helpers/mockmarket
+import ../../helpers/mockclock
+
+asyncchecksuite "sales state 'cancelled'":
+  let request = StorageRequest.example
+  let slotIndex = (request.ask.slots div 2).u256
+  let market = MockMarket.new()
+  let clock = MockClock.new()
+
+  var state: SaleCancelled
+  var agent: SalesAgent
+  var returnBytesWas = false
+  var reprocessSlotWas = false
+
+  setup:
+    let onCleanUp = proc (returnBytes = false, reprocessSlot = false) {.async.} =
+                      returnBytesWas = returnBytes
+                      reprocessSlotWas = reprocessSlot
+
+    let context = SalesContext(
+      market: market,
+      clock: clock
+    )
+    agent = newSalesAgent(context,
+                          request.id,
+                          slotIndex,
+                          request.some)
+    agent.onCleanUp = onCleanUp
+    state = SaleCancelled.new()
+
+  test "calls onCleanUp with returnBytes = false and reprocessSlot = true":
+    discard await state.run(agent)
+    check eventually returnBytesWas == true
+    check eventually reprocessSlotWas == false

--- a/tests/codex/sales/states/testdownloading.nim
+++ b/tests/codex/sales/states/testdownloading.nim
@@ -1,8 +1,9 @@
 import std/unittest
 import pkg/questionable
 import pkg/codex/contracts/requests
-import pkg/codex/sales/states/downloading
 import pkg/codex/sales/states/cancelled
+import pkg/codex/sales/states/downloading
+import pkg/codex/sales/states/errored
 import pkg/codex/sales/states/failed
 import pkg/codex/sales/states/filled
 import ../../examples
@@ -27,3 +28,8 @@ checksuite "sales state 'downloading'":
   test "switches to filled state when slot is filled":
     let next = state.onSlotFilled(request.id, slotIndex)
     check !next of SaleFilled
+
+  test "switches to errored state with `reprocessSlot = true` when onError called":
+    let next = state.onError(newException(ValueError, "oh no!"))
+    check !next of SaleErrored
+    check SaleErrored(!next).reprocessSlot == true

--- a/tests/codex/sales/states/testdownloading.nim
+++ b/tests/codex/sales/states/testdownloading.nim
@@ -28,8 +28,3 @@ checksuite "sales state 'downloading'":
   test "switches to filled state when slot is filled":
     let next = state.onSlotFilled(request.id, slotIndex)
     check !next of SaleFilled
-
-  test "switches to errored state with `reprocessSlot = true` when onError called":
-    let next = state.onError(newException(ValueError, "oh no!"))
-    check !next of SaleErrored
-    check SaleErrored(!next).reprocessSlot == true

--- a/tests/codex/sales/states/testerrored.nim
+++ b/tests/codex/sales/states/testerrored.nim
@@ -40,6 +40,10 @@ asyncchecksuite "sales state 'errored'":
     state = SaleErrored(error: newException(ValueError, "oh no!"))
 
   test "calls onCleanUp with returnBytes = false and reprocessSlot = true":
+    state = SaleErrored(
+      error: newException(ValueError, "oh no!"),
+      reprocessSlot: true
+    )
     discard await state.run(agent)
     check eventually returnBytesWas == true
     check eventually reprocessSlotWas == true

--- a/tests/codex/sales/states/testerrored.nim
+++ b/tests/codex/sales/states/testerrored.nim
@@ -1,0 +1,45 @@
+import pkg/questionable
+import pkg/chronos
+import pkg/codex/contracts/requests
+import pkg/codex/sales/states/errored
+import pkg/codex/sales/salesagent
+import pkg/codex/sales/salescontext
+import pkg/codex/market
+
+import ../../../asynctest
+import ../../examples
+import ../../helpers
+import ../../helpers/mockmarket
+import ../../helpers/mockclock
+
+asyncchecksuite "sales state 'errored'":
+  let request = StorageRequest.example
+  let slotIndex = (request.ask.slots div 2).u256
+  let market = MockMarket.new()
+  let clock = MockClock.new()
+
+  var state: SaleErrored
+  var agent: SalesAgent
+  var returnBytesWas = false
+  var reprocessSlotWas = false
+
+  setup:
+    let onCleanUp = proc (returnBytes = false, reprocessSlot = false) {.async.} =
+                      returnBytesWas = returnBytes
+                      reprocessSlotWas = reprocessSlot
+
+    let context = SalesContext(
+      market: market,
+      clock: clock
+    )
+    agent = newSalesAgent(context,
+                          request.id,
+                          slotIndex,
+                          request.some)
+    agent.onCleanUp = onCleanUp
+    state = SaleErrored(error: newException(ValueError, "oh no!"))
+
+  test "calls onCleanUp with returnBytes = false and reprocessSlot = true":
+    discard await state.run(agent)
+    check eventually returnBytesWas == true
+    check eventually reprocessSlotWas == true

--- a/tests/codex/sales/states/testignored.nim
+++ b/tests/codex/sales/states/testignored.nim
@@ -1,0 +1,45 @@
+import pkg/questionable
+import pkg/chronos
+import pkg/codex/contracts/requests
+import pkg/codex/sales/states/ignored
+import pkg/codex/sales/salesagent
+import pkg/codex/sales/salescontext
+import pkg/codex/market
+
+import ../../../asynctest
+import ../../examples
+import ../../helpers
+import ../../helpers/mockmarket
+import ../../helpers/mockclock
+
+asyncchecksuite "sales state 'ignored'":
+  let request = StorageRequest.example
+  let slotIndex = (request.ask.slots div 2).u256
+  let market = MockMarket.new()
+  let clock = MockClock.new()
+
+  var state: SaleIgnored
+  var agent: SalesAgent
+  var returnBytesWas = false
+  var reprocessSlotWas = false
+
+  setup:
+    let onCleanUp = proc (returnBytes = false, reprocessSlot = false) {.async.} =
+                      returnBytesWas = returnBytes
+                      reprocessSlotWas = reprocessSlot
+
+    let context = SalesContext(
+      market: market,
+      clock: clock
+    )
+    agent = newSalesAgent(context,
+                          request.id,
+                          slotIndex,
+                          request.some)
+    agent.onCleanUp = onCleanUp
+    state = SaleIgnored.new()
+
+  test "calls onCleanUp with returnBytes = false and reprocessSlot = true":
+    discard await state.run(agent)
+    check eventually returnBytesWas == false
+    check eventually reprocessSlotWas == true

--- a/tests/codex/sales/testreservations.nim
+++ b/tests/codex/sales/testreservations.nim
@@ -287,30 +287,6 @@ asyncchecksuite "Reservations module":
 
     check not called
 
-  test "availability considered empty when freeSize drops below DefaultBlockSize":
-    var availability = createAvailability()
-    availability.freeSize = (DefaultBlockSize - 1).int.u256
-    check availability.empty
-
-  test "availability considered empty when freeSize drops below DefaultBlockSize":
-    let example = Availability.example
-    var availability = Availability.init(
-                        example.totalSize,
-                        freeSize = (DefaultBlockSize - 1).int.u256,
-                        example.duration,
-                        example.minPrice,
-                        example.maxCollateral)
-    check availability.empty
-
-  test "onAvailabilitiesEmptied called when all availabilities are 'empty'":
-    var availability = createAvailability()
-    var called = false
-    reservations.onAvailabilitiesEmptied = proc {.async.} =
-      called = true
-    availability.freeSize = (DefaultBlockSize - 1).int.u256
-    discard await reservations.update(availability)
-    check called
-
   test "availabilities can be found":
     let availability = createAvailability()
 

--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -275,6 +275,7 @@ asyncchecksuite "Sales":
   test "items in queue are readded (and marked seen) once ignored":
     await market.requestStorage(request)
     let items = SlotQueueItem.init(request)
+    await sleepAsync(10.millis) # queue starts paused, allow items to be added to the queue
     check eventually queue.paused
     # The first processed item will be will have been re-pushed with `seen =
     # true`. Then, once this item is processed by the queue, its 'seen' flag
@@ -292,6 +293,7 @@ asyncchecksuite "Sales":
     createAvailability() # enough to fill a single slot
     await market.requestStorage(request)
     let items = SlotQueueItem.init(request)
+    await sleepAsync(10.millis) # queue starts paused, allow items to be added to the queue
     check eventually queue.paused
     # The first processed item/slot will be filled (eventually). Subsequent
     # items will have been re-pushed with `seen = true`. Then, once a "seen"

--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -499,6 +499,10 @@ asyncchecksuite "Sales":
       await sleepAsync(chronos.hours(1))
       return success()
     createAvailability()
+    # ensure only one slot, otherwise once bytes are returned to the
+    # availability, the queue will be unpaused and availability will be consumed
+    # by other slots
+    request.ask.slots = 1.uint64
     await market.requestStorage(request)
     market.requestState[request.id]=RequestState.New # "On-chain" is the request still ongoing even after local expiration
 

--- a/tests/codex/sales/testslotqueue.nim
+++ b/tests/codex/sales/testslotqueue.nim
@@ -163,8 +163,6 @@ suite "Slot queue":
     check itemB < itemA # B higher priority than A
     check itemA > itemB
 
-  # TODO: fix above test to use MockSlotQueueItem. Also add multiple tests for each item property
-
   test "correct prioritizes SlotQueueItems based on 'seen'":
     let request = StorageRequest.example
     let itemA = MockSlotQueueItem(


### PR DESCRIPTION
Adds slot queue pausing based on the design in https://github.com/codex-storage/codex-research/pull/188.

@AuHau -- I took the changes in commit https://github.com/codex-storage/nim-codex/pull/748/commits/1425bf5c3f42a80f16821789af7957d4757f1e17 and added to this PR as I needed to update that routine.

Close #549 