### PR TITLE
Announce to DHT only tree and manifest CIDs

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -297,18 +297,18 @@ proc cancelBlocks(b: BlockExcEngine, addrs: seq[BlockAddress]) {.async.} =
 
 proc getAnnouceCids(blocksDelivery: seq[BlockDelivery]): seq[Cid] = 
   var cids = initHashSet[Cid]()
-  # for bd in blocksDelivery:
-  #   if bd.address.leaf:
-  #     # Announce tree CIDs
-  #     if bd.address.treeCid notin cids:
-  #       cids.incl(bd.address.treeCid)
-  #   else:
-  #     # Announce manifest CIDs
-  #     without isM =? bd.address.cid.isManifest, err:
-  #       warn "Unable to determine if cid is manifest"
-  #       continue
-  #     if isM:
-  #       cids.incl(bd.address.cid)
+  for bd in blocksDelivery:
+    if bd.address.leaf:
+      # Announce tree CIDs
+      if bd.address.treeCid notin cids:
+        cids.incl(bd.address.treeCid)
+    else:
+      # Announce manifest CIDs
+      without isM =? bd.address.cid.isManifest, err:
+        warn "Unable to determine if cid is manifest"
+        continue
+      if isM:
+        cids.incl(bd.address.cid)
   return cids.toSeq
 
 proc resolveBlocks*(b: BlockExcEngine, blocksDelivery: seq[BlockDelivery]) {.async.} =

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -299,11 +299,8 @@ proc getAnnouceCids(blocksDelivery: seq[BlockDelivery]): seq[Cid] =
   var cids = initHashSet[Cid]()
   for bd in blocksDelivery:
     if bd.address.leaf:
-      # Announce tree CIDs
-      if bd.address.treeCid notin cids:
-        cids.incl(bd.address.treeCid)
+      cids.incl(bd.address.treeCid)
     else:
-      # Announce manifest CIDs
       without isM =? bd.address.cid.isManifest, err:
         warn "Unable to determine if cid is manifest"
         continue

--- a/tests/codex/blockexchange/engine/testengine.nim
+++ b/tests/codex/blockexchange/engine/testengine.nim
@@ -616,4 +616,3 @@ asyncchecksuite "Task Handler":
     )
 
     await engine.taskHandler(peersCtx[0])
-

--- a/tests/codex/blockexchange/engine/testengine.nim
+++ b/tests/codex/blockexchange/engine/testengine.nim
@@ -389,6 +389,21 @@ asyncchecksuite "NetworkStore engine handlers":
     discard await allFinished(pending)
     await allFuturesThrowing(cancellations.values().toSeq)
 
+# test "resolveBlocks should queue manifest CIDs for discovery":
+#   let
+#     manifest = Manifest.new(
+#       treeCid: Cid.example,
+#       blockSize: 123.NBytes,
+#       datasetSize: 234.NBytes
+#     )
+#   manifestBlk = Block.new(data = manifest.encode().tryGet(), codec = ManifestCodec).tryGet()
+#   blks = @[manifestBlk]
+# await engine.resolveBlocks(blks) #seqblocks
+
+# test "resolveBlocks should queue tree CIDs for discovery":
+
+# test "resolveBlocks should not queue non-manifest non-tree CIDs for discovery":
+
 asyncchecksuite "Task Handler":
   var
     rng: Rng
@@ -570,3 +585,4 @@ asyncchecksuite "Task Handler":
     )
 
     await engine.taskHandler(peersCtx[0])
+

--- a/tests/codex/blockexchange/engine/testengine.nim
+++ b/tests/codex/blockexchange/engine/testengine.nim
@@ -15,6 +15,7 @@ import pkg/codex/chunker
 import pkg/codex/discovery
 import pkg/codex/blocktype
 import pkg/codex/utils/asyncheapqueue
+import pkg/codex/manifest
 
 import ../../../asynctest
 import ../../helpers
@@ -389,20 +390,50 @@ asyncchecksuite "NetworkStore engine handlers":
     discard await allFinished(pending)
     await allFuturesThrowing(cancellations.values().toSeq)
 
-# test "resolveBlocks should queue manifest CIDs for discovery":
-#   let
-#     manifest = Manifest.new(
-#       treeCid: Cid.example,
-#       blockSize: 123.NBytes,
-#       datasetSize: 234.NBytes
-#     )
-#   manifestBlk = Block.new(data = manifest.encode().tryGet(), codec = ManifestCodec).tryGet()
-#   blks = @[manifestBlk]
-# await engine.resolveBlocks(blks) #seqblocks
+  test "resolveBlocks should queue manifest CIDs for discovery":
+    engine.network = BlockExcNetwork(
+      request: BlockExcRequest(sendWantCancellations: NopSendWantCancellationsProc))
 
-# test "resolveBlocks should queue tree CIDs for discovery":
+    let
+      manifest = Manifest.new(
+        treeCid = Cid.example,
+        blockSize = 123.NBytes,
+        datasetSize = 234.NBytes
+      )
 
-# test "resolveBlocks should not queue non-manifest non-tree CIDs for discovery":
+    let manifestBlk = Block.new(data = manifest.encode().tryGet(), codec = ManifestCodec).tryGet()
+    let blks = @[manifestBlk]
+
+    await engine.resolveBlocks(blks)
+
+    check:
+      manifestBlk.cid in engine.discovery.advertiseQueue
+
+  test "resolveBlocks should queue tree CIDs for discovery":
+    engine.network = BlockExcNetwork(
+      request: BlockExcRequest(sendWantCancellations: NopSendWantCancellationsProc))
+
+    let
+      tCid = Cid.example
+      delivery = BlockDelivery(blk: Block.example, address: BlockAddress(leaf: true, treeCid: tCid))
+      
+    await engine.resolveBlocks(@[delivery])
+
+    check:
+      tCid in engine.discovery.advertiseQueue
+
+  test "resolveBlocks should not queue non-manifest non-tree CIDs for discovery":
+    engine.network = BlockExcNetwork(
+      request: BlockExcRequest(sendWantCancellations: NopSendWantCancellationsProc))
+
+    let
+      blkCid = Cid.example
+      delivery = BlockDelivery(blk: Block.example, address: BlockAddress(leaf: false, cid: blkCid))
+      
+    await engine.resolveBlocks(@[delivery])
+
+    check:
+      blkCid notin engine.discovery.advertiseQueue
 
 asyncchecksuite "Task Handler":
   var


### PR DESCRIPTION
Current implementation announces every local block to the DHT.
Only the treeCID and manifestCID are used for discovery.
