### PR TITLE
Bug/sales race

### DIFF
--- a/tests/codex/sales/states/testpreparing.nim
+++ b/tests/codex/sales/states/testpreparing.nim
@@ -1,21 +1,62 @@
-import std/unittest
+import pkg/chronos
 import pkg/questionable
+import pkg/datastore
+import pkg/stew/byteutils
 import pkg/codex/contracts/requests
 import pkg/codex/sales/states/preparing
 import pkg/codex/sales/states/downloading
 import pkg/codex/sales/states/cancelled
 import pkg/codex/sales/states/failed
 import pkg/codex/sales/states/filled
+import pkg/codex/sales/states/ignored
+import pkg/codex/sales/states/errored
+import pkg/codex/sales/salesagent
+import pkg/codex/sales/salescontext
+import pkg/codex/sales/reservations
+import pkg/codex/stores/repostore
+import ../../../asynctest
+import ../../helpers
 import ../../examples
+import ../../helpers/mockmarket
+import ../../helpers/mockclock
 
-suite "sales state 'preparing'":
-
+asyncchecksuite "sales state 'preparing'":
   let request = StorageRequest.example
   let slotIndex = (request.ask.slots div 2).u256
+  let market = MockMarket.new()
+  let clock = MockClock.new()
+  var agent: SalesAgent
   var state: SalePreparing
+  var repo: RepoStore
+  var availability: Availability
+  var context: SalesContext
 
-  setup:
+  setup:    
+    availability = Availability(
+      totalSize: request.ask.slotSize + 100.u256,
+      freeSize: request.ask.slotSize + 100.u256,
+      duration: request.ask.duration + 60.u256,
+      minPrice: request.ask.pricePerSlot - 10.u256,
+      maxCollateral: request.ask.collateral + 400.u256
+    )
+    let repoDs = SQLiteDatastore.new(Memory).tryGet()
+    let metaDs = SQLiteDatastore.new(Memory).tryGet()
+    repo = RepoStore.new(repoDs, metaDs)
+    await repo.start()
+
     state = SalePreparing.new()
+    context = SalesContext(
+      market: market,
+      clock: clock
+    )
+    context.reservations = Reservations.new(repo)
+    agent = newSalesAgent(context,
+                          request.id,
+                          slotIndex,
+                          request.some)
+
+  teardown:
+    await repo.stop()
 
   test "switches to cancelled state when request expires":
     let next = state.onCancelled(request)
@@ -28,3 +69,40 @@ suite "sales state 'preparing'":
   test "switches to filled state when slot is filled":
     let next = state.onSlotFilled(request.id, slotIndex)
     check !next of SaleFilled
+
+  proc createAvailability() =
+    let a = waitFor context.reservations.createAvailability(
+      availability.totalSize,
+      availability.duration,
+      availability.minPrice,
+      availability.maxCollateral
+    )
+    availability = a.get
+
+  test "run switches to ignored when no availability":
+    let next = await state.run(agent)
+    check !next of SaleIgnored
+  
+  test "run switches to downloading when reserved":
+    createAvailability()
+    let next = await state.run(agent)
+    check !next of SaleDownloading
+
+  test "run switches to errored when reserve failed":
+    createAvailability()
+    state.doThing = proc(): Future[void] {.async, gcsafe.} =
+      # Mess up availability, causes createReservation to fail:
+      (await repo.metaDs.put(availability.id.key.tryGet(), "A!".toBytes())).tryGet()
+
+    let next = await state.run(agent)
+    check !next of SaleErrored
+
+  test "run switches to ignored when reserve fails with BytesOutOfBounds":
+    createAvailability()
+    state.doThing = proc(): Future[void] {.async, gcsafe.} =
+      # Oops we don't have any free bytes after all.
+      availability.freeSize = 0.u256
+      (await repo.metaDs.put(availability.id.key.tryGet(), availability.toJson.toBytes)).tryGet()
+
+    let next = await state.run(agent)
+    check !next of SaleIgnored

--- a/tests/codex/sales/states/testpreparing.nim
+++ b/tests/codex/sales/states/testpreparing.nim
@@ -1,6 +1,7 @@
 import std/unittest
 import pkg/questionable
 import pkg/codex/contracts/requests
+import pkg/codex/sales/states/preparing
 import pkg/codex/sales/states/downloading
 import pkg/codex/sales/states/cancelled
 import pkg/codex/sales/states/failed

--- a/tests/codex/sales/teststates.nim
+++ b/tests/codex/sales/teststates.nim
@@ -6,5 +6,9 @@ import ./states/testinitialproving
 import ./states/testfilled
 import ./states/testproving
 import ./states/testsimulatedproving
+import ./states/testcancelled
+import ./states/testerrored
+import ./states/testignored
+import ./states/testpreparing
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
I need help with this one. Please look.

OK, I'll explain.
`preparing.nim` does a `reservations.findAvailability` followed by a `reservations.createReservation`.
It assumes that if availability was found, then the reservation can be created. Unfortunately, both of these are async functions with a descent call-stack. So, plenty of time for interruptions. Additionally, we start 3 workers. These workers pop items from the slot queue and fire up a state machine for each. So, if we push 3 or more items to the queue at once, we can get:

(1) findAvailability -> query -> lots of free space
(2) findAvailability -> query -> lots of free space
(3) findAvailability -> query -> lots of free space
(1) createReservation -> put -> no more free space
(2) createReservation -> put -> BytesOutOfBoundsError `reservations.nim:391` -> transit to Errored state -> test failure
This occurs about 5% to 10% of the time on my machine while using leveldb. It's possible to reproduce with the sqlite backend by strategically placing a sleep.

This issue has always been there. The switch to LevelDB revealed it. The solution is: You can never assume `createReservation` will succeed until afterwards. There's always a chance it will be interrupted at the lowest point in the call-stack.

So the fix is that one if-statement I added to `preparing.nim`. My major issue with this PR is the test code. Because we don't have any convenient way to mock or stub anything, I basically once again had to bootstrap half of Codex in the test in order to even get `preparing`'s run method to run. After that, I realized there was no way to make the availability check pass while making the createReservation fail in the desired way. If we could somehow mock these out with objects we could control from the test, this would have been a 5-minute fix. I decided to add that horrible production-code hook, just so I could get this covered and in a state where I could present it to you. Now I hope you have a better idea for how to test this.
