### PR TITLE
Add Node SPR endpoint

### DIFF
--- a/docs/TWOCLIENTTEST.md
+++ b/docs/TWOCLIENTTEST.md
@@ -48,21 +48,39 @@ Codex uses sane defaults for most of its arguments. Here we specify some explici
 
 ### 2. Sign of life
 
+Run the command :
+
 ```bash
-curl --request GET \
-  --url http://127.0.0.1:8080/api/codex/v1/debug/info
+curl -X GET http://127.0.0.1:8080/api/codex/v1/debug/info
 ```
 
 This GET request will return the node's debug information. The response JSON should look like:
 
 ```json
 {
-	"id": "16Uiu2HAmGzJQEvNRYVVJNxHSb1Gd5xzxTK8XRZuMJzuoDaz7fADb",
-	"addrs": [
-		"/ip4/127.0.0.1/tcp/8070"
-	],
-	"repo": "Data1",
-	"spr": "spr:CiUIAhIhA0BhMXo12O4h8DSdfnvU6MWUQx3kd-xw_2sCZrWOWChOEgIDARo8CicAJQgCEiEDQGExejXY7iHwNJ1-e9ToxZRDHeR37HD_awJmtY5YKE4Q7aqInwYaCwoJBH8AAAGRAh-aKkYwRAIgSHGvrb4mxQbOTU5wdcJJYz3fErkVx4v09nqHE4n9d4ECIGWyfF58pmfUKeC7MWCtIhBDCgNJkjHz2JkKfJoYgqHW"
+  "id": "16Uiu2HAmJ3TSfPnrJNedHy2DMsjTqwBiVAQQqPo579DuMgGxmG99",
+  "addrs": [
+    "/ip4/127.0.0.1/tcp/8070"
+  ],
+  "repo": "/Users/user/projects/nim-codex/Data1",
+  "spr": "spr:CiUIAhIhA1AL2J7EWfg7x77iOrR9YYBisY6CDtU2nEhuwDaQyjpkEgIDARo8CicAJQgCEiEDUAvYnsRZ-DvHvuI6tH1hgGKxjoIO1TacSG7ANpDKOmQQ2MWasAYaCwoJBH8AAAGRAh-aKkYwRAIgB2ooPfAyzWEJDe8hD2OXKOBnyTOPakc4GzqKqjM2OGoCICraQLPWf0oSEuvmSroFebVQx-3SDtMqDoIyWhjq1XFF",
+  "announceAddresses": [
+    "/ip4/127.0.0.1/tcp/8070"
+  ],
+  "table": {
+    "localNode": {
+      "nodeId": "f6e6d48fa7cd171688249a57de0c1aba15e88308c07538c91e1310c9f48c860a",
+      "peerId": "16Uiu2HAmJ3TSfPnrJNedHy2DMsjTqwBiVAQQqPo579DuMgGxmG99",
+      "record": "...",
+      "address": "0.0.0.0:8090",
+      "seen": false
+    },
+    "nodes": []
+  },
+  "codex": {
+    "version": "untagged build",
+    "revision": "b3e626a5"
+  }
 }
 ```
 
@@ -72,14 +90,28 @@ This GET request will return the node's debug information. The response JSON sho
 | `addrs` | Multiaddresses currently open to accept connections from other nodes.                    |
 | `repo`  | Path of this node's data folder.                                                         |
 | `spr`   | Signed Peer Record, encoded information about this node and its location in the network. |
+| `announceAddresses`   | Multiaddresses used for annoucning this node
+| `table`   | Table of nodes present in the node's DHT
+| `codex`   | Codex version information
 
 ### 3. Launch Node #2
 
-Replace `<SPR HERE>` in the next command with the string value for `spr`, returned by the first node's `debug/info` response.
+Retreive the SPR:
+```bash
+curl -H 'Accept: text/plain'  http://127.0.0.1:8080/api/codex/v1/spr
+```
+
+Replace `<SPR HERE>` in the next command the value returned by the SPR value. Note it include the `spr:` at the beginning.
 
 Open a new terminal and run:
-- Mac/Unx: `"build/codex" --data-dir="$(pwd)/Data2" --listen-addrs=/ip4/127.0.0.1/tcp/8071 --api-port=8081 --disc-port=8091 --bootstrap-node=<SPR HERE>`
+- Mac/Linux: `"build/codex" --data-dir="$(pwd)/Data2" --listen-addrs=/ip4/127.0.0.1/tcp/8071 --api-port=8081 --disc-port=8091 --bootstrap-node=<SPR HERE>`
 - Windows: `"build/codex.exe" --data-dir="Data2" --listen-addrs=/ip4/127.0.0.1/tcp/8071 --api-port=8081 --disc-port=8091 --bootstrap-node=<SPR HERE>`
+
+On Mac, Linux, or MSYS2 you can run it in one command like:
+
+```sh
+"build/codex" --data-dir="$(pwd)/Data2" --listen-addrs=/ip4/127.0.0.1/tcp/8071 --api-port=8081 --disc-port=8091 --bootstrap-node=$(curl -H 'Accept: text/plain'  http://127.0.0.1:8080/api/codex/v1/spr)
+```
 
 Notice we're using a new data-dir, and we've increased each port number by one. This is needed so that the new node won't try to open ports already in use by the first node.
 
@@ -87,18 +119,22 @@ We're now also including the `bootstrap-node` argument. This allows us to link t
 
 ### 4. Connect The Two
 
-Use the command we've used in step 2 to retrieve the debug information from node 2:
+Normally the two will automatically connect. If not you can use the command we've used in step 2 to retrieve the debug information from node 2 and tell it to connect to the first node:
 
 ```bash
-curl --request GET \
-  --url http://127.0.0.1:8081/api/codex/v1/debug/info
+curl -X GET -H 'Accept: text/plain' http://127.0.0.1:8081/api/codex/v1/peerid
 ```
 
-In the JSON response copy the value for `id`, and use it to replace `<PEER ID HERE>` in the following command:
+Use the response to replace `<PEER ID HERE>` in the following command:
 
 ```bash
-curl --request GET \
-  --url http://127.0.0.1:8080/api/codex/v1/connect/<PEER ID HERE>?addrs=/ip4/127.0.0.1/tcp/8071
+curl -X GET http://127.0.0.1:8080/api/codex/v1/connect/<PEER ID HERE>?addrs=/ip4/127.0.0.1/tcp/8071
+```
+
+On Mac, Linux, or MSYS2 you can run it in one command like:
+
+```bash
+curl -X GET http://127.0.0.1:8080/api/codex/v1/connect/$(curl -X GET -H 'Accept: text/plain' http://127.0.0.1:8081/api/codex/v1/peerid)\?addrs=/ip4/127.0.0.1/tcp/8071
 ```
 
 Notice that we are sending the peerId and the multiaddress of node 2 to the `/connect` endpoint of node 1. This provides node 1 all the information it needs to communicate with node 2. The response to this request should be `Successfully connected to peer`.
@@ -110,7 +146,7 @@ We're now ready to upload a file to the network. In this example we'll use node 
 Replace `<FILE PATH>` with the path to the file you want to upload in the following command:
 
 ```bash
- curl -H "content-type: application/octet-stream" -H "Expect: 100-continue" -T "<FILE PATH>" 127.0.0.1:8080/api/codex/v1/data -X POST
+ curl -H "Content-Type: application/octet-stream" -H "Expect: 100-continue" -T "<FILE PATH>" 127.0.0.1:8080/api/codex/v1/data -X POST
 ```
 
 (Hint: if curl is reluctant to show you the response, add `-o <FILENAME>` to write the result to a file.)
@@ -130,50 +166,3 @@ Notice we are connecting to the second node in order to download the file. The C
 ### 7. Verify The Results
 
 If your file is downloaded and identical to the file you uploaded, then this manual test has passed. Rejoice! If on the other hand that didn't happen or you were unable to complete any of these steps, please leave us a message detailing your troubles.
-
-### 8. Offer your storage for sale (optional)
-
-```bash
-curl --location 'http://localhost:8081/api/codex/v1/sales/availability' \
---header 'Content-Type: application/json' \
---data '{
-    "size": "1000000",
-    "duration": "3600",
-    "minPrice": "1000",
-    "maxCollateral": "1"
-}'
-```
-
-This informs your node that you are available to store 1MB of data for a duration of one hour (3600 seconds) at a minimum price of 1,000 tokens, automatically matching any storage requests announced on the network.
-
-### 9. Create storage Request (optional)
-
-```bash
-curl --location 'http://localhost:8080/api/codex/v1/storage/request/<CID>' \
---header 'Content-Type: application/json' \
---data '{
-    "reward": "1024",
-    "duration": "120",
-    "proofProbability": "8"
-    "collateral": "1"
-}'
-```
-
-This creates a storage Request for `<CID>` (that you have to fill in) for
-duration of 2 minutes and with reward of 1024 tokens. It expects hosts to
-provide a storage proof once every 8 periods on average.
-
-It returns Request ID which you can then use to query for the Request's state as follows:
-
-```bash
-curl --location 'http://localhost:8080/api/codex/v1/storage/purchases/<RequestID>'
-```
-
-## Notes
-
-When using the Ganache blockchain, there are some deviations from the expected behavior, mainly linked to how blocks are mined, which affects certain functionalities in the Sales module.
-Therefore, if you are manually testing processes such as payout collection after a request is finished or proof submissions, you need to mine some blocks manually for it to work correctly. You can do this by using the following curl command:
-
-```bash
-$ curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[],"id":67}' 127.0.0.1:8545
-```

--- a/docs/TWOCLIENTTEST.md
+++ b/docs/TWOCLIENTTEST.md
@@ -12,10 +12,10 @@ Make sure you have built the client, and can run it as explained in the [README]
 
 You need to have installed NodeJS and npm in order to spinup a local blockchain node.
 
-Go to directory `vendor/codex-contracts-eth` and run these commands:
+Go to directory `vendor/codex-contracts-eth` and run these two commands:
 ```
-$ npm ci
-$ npm start
+npm ci
+npm start
 ```
 
 This will launch a local Ganache blockchain.
@@ -54,7 +54,7 @@ Run the command :
 curl -X GET http://127.0.0.1:8080/api/codex/v1/debug/info
 ```
 
-This GET request will return the node's debug information. The response JSON should look like:
+This GET request will return the node's debug information. The response will be in JSON and should look like:
 
 ```json
 {
@@ -96,21 +96,21 @@ This GET request will return the node's debug information. The response JSON sho
 
 ### 3. Launch Node #2
 
-Retreive the SPR:
+Retreive the SPR by running:
 ```bash
-curl -H 'Accept: text/plain'  http://127.0.0.1:8080/api/codex/v1/spr
+curl -H "Accept: text/plain" http://127.0.0.1:8080/api/codex/v1/spr
 ```
 
-Replace `<SPR HERE>` in the next command the value returned by the SPR value. Note it include the `spr:` at the beginning.
+Next replace `<SPR HERE>` in the following command with the SPR returned from the previous command. (Note that it should include the `spr:` at the beginning.)
 
 Open a new terminal and run:
 - Mac/Linux: `"build/codex" --data-dir="$(pwd)/Data2" --listen-addrs=/ip4/127.0.0.1/tcp/8071 --api-port=8081 --disc-port=8091 --bootstrap-node=<SPR HERE>`
 - Windows: `"build/codex.exe" --data-dir="Data2" --listen-addrs=/ip4/127.0.0.1/tcp/8071 --api-port=8081 --disc-port=8091 --bootstrap-node=<SPR HERE>`
 
-On Mac, Linux, or MSYS2 you can run it in one command like:
+Alternatively on Mac, Linux, or MSYS2 you can run it in one command like:
 
 ```sh
-"build/codex" --data-dir="$(pwd)/Data2" --listen-addrs=/ip4/127.0.0.1/tcp/8071 --api-port=8081 --disc-port=8091 --bootstrap-node=$(curl -H 'Accept: text/plain'  http://127.0.0.1:8080/api/codex/v1/spr)
+"build/codex" --data-dir="$(pwd)/Data2" --listen-addrs=/ip4/127.0.0.1/tcp/8071 --api-port=8081 --disc-port=8091 --bootstrap-node=$(curl -H "Accept: text/plain" http://127.0.0.1:8080/api/codex/v1/spr)
 ```
 
 Notice we're using a new data-dir, and we've increased each port number by one. This is needed so that the new node won't try to open ports already in use by the first node.
@@ -119,22 +119,24 @@ We're now also including the `bootstrap-node` argument. This allows us to link t
 
 ### 4. Connect The Two
 
-Normally the two will automatically connect. If not you can use the command we've used in step 2 to retrieve the debug information from node 2 and tell it to connect to the first node:
+Normally the two nodes will automatically connect. If they do not automatically connect or you want to manually connect nodes you can use the peerId to connect nodes.
+
+You can get the first node's peer id by running:
 
 ```bash
-curl -X GET -H 'Accept: text/plain' http://127.0.0.1:8081/api/codex/v1/peerid
+curl -X GET -H "Accept: text/plain" http://127.0.0.1:8081/api/codex/v1/peerid
 ```
 
-Use the response to replace `<PEER ID HERE>` in the following command:
+Next replace `<PEER ID HERE>` in the following command with the peerId returned from the previous command:
 
 ```bash
 curl -X GET http://127.0.0.1:8080/api/codex/v1/connect/<PEER ID HERE>?addrs=/ip4/127.0.0.1/tcp/8071
 ```
 
-On Mac, Linux, or MSYS2 you can run it in one command like:
+Alternatively on Mac, Linux, or MSYS2 you can run it in one command like:
 
 ```bash
-curl -X GET http://127.0.0.1:8080/api/codex/v1/connect/$(curl -X GET -H 'Accept: text/plain' http://127.0.0.1:8081/api/codex/v1/peerid)\?addrs=/ip4/127.0.0.1/tcp/8071
+curl -X GET http://127.0.0.1:8080/api/codex/v1/connect/$(curl -X GET -H "Accept: text/plain" http://127.0.0.1:8081/api/codex/v1/peerid)\?addrs=/ip4/127.0.0.1/tcp/8071
 ```
 
 Notice that we are sending the peerId and the multiaddress of node 2 to the `/connect` endpoint of node 1. This provides node 1 all the information it needs to communicate with node 2. The response to this request should be `Successfully connected to peer`.
@@ -143,7 +145,7 @@ Notice that we are sending the peerId and the multiaddress of node 2 to the `/co
 
 We're now ready to upload a file to the network. In this example we'll use node 1 for uploading and node 2 for downloading. But the reverse also works.
 
-Replace `<FILE PATH>` with the path to the file you want to upload in the following command:
+Next replace `<FILE PATH>` with the path to the file you want to upload in the following command:
 
 ```bash
  curl -H "Content-Type: application/octet-stream" -H "Expect: 100-continue" -T "<FILE PATH>" 127.0.0.1:8080/api/codex/v1/data -X POST

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -65,6 +65,22 @@ components:
       description: A timestamp as seconds since unix epoch at which this request expires if the Request does not find requested amount of nodes to host the data.
       default: 10 minutes
 
+    SPR:
+      type: string
+      description: Signed Peer Record (libp2p)
+
+    SPRRead:
+      type: object
+      properties:
+        spr:
+          $ref: "#/components/schemas/SPR"
+
+    PeerIdRead:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/PeerId"
+
     ErasureParameters:
       type: object
       properties:
@@ -106,8 +122,7 @@ components:
           type: string
           description: Path of the data repository where all nodes data are stored
         spr:
-          type: string
-          description: Signed Peer Record to advertise DHT connection information
+          $ref: "#/components/schemas/SPR"
 
     SalesAvailability:
       type: object
@@ -684,6 +699,40 @@ paths:
           description: Purchase not found
         "503":
           description: Purchasing is unavailable
+
+  "/node/spr":
+    get:
+      summary: "Get Node's SPR"
+      operationId: getSPR
+      tags: [ Node ]
+      responses:
+        "200":
+          description: Node's SPR
+          content:
+            plain/text:
+              schema:
+                $ref: "#/components/schemas/SPR"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SPRRead"
+        "503":
+          description: Node SPR not ready, try again later
+
+  "/node/peerid":
+    get:
+      summary: "Get Node's PeerID"
+      operationId: getPeerId
+      tags: [ Node ]
+      responses:
+        "200":
+          description: Node's Peer ID
+          content:
+            plain/text:
+              schema:
+                $ref: "#/components/schemas/PeerId"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PeerIdRead"
 
   "/debug/chronicles/loglevel":
     post:


### PR DESCRIPTION
Adds a text only API endpoint `curl http://127.0.0.1:8080/api/codex/v1/spr` to simplify curl commands.

Question, when `node.discovery.dhtRecord.isSome` is empty what should we do? I followed the debug info and return empty string 204 status code. Though perhaps it should be an error, maybe a 503?

Implements https://github.com/orgs/codex-storage/projects/3/views/9?pane=issue&itemId=57116903 