### PR TITLE
Add Release workflow

### DIFF
--- a/.github/actions/nimbus-build-system/action.yml
+++ b/.github/actions/nimbus-build-system/action.yml
@@ -12,14 +12,23 @@ inputs:
   nim_version:
     description: "Nim version"
     default: "version-1-6"
+  rust_version:
+    description: "Rust version"
+    default: "1.78.0"
   shell:
     description: "Shell to run commands in"
     default: "bash --noprofile --norc -e -o pipefail"
 runs:
   using: "composite"
   steps:
-    - name: APT (Linux amd64)
-      if: inputs.os == 'linux' && inputs.cpu == 'amd64'
+    - name: Rust (Linux)
+      if: inputs.os == 'linux'
+      shell: ${{ inputs.shell }} {0}
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --default-toolchain=${rust_version} -y
+
+    - name: APT (Linux amd64/arm64)
+      if: inputs.os == 'linux' && (inputs.cpu == 'amd64' || inputs.cpu == 'arm64')
       shell: ${{ inputs.shell }} {0}
       run: |
         sudo apt-fast update -qq
@@ -77,15 +86,15 @@ runs:
           printf "'%s'" "$quoted"
         }
 
-        if [[ '${{ inputs.cpu }}' == 'amd64' ]]; then
-          PLATFORM=x64
-        else
-          PLATFORM=x86
-        fi
+        case '${{ inputs.cpu }}' in
+          'amd64') PLATFORM=x64 ;;
+          'arm64') PLATFORM=x64 ;;
+          'i386')  PLATFORM=x86 ;;
+        esac
         echo "PLATFORM=${PLATFORM}" >> ${GITHUB_ENV}
 
-        # Stack usage on Linux amd64
-        if [[ '${{ inputs.os }}' == 'linux' && '${{ inputs.cpu }}' == 'amd64' ]]; then
+        # Stack usage on Linux amd64/arm64
+        if [[ '${{ inputs.os }}' == 'linux' && ('${{ inputs.cpu }}' == 'amd64' || '${{ inputs.cpu }}' == 'arm64')]]; then
           NIMFLAGS="${NIMFLAGS} -d:limitStackUsage"
           echo "NIMFLAGS=${NIMFLAGS}" >> $GITHUB_ENV
         fi
@@ -139,15 +148,9 @@ runs:
         # Use all available CPUs for build process
         ncpu=""
         case '${{ inputs.os }}' in
-        'linux')
-          ncpu=$(nproc)
-          ;;
-        'macos')
-          ncpu=$(sysctl -n hw.ncpu)
-          ;;
-        'windows')
-          ncpu=${NUMBER_OF_PROCESSORS}
-          ;;
+        'linux')   ncpu=$(nproc)                ;;
+        'macos')   ncpu=$(sysctl -n hw.ncpu)    ;;
+        'windows') ncpu=${NUMBER_OF_PROCESSORS} ;;
         esac
         [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
         echo "ncpu=${ncpu}" >> ${GITHUB_ENV}
@@ -170,4 +173,3 @@ runs:
         make -j${ncpu} CI_CACHE=NimBinaries ARCH_OVERRIDE=${PLATFORM} QUICK_AND_DIRTY_COMPILER=1 update
         echo
         ./env.sh nim --version
-

--- a/.github/actions/nimbus-build-system/action.yml
+++ b/.github/actions/nimbus-build-system/action.yml
@@ -86,12 +86,7 @@ runs:
           printf "'%s'" "$quoted"
         }
 
-        case '${{ inputs.cpu }}' in
-          'amd64') PLATFORM=x64 ;;
-          'arm64') PLATFORM=x64 ;;
-          'i386')  PLATFORM=x86 ;;
-        esac
-        echo "PLATFORM=${PLATFORM}" >> ${GITHUB_ENV}
+        [[ '${{ inputs.cpu }}' == 'i386' ]] && echo "ARCH_OVERRIDE=ARCH_OVERRIDE=x86" >> ${GITHUB_ENV}
 
         # Stack usage on Linux amd64/arm64
         if [[ '${{ inputs.os }}' == 'linux' && ('${{ inputs.cpu }}' == 'amd64' || '${{ inputs.cpu }}' == 'arm64')]]; then
@@ -170,6 +165,6 @@ runs:
     - name: Build Nim and Codex dependencies
       shell: ${{ inputs.shell }} {0}
       run: |
-        make -j${ncpu} CI_CACHE=NimBinaries ARCH_OVERRIDE=${PLATFORM} QUICK_AND_DIRTY_COMPILER=1 update
+        make -j${ncpu} CI_CACHE=NimBinaries ${ARCH_OVERRIDE} QUICK_AND_DIRTY_COMPILER=1 update
         echo
         ./env.sh nim --version

--- a/.github/actions/nimbus-build-system/action.yml
+++ b/.github/actions/nimbus-build-system/action.yml
@@ -25,7 +25,7 @@ runs:
       if: inputs.os == 'linux'
       shell: ${{ inputs.shell }} {0}
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --default-toolchain=${rust_version} -y
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --default-toolchain=${{ inputs.rust_version }} -y
 
     - name: APT (Linux amd64/arm64)
       if: inputs.os == 'linux' && (inputs.cpu == 'amd64' || inputs.cpu == 'arm64')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,9 @@ jobs:
           merge-multiple: true
           path: /tmp/release
 
-      - name: Release - Archive and checksum
+      - name: Release - Compress and checksum
         run: |
           cd /tmp/release
-          # Archive
           prepare() {
             # Checksum
             arc="${1}"
@@ -123,6 +122,7 @@ jobs:
               done
             fi
           }
+          # Compress and prepare
           for file in *; do
             if [[ "${file}" == *".exe"* ]]; then
               arc="${file%.*}.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
   nim_version: v1.6.14
   rust_version: 1.78.0
   binary_base: codex
-  upload_to_codex: true
+  upload_to_codex: false
 
 jobs:
   # Matrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,145 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+env:
+  cache_nonce: 0 # Allows for easily busting actions/cache caches
+  nim_version: v1.6.14
+  rust_version: 1.78.0
+  binary_base: codex
+  upload_to_codex: true
+
+jobs:
+  # Matrix
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+    - name: Compute matrix
+      id: matrix
+      uses: fabiocaccamo/create-matrix-action@v4
+      with:
+        matrix: |
+          os {linux},   cpu {amd64}, builder {ubuntu-22.04},                   nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {linux},   cpu {arm64}, builder {buildjet-4vcpu-ubuntu-2204-arm}, nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {macos},   cpu {amd64}, builder {macos-13},                       nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {macos},   cpu {arm64}, builder {macos-14},                       nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {windows}, cpu {amd64}, builder {windows-latest},                 nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {msys2}
+
+  # Build
+  build:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{fromJson(needs.matrix.outputs.matrix)}}
+
+    defaults:
+      run:
+        shell: ${{ matrix.shell }} {0}
+
+    name: ${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.nim_version }}
+    runs-on: ${{ matrix.builder }}
+    timeout-minutes: 80
+    steps:
+      - name: Release - Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Release - Setup Nimbus Build System
+        uses: ./.github/actions/nimbus-build-system
+        with:
+          os: ${{ matrix.os }}
+          cpu: ${{ matrix.cpu }}
+          shell: ${{ matrix.shell }}
+          nim_version: ${{ matrix.nim_version }}
+          rust_version: ${{ matrix.rust_version }}
+
+      - name: Release - Compute binary name
+        run: |
+          case ${{ matrix.os }} in
+            linux*)   os_name="linux"   ;;
+            macos*)   os_name="darwin"  ;;
+            windows*) os_name="windows" ;;
+          esac
+          binary="${{ env.binary_base }}-${{ github.ref_name }}-${os_name}-${{ matrix.cpu }}"
+          [[ ${os_name} == "windows" ]] && binary="${binary}.exe"
+          echo "binary=${binary}" >>$GITHUB_ENV
+
+      - name: Release - Build
+        run: |
+          make NIMFLAGS="--out:${{ env.binary }}"
+          
+      - name: Release - Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ env.binary }}
+          path: ${{ env.binary }}
+          retention-days: 1
+
+  # Release
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: success() || failure()
+    steps:
+      - name: Release - Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release*
+          merge-multiple: true
+          path: /tmp/release
+
+      - name: Release - Archive and checksum
+        run: |
+          cd /tmp/release
+          # Archive
+          prepare() {
+            # Checksum
+            arc="${1}"
+            sha256sum "${arc}" >"${arc}.sha256"
+
+            # Upload to Codex
+            if [[ "${{ env.upload_to_codex }}" == "true" ]]; then
+              codex_endpoints="${{ secrets.CODEX_ENDPOINTS }}"
+              codex_username="${{ secrets.CODEX_USERNAME }}"
+              codex_password="${{ secrets.CODEX_PASSWORD }}"
+
+              for endpoint in ${codex_endpoints}; do
+                echo "::add-mask::${endpoint}"
+                cid=$(curl -X POST \
+                  "${endpoint}/api/codex/v1/data" \
+                  -u "${codex_username}":"${codex_password}" \
+                  -H "content-type: application/octet-stream" \
+                  -T "${arc}")
+
+                echo "${cid}" >"${arc}.cid"
+              done
+            fi
+          }
+          for file in *; do
+            if [[ "${file}" == *".exe"* ]]; then
+              arc="${file%.*}.zip"
+              zip "${arc}" "${file}"
+              rm -f "${file}"
+              prepare "${arc}"
+            else
+              arc="${file}.tar.gz"
+              tar cfz "${arc}" "${file}"
+              rm -f "${file}"
+              prepare "${arc}"
+            fi
+          done
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            /tmp/release/*
+          make_latest: true

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -34,9 +34,6 @@ On a bare bones installation of Debian (or a distribution derived from Debian, s
 
 ```shell
 apt-get update && apt-get install build-essential cmake curl git rustc cargo
-
-# curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --default-toolchain=1.76.0 -y
-# . "$HOME/.cargo/env"
 ```
 
 Non-Debian distributions have different package managers: `apk`, `dnf`, `pacman`, `rpm`, `yum`, etc.
@@ -45,6 +42,13 @@ For example, on a bare bones installation of Fedora, run
 
 ```shell
 dnf install @development-tools cmake gcc-c++ rust cargo
+```
+
+In case your distribution does not provide required Rust version, we may install it using [rustup](https://www.rust-lang.org/tools/install)
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --default-toolchain=1.76.0 -y
+
+. "$HOME/.cargo/env"
 ```
 
 ### macOS

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -24,7 +24,7 @@ Other approaches may be viable. On macOS, some users may prefer [MacPorts](https
 
 ### Rust
 
-The current implementation of Codex's zero-knowledge proving circuit requires the installation of rust v1.74.0 or greater. Be sure to install it for your OS and add it to your terminal's path such that the command `cargo --version` gives a compatible version.
+The current implementation of Codex's zero-knowledge proving circuit requires the installation of rust v1.76.0 or greater. Be sure to install it for your OS and add it to your terminal's path such that the command `cargo --version` gives a compatible version.
 
 ### Linux
 
@@ -34,6 +34,9 @@ On a bare bones installation of Debian (or a distribution derived from Debian, s
 
 ```shell
 apt-get update && apt-get install build-essential cmake curl git rustc cargo
+
+# curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --default-toolchain=1.76.0 -y
+# . "$HOME/.cargo/env"
 ```
 
 Non-Debian distributions have different package managers: `apk`, `dnf`, `pacman`, `rpm`, `yum`, etc.


### PR DESCRIPTION
PR adds a simple release workflow which will build binaries and attach them to the release
- Update Rust requirements in the Building guide
- It was required to adjust composite action [nimbus-build-system](https://github.com/codex-storage/nim-codex/tree/master/.github/actions/nimbus-build-system) to add Linux arm64 support
- In a composite action we also install specific Rust version, because BuildJet one is out of date
- Small refactoring of the composite action to make code more readable
- Release workflow added
   - Use all free available architectures on GitHub Actions
   - For Linux ARM use BuildJet
   - Include version in the binaries names
   - Pack binaries to minimize the size
   - Experimenting with the uploading binaries to the Codex Testnet nodes

> **Note:** Window arm64 runners will be available on GitHub for open source projects [by the end of the year](https://github.blog/changelog/2024-06-03-actions-arm-based-linux-and-windows-runners-are-now-in-public-beta/).

```shell
./codex-v0.0.1-darwin-arm64 --version
Codex version:  v0.0.1
Codex revision: 60e3e00
Nim Compiler Version 1.6.14 [MacOSX: arm64]
```

<details>
<summary>screenshots</summary>

**Workflow execution and timings**
<img width="1490" alt="Screenshot 2024-06-04 at 19 35 45" src="https://github.com/codex-storage/nim-codex/assets/20563034/3572b841-30f4-4666-8e53-c59c2a69a9e3">

**Artifacts**
<img width="1232" alt="Screenshot 2024-06-04 at 19 36 52" src="https://github.com/codex-storage/nim-codex/assets/20563034/dac56809-d343-496f-bb93-be488ebc4cde">
</details>

Closes #749