### PR TITLE
Allow compiler version to be pinned consistently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
-  nim_version: v1.6.14
+  nim_version: pinned
 
 
 concurrency:

--- a/.github/workflows/nim-matrix.yml
+++ b/.github/workflows/nim-matrix.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
-  nim_version: pinned, v1.6.14, v1.6.16, v1.6.18
+  nim_version: pinned, v1.6.16, v1.6.18
 
 jobs:
   matrix:

--- a/.github/workflows/nim-matrix.yml
+++ b/.github/workflows/nim-matrix.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   cache_nonce: 0 # Allows for easily busting actions/cache caches
-  nim_version: v1.6.14, v1.6.16, v1.6.18
+  nim_version: pinned, v1.6.14, v1.6.16, v1.6.18
 
 jobs:
   matrix:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 # If NIM_COMMIT is set to "nimbusbuild", this will use the
 # version pinned by nimbus-build-system.
-PINNED_NIM_VERSION := v1.6.18
+PINNED_NIM_VERSION := v1.6.14
 
 ifeq ($(NIM_COMMIT),)
 NIM_COMMIT := $(PINNED_NIM_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,30 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
+# This is the Nim version used locally and in regular CI builds.
+# Can be a specific version tag, a branch name, or a commit hash.
+# Can be overridden by setting the NIM_COMMIT environment variable
+# before calling make.
+#
+# For readability in CI, if NIM_COMMIT is set to "pinned",
+# this will also default to the version pinned here.
+#
+# If NIM_COMMIT is set to "nimbusbuild", this will use the
+# version pinned by nimbus-build-system.
+PINNED_NIM_VERSION := v1.6.18
+
+ifeq ($(NIM_COMMIT),)
+NIM_COMMIT := $(PINNED_NIM_VERSION)
+else ifeq ($(NIM_COMMIT),pinned)
+NIM_COMMIT := $(PINNED_NIM_VERSION)
+endif
+
+ifeq ($(NIM_COMMIT),nimbusbuild)
+undefine NIM_COMMIT
+else
+export NIM_COMMIT
+endif
+
 SHELL := bash # the shell used internally by Make
 
 # used inside the included makefiles


### PR DESCRIPTION
This PR introduces the ability to pin a compiler version (major or minor) so that we get consistent builds locally, in docker, and in CI.

The compiler version can be overridden by setting the `NIM_COMMIT` env variable as before to either a compiler version, branch, or commit hash, but we also introduce the following special semantics for `NIM_COMMIT`:

* if unset, uses the pinned version;
* if set to `pinned`, uses the pinned version (so that CI can specify it wants the pinned version in a matrix);
* if set to `nimbusbuild`, uses the version defined by the nimbus-build-system.

In case you need more convincing, the original reasoning for doing this [can be found here](https://hackmd.io/2dp6Q2tmQzWoKN-dIPckTQ).