### PR TITLE
Disables testsales.nim

### DIFF
--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -21,6 +21,11 @@ import ../helpers/always
 import ../examples
 import ./helpers/periods
 
+# TODO:
+# This test file is disabled while the race-condition in
+# preparing.nim is being solved.
+# https://github.com/codex-storage/nim-codex/pull/816
+
 asyncchecksuite "Sales - start":
   let
     proof = Groth16Proof.example

--- a/tests/codex/testsales.nim
+++ b/tests/codex/testsales.nim
@@ -1,4 +1,9 @@
-import ./sales/testsales
+# TODO:
+# This test file is disabled while the race-condition in
+# preparing.nim is being solved.
+# https://github.com/codex-storage/nim-codex/pull/816
+# import ./sales/testsales
+
 import ./sales/teststates
 import ./sales/testreservations
 import ./sales/testslotqueue


### PR DESCRIPTION
This test file is disabled while the race-condition in preparing.nim is being solved.
https://github.com/codex-storage/nim-codex/pull/816
