### PR TITLE
Disable Discv5 bucket and routing table IP limits

### DIFF
--- a/codex/discovery.nim
+++ b/codex/discovery.nim
@@ -16,7 +16,7 @@ import pkg/questionable
 import pkg/questionable/results
 import pkg/stew/shims/net
 import pkg/contractabi/address as ca
-import pkg/codexdht/discv5/protocol as discv5
+import pkg/codexdht/discv5/[routing_table, protocol as discv5]
 
 import ./rng
 import ./errors
@@ -192,6 +192,18 @@ proc new*(
       peerId: PeerId.init(key).expect("Should construct PeerId"))
 
   self.updateAnnounceRecord(announceAddrs)
+
+  # --------------------------------------------------------------------------
+  # FIXME disable IP limits temporarily so we can run our workshop. Re-enable
+  #   and figure out proper solution.
+  let discoveryConfig = DiscoveryConfig(
+    tableIpLimits: TableIpLimits(
+      tableIpLimit: high(uint),
+      bucketIpLimit:high(uint)
+    ),
+    bitsPerHop: DefaultBitsPerHop
+  )
+  # --------------------------------------------------------------------------
 
   self.protocol = newProtocol(
     key,

--- a/codex/discovery.nim
+++ b/codex/discovery.nim
@@ -212,6 +212,7 @@ proc new*(
     record = self.providerRecord.get,
     bootstrapRecords = bootstrapNodes,
     rng = Rng.instance(),
-    providers = ProvidersManager.new(store))
+    providers = ProvidersManager.new(store),
+    config = discoveryConfig)
 
   self


### PR DESCRIPTION
This PR **temporarily** disables per-k-bucket and aggregate routing table IP limits on the discv5 DHT until we figure out how to make those play nice with heavily NATed environments (think room full of people at a Codex workshop).

Follow up issue to handle this issue in a more sensible manner [here](https://github.com/orgs/codex-storage/projects/3/views/9?pane=issue&itemId=58252879).

