### PR TITLE
Make CI build against branch HEAD instead of merge

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Nimbus Build System
         uses: ./.github/actions/nimbus-build-system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Nimbus Build System
         uses: ./.github/actions/nimbus-build-system


### PR DESCRIPTION
Currently, our CI will build branches against a PR's "merge" commit, which is a commit that previews the merge of the current branch against master. This can result in very surprising behavior, and I'd argue it's not what we typically want.

This PR modifies the CI flow so that it uses HEAD instead.