### PR TITLE
Bug: Large manifests encoding

### DIFF
--- a/codex/manifest/coders.nim
+++ b/codex/manifest/coders.nim
@@ -66,7 +66,7 @@ proc encode*(manifest: Manifest): ?!seq[byte] =
   var header = initProtoBuffer()
   header.write(1, manifest.treeCid.data.buffer)
   header.write(2, manifest.blockSize.uint32)
-  header.write(3, manifest.datasetSize.uint32)
+  header.write(3, manifest.datasetSize.uint64)
   header.write(4, manifest.codec.uint32)
   header.write(5, manifest.hcodec.uint32)
   header.write(6, manifest.version.uint32)
@@ -75,7 +75,7 @@ proc encode*(manifest: Manifest): ?!seq[byte] =
     erasureInfo.write(1, manifest.ecK.uint32)
     erasureInfo.write(2, manifest.ecM.uint32)
     erasureInfo.write(3, manifest.originalTreeCid.data.buffer)
-    erasureInfo.write(4, manifest.originalDatasetSize.uint32)
+    erasureInfo.write(4, manifest.originalDatasetSize.uint64)
     erasureInfo.write(5, manifest.protectedStrategy.uint32)
 
     if manifest.verifiable:
@@ -106,12 +106,12 @@ proc decode*(_: type Manifest, data: openArray[byte]): ?!Manifest =
     pbVerificationInfo: ProtoBuffer
     treeCidBuf: seq[byte]
     originalTreeCid: seq[byte]
-    datasetSize: uint32
+    datasetSize: uint64
     codec: uint32
     hcodec: uint32
     version: uint32
     blockSize: uint32
-    originalDatasetSize: uint32
+    originalDatasetSize: uint64
     ecK, ecM: uint32
     protectedStrategy: uint32
     verifyRoot: seq[byte]

--- a/tests/codex/testmanifest.nim
+++ b/tests/codex/testmanifest.nim
@@ -57,6 +57,16 @@ checksuite "Manifest":
     check:
       encodeDecode(manifest) == manifest
 
+  test "Should encode/decode large manifest":
+    let large = Manifest.new(
+      treeCid = Cid.example,
+      blockSize = (64 * 1024).NBytes,
+      datasetSize = (5 * 1024).MiBs
+    )
+
+    check:
+      encodeDecode(large) == large
+
   test "Should encode/decode to/from protected manifest":
     check:
       encodeDecode(protectedManifest) == protectedManifest


### PR DESCRIPTION
Something strange is happening to manifests that describe large datasets when they are encoded/decoded into blocks.
The datasetSize parameter never comes out right when the dataset is 5GB or larger.

Traced the issue to: uint32 is used in protobuf-encoding for datasetSize parameters.
5GB in bytes = 5.368.709.120
uint32 max = 4.294.967.295

This PR bumps those to uint64s.
