### PR TITLE
Use FileSystem datastore instead of SQL datastore in RepoStore

### DIFF
--- a/codex.nim
+++ b/codex.nim
@@ -67,6 +67,9 @@ when isMainModule:
     # permissions are insecure.
     quit QuitFailure
 
+  if not(checkAndCreateDataDir((config.metaDir).string)):
+    quit QuitFailure
+
   trace "Data dir initialized", dir = $config.dataDir
 
   if not(checkAndCreateDataDir((config.dataDir / "repo"))):

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -252,10 +252,12 @@ proc new*(
                 of repoSQLite: Datastore(SQLiteDatastore.new($config.dataDir)
                   .expect("Should create repo SQLite data store!"))
 
+    metadataStore = Datastore(FSDatastore.new($config.metaDir, depth = 5)
+      .expect("Should create repo metadata store!"))
+
     repoStore = RepoStore.new(
       repoDs = repoData,
-      metaDs = SQLiteDatastore.new(config.dataDir / CodexMetaNamespace)
-        .expect("Should create meta data store!"),
+      metaDs = metadataStore,
       quotaMaxBytes = config.storageQuota.uint,
       blockTtl = config.blockTtl)
 

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -62,6 +62,7 @@ const
   codex_enable_log_counter* {.booldefine.} = false
 
   DefaultDataDir* = defaultDataDir()
+  DefaultMetaDataDir* = defaultDataDir() / "metadata"
 
 type
   StartUpCmd* {.pure.} = enum
@@ -124,6 +125,13 @@ type
       defaultValueDesc: $DefaultDataDir
       abbr: "d"
       name: "data-dir" }: OutDir
+
+    metaDir* {.
+      desc: "The directory where codex will store metadata"
+      defaultValue: DefaultMetaDataDir
+      defaultValueDesc: $DefaultMetaDataDir
+      abbr: "md"
+      name: "meta-dir" }: OutDir
 
     listenAddrs* {.
       desc: "Multi Addresses to listen on"


### PR DESCRIPTION
Seen in dist-tests, uploading of a 1000 MB file:
With (current) SQL metadata store: (2 mins, 19 secs)
With (custom test image) FS store: (10 secs)
