### PR TITLE
Advertise manifests and trees

### DIFF
--- a/tests/codex/blockexchange/discovery/testdiscovery.nim
+++ b/tests/codex/blockexchange/discovery/testdiscovery.nim
@@ -50,7 +50,7 @@ asyncchecksuite "Block Advertising and Discovery":
     blockDiscovery = MockDiscovery.new()
     wallet = WalletRef.example
     network = BlockExcNetwork.new(switch)
-    localStore = CacheStore.new(blocks.mapIt( it ))
+    localStore = CacheStore.new(blocks.mapIt(it))
     peerStore = PeerCtxStore.new()
     pendingBlocks = PendingBlocksManager.new()
 
@@ -92,7 +92,7 @@ asyncchecksuite "Block Advertising and Discovery":
 
     blockDiscovery.findBlockProvidersHandler =
       proc(d: MockDiscovery, cid: Cid): Future[seq[SignedPeerRecord]] {.async.} =
-        await engine.resolveBlocks(blocks.filterIt( it.cid == cid ))
+        await engine.resolveBlocks(blocks.filterIt(it.cid == cid))
 
     await allFuturesThrowing(
       allFinished(pendingBlocks))
@@ -148,7 +148,7 @@ asyncchecksuite "Block Advertising and Discovery":
       proc(d: MockDiscovery, cid: Cid): Future[seq[SignedPeerRecord]] =
         check false
 
-    await engine.start() # fire up discovery loop
+    await engine.start()
     engine.pendingBlocks.resolve(blocks.mapIt(BlockDelivery(blk: it, address: it.address)))
 
     await allFuturesThrowing(
@@ -156,23 +156,33 @@ asyncchecksuite "Block Advertising and Discovery":
 
     await engine.stop()
 
-asyncchecksuite "E2E - Multiple Nodes Discovery":
-  let chunker = RandomChunker.new(Rng.instance(), size = 4096, chunkSize = 256)
+proc asBlock(m: Manifest): bt.Block =
+  let mdata = m.encode().tryGet()
+  bt.Block.new(data = mdata, codec = ManifestCodec).tryGet()
 
+asyncchecksuite "E2E - Multiple Nodes Discovery":
   var
     switch: seq[Switch]
     blockexc: seq[NetworkStore]
-    blocks: seq[bt.Block]
+    manifests: seq[Manifest]
+    mBlocks: seq[bt.Block]
+    trees: seq[CodexTree]
 
   setup:
-    while true:
-      let chunk = await chunker.getBytes()
-      if chunk.len <= 0:
-        break
-
-      blocks.add(bt.Block.new(chunk).tryGet())
-
     for _ in 0..<4:
+      let chunker = RandomChunker.new(Rng.instance(), size = 4096, chunkSize = 256)
+      var blocks = newSeq[bt.Block]()
+      while true:
+        let chunk = await chunker.getBytes()
+        if chunk.len <= 0:
+          break
+
+        blocks.add(bt.Block.new(chunk).tryGet())
+      let (manifest, tree) = makeManifestAndTree(blocks).tryGet()
+      manifests.add(manifest)
+      mBlocks.add(manifest.asBlock())
+      trees.add(tree)
+
       let
         s = newStandardSwitch(transportFlags = {ServerFlags.ReuseAddr})
         blockDiscovery = MockDiscovery.new()
@@ -206,9 +216,12 @@ asyncchecksuite "E2E - Multiple Nodes Discovery":
   teardown:
     switch = @[]
     blockexc = @[]
+    manifests = @[]
+    mBlocks = @[]
+    trees = @[]
 
   test "E2E - Should advertise and discover blocks":
-    # Distribute the blocks amongst 1..3
+    # Distribute the manifests and trees amongst 1..3
     # Ask 0 to download everything without connecting him beforehand
 
     var advertised: Table[Cid, SignedPeerRecord]
@@ -225,14 +238,14 @@ asyncchecksuite "E2E - Multiple Nodes Discovery":
       .publishBlockProvideHandler = proc(d: MockDiscovery, cid: Cid): Future[void] {.async.} =
         advertised[cid] = switch[3].peerInfo.signedPeerRecord
 
-    discard blocks[0..5].mapIt(blockexc[1].engine.pendingBlocks.getWantHandle(it.address))
-    await blockexc[1].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, blocks[0..5].mapIt(BlockDelivery(blk: it, address: it.address)))
+    discard blockexc[1].engine.pendingBlocks.getWantHandle(mBlocks[0].cid)
+    await blockexc[1].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, @[BlockDelivery(blk: mBlocks[0], address: BlockAddress(leaf: false, cid: mBlocks[0].cid))])
 
-    discard blocks[4..10].mapIt(blockexc[2].engine.pendingBlocks.getWantHandle(it.address))
-    await blockexc[2].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, blocks[4..10].mapIt(BlockDelivery(blk: it, address: it.address)))
+    discard blockexc[2].engine.pendingBlocks.getWantHandle(mBlocks[1].cid)
+    await blockexc[2].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, @[BlockDelivery(blk: mBlocks[1], address: BlockAddress(leaf: false, cid: mBlocks[1].cid))])
 
-    discard blocks[10..15].mapIt(blockexc[3].engine.pendingBlocks.getWantHandle(it.address))
-    await blockexc[3].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, blocks[10..15].mapIt(BlockDelivery(blk: it, address: it.address)))
+    discard blockexc[3].engine.pendingBlocks.getWantHandle(mBlocks[2].cid)
+    await blockexc[3].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, @[BlockDelivery(blk: mBlocks[2], address: BlockAddress(leaf: false, cid: mBlocks[2].cid))])
 
     MockDiscovery(blockexc[0].engine.discovery.discovery)
       .findBlockProvidersHandler = proc(d: MockDiscovery, cid: Cid):
@@ -241,22 +254,22 @@ asyncchecksuite "E2E - Multiple Nodes Discovery":
           result.add(advertised[cid])
 
     let futs = collect(newSeq):
-      for b in blocks:
-        blockexc[0].engine.requestBlock(b.cid)
+      for m in mBlocks[0..2]:
+        blockexc[0].engine.requestBlock(m.cid)
 
     await allFuturesThrowing(
-      switch.mapIt( it.start() ) &
-      blockexc.mapIt( it.engine.start() )).wait(10.seconds)
+      switch.mapIt(it.start()) &
+      blockexc.mapIt(it.engine.start())).wait(10.seconds)
 
     await allFutures(futs).wait(10.seconds)
 
     await allFuturesThrowing(
-      blockexc.mapIt( it.engine.stop() ) &
-      switch.mapIt( it.stop() )).wait(10.seconds)
+      blockexc.mapIt(it.engine.stop()) &
+      switch.mapIt(it.stop())).wait(10.seconds)
 
   test "E2E - Should advertise and discover blocks with peers already connected":
     # Distribute the blocks amongst 1..3
-    # Ask 0 to download everything without connecting him beforehand
+    # Ask 0 to download everything *WITH* connecting him beforehand
 
     var advertised: Table[Cid, SignedPeerRecord]
 
@@ -272,14 +285,14 @@ asyncchecksuite "E2E - Multiple Nodes Discovery":
       .publishBlockProvideHandler = proc(d: MockDiscovery, cid: Cid): Future[void] {.async.} =
         advertised[cid] = switch[3].peerInfo.signedPeerRecord
 
-    discard blocks[0..5].mapIt(blockexc[1].engine.pendingBlocks.getWantHandle(it.address))
-    await blockexc[1].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, blocks[0..5].mapIt(BlockDelivery(blk: it, address: it.address)))
+    discard blockexc[1].engine.pendingBlocks.getWantHandle(mBlocks[0].cid)
+    await blockexc[1].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, @[BlockDelivery(blk: mBlocks[0], address: BlockAddress(leaf: false, cid: mBlocks[0].cid))])
 
-    discard blocks[4..10].mapIt(blockexc[2].engine.pendingBlocks.getWantHandle(it.address))
-    await blockexc[2].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, blocks[4..10].mapIt(BlockDelivery(blk: it, address: it.address)))
+    discard blockexc[2].engine.pendingBlocks.getWantHandle(mBlocks[1].cid)
+    await blockexc[2].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, @[BlockDelivery(blk: mBlocks[1], address: BlockAddress(leaf: false, cid: mBlocks[1].cid))])
 
-    discard blocks[10..15].mapIt(blockexc[3].engine.pendingBlocks.getWantHandle(it.address))
-    await blockexc[3].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, blocks[10..15].mapIt(BlockDelivery(blk: it, address: it.address)))
+    discard blockexc[3].engine.pendingBlocks.getWantHandle(mBlocks[2].cid)
+    await blockexc[3].engine.blocksDeliveryHandler(switch[0].peerInfo.peerId, @[BlockDelivery(blk: mBlocks[2], address: BlockAddress(leaf: false, cid: mBlocks[2].cid))])
 
     MockDiscovery(blockexc[0].engine.discovery.discovery)
       .findBlockProvidersHandler = proc(d: MockDiscovery, cid: Cid):
@@ -288,14 +301,14 @@ asyncchecksuite "E2E - Multiple Nodes Discovery":
           return @[advertised[cid]]
 
     let
-      futs = blocks.mapIt( blockexc[0].engine.requestBlock( it.cid ) )
+      futs = mBlocks[0..2].mapIt(blockexc[0].engine.requestBlock(it.cid))
 
     await allFuturesThrowing(
-      switch.mapIt( it.start() ) &
-      blockexc.mapIt( it.engine.start() )).wait(10.seconds)
+      switch.mapIt(it.start()) &
+      blockexc.mapIt(it.engine.start())).wait(10.seconds)
 
     await allFutures(futs).wait(10.seconds)
 
     await allFuturesThrowing(
-      blockexc.mapIt( it.engine.stop() ) &
-      switch.mapIt( it.stop() )).wait(10.seconds)
+      blockexc.mapIt(it.engine.stop()) &
+      switch.mapIt(it.stop())).wait(10.seconds)


### PR DESCRIPTION
This updates the advertising loop in the discovery engine to advertise only manifest CIDs and tree CIDs.
Current implementation advertises every block, and does NOT advertise trees.
