### PR TITLE
Sets int64 formats for byte-counting integers in openapi spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -289,6 +289,7 @@ components:
           description: "Root hash of the content"
         originalBytes:
           type: integer
+          format: int64
           description: "Length of original content in bytes"
         blockSize:
           type: integer
@@ -303,14 +304,18 @@ components:
         totalBlocks:
           description: "Number of blocks stored by the node"
           type: integer
+          format: int64
         quotaMaxBytes:
           type: integer
+          format: int64
           description: "Maximum storage space used by the node"
         quotaUsedBytes:
           type: integer
+          format: int64
           description: "Amount of storage space currently in use"
         quotaReservedBytes:
           type: integer
+          format: int64
           description: "Amount of storage space reserved"
 
 servers:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -289,7 +289,7 @@ components:
           description: "Root hash of the content"
         originalBytes:
           type: integer
-          format: int64
+          format: uint64
           description: "Length of original content in bytes"
         blockSize:
           type: integer
@@ -304,18 +304,18 @@ components:
         totalBlocks:
           description: "Number of blocks stored by the node"
           type: integer
-          format: int64
+          format: uint64
         quotaMaxBytes:
           type: integer
-          format: int64
+          format: uint64
           description: "Maximum storage space used by the node"
         quotaUsedBytes:
           type: integer
-          format: int64
+          format: uint64
           description: "Amount of storage space currently in use"
         quotaReservedBytes:
           type: integer
-          format: int64
+          format: uint64
           description: "Amount of storage space reserved"
 
 servers:


### PR DESCRIPTION
JSON deserialize fails:
OpenAPI spec defines int32s, but values exceed int32.max.

This fix: Sets spec to int64s wherever we are counting bytes.
