### PR TITLE
feat: one confirmation for all transactions

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -92,7 +92,7 @@ method requestStorage(market: OnChainMarket, request: StorageRequest){.async.} =
   convertEthersError:
     debug "Requesting storage"
     await market.approveFunds(request.price())
-    await market.contract.requestStorage(request)
+    discard await market.contract.requestStorage(request).confirm(1)
 
 method getRequest(market: OnChainMarket,
                   id: RequestId): Future[?StorageRequest] {.async.} =

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -159,16 +159,16 @@ method fillSlot(market: OnChainMarket,
                 collateral: UInt256) {.async.} =
   convertEthersError:
     await market.approveFunds(collateral)
-    await market.contract.fillSlot(requestId, slotIndex, proof)
+    discard await market.contract.fillSlot(requestId, slotIndex, proof).confirm(1)
 
 method freeSlot*(market: OnChainMarket, slotId: SlotId) {.async.} =
   convertEthersError:
-    await market.contract.freeSlot(slotId)
+    discard await market.contract.freeSlot(slotId).confirm(1)
 
 method withdrawFunds(market: OnChainMarket,
                      requestId: RequestId) {.async.} =
   convertEthersError:
-    await market.contract.withdrawFunds(requestId)
+    discard await market.contract.withdrawFunds(requestId).confirm(1)
 
 method isProofRequired*(market: OnChainMarket,
                         id: SlotId): Future[bool] {.async.} =
@@ -201,13 +201,13 @@ method submitProof*(market: OnChainMarket,
                     id: SlotId,
                     proof: Groth16Proof) {.async.} =
   convertEthersError:
-    await market.contract.submitProof(id, proof)
+    discard await market.contract.submitProof(id, proof).confirm(1)
 
 method markProofAsMissing*(market: OnChainMarket,
                            id: SlotId,
                            period: Period) {.async.} =
   convertEthersError:
-    await market.contract.markProofAsMissing(id, period)
+    discard await market.contract.markProofAsMissing(id, period).confirm(1)
 
 method canProofBeMarkedAsMissing*(
     market: OnChainMarket,
@@ -218,7 +218,7 @@ method canProofBeMarkedAsMissing*(
   let contractWithoutSigner = market.contract.connect(provider)
   let overrides = CallOverrides(blockTag: some BlockTag.pending)
   try:
-    await contractWithoutSigner.markProofAsMissing(id, period, overrides)
+    discard await contractWithoutSigner.markProofAsMissing(id, period, overrides)
     return true
   except EthersError as e:
     trace "Proof cannot be marked as missing", msg = e.msg

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -46,7 +46,7 @@ proc approveFunds(market: OnChainMarket, amount: UInt256) {.async.} =
   convertEthersError:
     let tokenAddress = await market.contract.token()
     let token = Erc20Token.new(tokenAddress, market.signer)
-    discard await token.increaseAllowance(market.contract.address(), amount).confirm(1)
+    discard await token.increaseAllowance(market.contract.address(), amount).confirm(0)
 
 method getZkeyHash*(market: OnChainMarket): Future[?string] {.async.} =
   let config = await market.contract.config()
@@ -92,7 +92,7 @@ method requestStorage(market: OnChainMarket, request: StorageRequest){.async.} =
   convertEthersError:
     debug "Requesting storage"
     await market.approveFunds(request.price())
-    discard await market.contract.requestStorage(request).confirm(1)
+    discard await market.contract.requestStorage(request).confirm(0)
 
 method getRequest(market: OnChainMarket,
                   id: RequestId): Future[?StorageRequest] {.async.} =
@@ -159,16 +159,16 @@ method fillSlot(market: OnChainMarket,
                 collateral: UInt256) {.async.} =
   convertEthersError:
     await market.approveFunds(collateral)
-    discard await market.contract.fillSlot(requestId, slotIndex, proof).confirm(1)
+    discard await market.contract.fillSlot(requestId, slotIndex, proof).confirm(0)
 
 method freeSlot*(market: OnChainMarket, slotId: SlotId) {.async.} =
   convertEthersError:
-    discard await market.contract.freeSlot(slotId).confirm(1)
+    discard await market.contract.freeSlot(slotId).confirm(0)
 
 method withdrawFunds(market: OnChainMarket,
                      requestId: RequestId) {.async.} =
   convertEthersError:
-    discard await market.contract.withdrawFunds(requestId).confirm(1)
+    discard await market.contract.withdrawFunds(requestId).confirm(0)
 
 method isProofRequired*(market: OnChainMarket,
                         id: SlotId): Future[bool] {.async.} =
@@ -201,13 +201,13 @@ method submitProof*(market: OnChainMarket,
                     id: SlotId,
                     proof: Groth16Proof) {.async.} =
   convertEthersError:
-    discard await market.contract.submitProof(id, proof).confirm(1)
+    discard await market.contract.submitProof(id, proof).confirm(0)
 
 method markProofAsMissing*(market: OnChainMarket,
                            id: SlotId,
                            period: Period) {.async.} =
   convertEthersError:
-    discard await market.contract.markProofAsMissing(id, period).confirm(1)
+    discard await market.contract.markProofAsMissing(id, period).confirm(0)
 
 method canProofBeMarkedAsMissing*(
     market: OnChainMarket,

--- a/codex/contracts/marketplace.nim
+++ b/codex/contracts/marketplace.nim
@@ -43,9 +43,9 @@ proc slashPercentage*(marketplace: Marketplace): UInt256 {.contract, view.}
 proc minCollateralThreshold*(marketplace: Marketplace): UInt256 {.contract, view.}
 
 proc requestStorage*(marketplace: Marketplace, request: StorageRequest): ?TransactionResponse {.contract.}
-proc fillSlot*(marketplace: Marketplace, requestId: RequestId, slotIndex: UInt256, proof: Groth16Proof) {.contract.}
-proc withdrawFunds*(marketplace: Marketplace, requestId: RequestId) {.contract.}
-proc freeSlot*(marketplace: Marketplace, id: SlotId) {.contract.}
+proc fillSlot*(marketplace: Marketplace, requestId: RequestId, slotIndex: UInt256, proof: Groth16Proof): ?TransactionResponse {.contract.}
+proc withdrawFunds*(marketplace: Marketplace, requestId: RequestId): ?TransactionResponse {.contract.}
+proc freeSlot*(marketplace: Marketplace, id: SlotId): ?TransactionResponse {.contract.}
 proc getRequest*(marketplace: Marketplace, id: RequestId): StorageRequest {.contract, view.}
 proc getHost*(marketplace: Marketplace, id: SlotId): Address {.contract, view.}
 proc getActiveSlot*(marketplace: Marketplace, id: SlotId): Slot {.contract, view.}
@@ -66,5 +66,5 @@ proc willProofBeRequired*(marketplace: Marketplace, id: SlotId): bool {.contract
 proc getChallenge*(marketplace: Marketplace, id: SlotId): array[32, byte] {.contract, view.}
 proc getPointer*(marketplace: Marketplace, id: SlotId): uint8 {.contract, view.}
 
-proc submitProof*(marketplace: Marketplace, id: SlotId, proof: Groth16Proof) {.contract.}
-proc markProofAsMissing*(marketplace: Marketplace, id: SlotId, period: UInt256) {.contract.}
+proc submitProof*(marketplace: Marketplace, id: SlotId, proof: Groth16Proof): ?TransactionResponse {.contract.}
+proc markProofAsMissing*(marketplace: Marketplace, id: SlotId, period: UInt256): ?TransactionResponse {.contract.}

--- a/codex/contracts/marketplace.nim
+++ b/codex/contracts/marketplace.nim
@@ -42,7 +42,7 @@ proc slashMisses*(marketplace: Marketplace): UInt256 {.contract, view.}
 proc slashPercentage*(marketplace: Marketplace): UInt256 {.contract, view.}
 proc minCollateralThreshold*(marketplace: Marketplace): UInt256 {.contract, view.}
 
-proc requestStorage*(marketplace: Marketplace, request: StorageRequest) {.contract.}
+proc requestStorage*(marketplace: Marketplace, request: StorageRequest): ?TransactionResponse {.contract.}
 proc fillSlot*(marketplace: Marketplace, requestId: RequestId, slotIndex: UInt256, proof: Groth16Proof) {.contract.}
 proc withdrawFunds*(marketplace: Marketplace, requestId: RequestId) {.contract.}
 proc freeSlot*(marketplace: Marketplace, id: SlotId) {.contract.}

--- a/codex/purchasing/states/pending.nim
+++ b/codex/purchasing/states/pending.nim
@@ -14,5 +14,5 @@ method run*(state: PurchasePending, machine: Machine): Future[?State] {.async.} 
   codex_purchases_pending.inc()
   let purchase = Purchase(machine)
   let request = !purchase.request
-  await purchase.market.requestStorage(request)
+  await purchase.market.requestStorage(request).confirm(1)
   return some State(PurchaseSubmitted())

--- a/codex/purchasing/states/pending.nim
+++ b/codex/purchasing/states/pending.nim
@@ -14,5 +14,5 @@ method run*(state: PurchasePending, machine: Machine): Future[?State] {.async.} 
   codex_purchases_pending.inc()
   let purchase = Purchase(machine)
   let request = !purchase.request
-  await purchase.market.requestStorage(request).confirm(1)
+  await purchase.market.requestStorage(request)
   return some State(PurchaseSubmitted())

--- a/tests/contracts/testContracts.nim
+++ b/tests/contracts/testContracts.nim
@@ -42,7 +42,7 @@ ethersuite "Marketplace contracts":
     discard await marketplace.requestStorage(request)
     switchAccount(host)
     discard await token.approve(marketplace.address, request.ask.collateral)
-    await marketplace.fillSlot(request.id, 0.u256, proof)
+    discard await marketplace.fillSlot(request.id, 0.u256, proof)
     slotId = request.slotId(0.u256)
 
   proc waitUntilProofRequired(slotId: SlotId) {.async.} =
@@ -57,12 +57,12 @@ ethersuite "Marketplace contracts":
   proc startContract() {.async.} =
     for slotIndex in 1..<request.ask.slots:
       discard await token.approve(marketplace.address, request.ask.collateral)
-      await marketplace.fillSlot(request.id, slotIndex.u256, proof)
+      discard await marketplace.fillSlot(request.id, slotIndex.u256, proof)
 
   test "accept marketplace proofs":
     switchAccount(host)
     await waitUntilProofRequired(slotId)
-    await marketplace.submitProof(slotId, proof)
+    discard await marketplace.submitProof(slotId, proof)
 
   test "can mark missing proofs":
     switchAccount(host)
@@ -71,7 +71,7 @@ ethersuite "Marketplace contracts":
     let endOfPeriod = periodicity.periodEnd(missingPeriod)
     await ethProvider.advanceTimeTo(endOfPeriod + 1)
     switchAccount(client)
-    await marketplace.markProofAsMissing(slotId, missingPeriod)
+    discard await marketplace.markProofAsMissing(slotId, missingPeriod)
 
   test "can be paid out at the end":
     switchAccount(host)
@@ -80,7 +80,7 @@ ethersuite "Marketplace contracts":
     let requestEnd = await marketplace.requestEnd(request.id)
     await ethProvider.advanceTimeTo(requestEnd.u256 + 1)
     let startBalance = await token.balanceOf(address)
-    await marketplace.freeSlot(slotId)
+    discard await marketplace.freeSlot(slotId)
     let endBalance = await token.balanceOf(address)
     check endBalance == (startBalance + request.ask.duration * request.ask.reward + request.ask.collateral)
 

--- a/tests/contracts/testContracts.nim
+++ b/tests/contracts/testContracts.nim
@@ -39,7 +39,7 @@ ethersuite "Marketplace contracts":
 
     switchAccount(client)
     discard await token.approve(marketplace.address, request.price)
-    await marketplace.requestStorage(request)
+    discard await marketplace.requestStorage(request)
     switchAccount(host)
     discard await token.approve(marketplace.address, request.ask.collateral)
     await marketplace.fillSlot(request.id, 0.u256, proof)

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -241,7 +241,7 @@ ethersuite "On-Chain Market":
         await waitUntilProofRequired(slotId)
         let missingPeriod = periodicity.periodOf(await ethProvider.currentTime())
         await advanceToNextPeriod()
-        await marketplace.markProofAsMissing(slotId, missingPeriod)
+        discard await marketplace.markProofAsMissing(slotId, missingPeriod)
     check receivedIds == @[request.id]
     await subscription.unsubscribe()
 


### PR DESCRIPTION
This is a follow-up fix PR for #793.

The `purchasing` module had an issue because `requestStorage` was called, and a transaction to the blockchain was created. Right away, the state machine transitioned from `pending` to `submitted` state. However, the last PR added a call to the blockchain in the `submitted` state, which requires the transaction to be already mined. This PR ensures that with a requiring confirmation of one block.

After a discussion with Mark, we agreed that we should add confirmation of one block to all transaction creation calls. Mainly because the `Market` abstraction sort of communicates that "when a call to its method finishes, then it is final". Having created a transaction that might not be included in the blockchain is not "final", hence the one confirmation.