### PR TITLE
config flag to enable CORS response headers for data downloads

### DIFF
--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -312,7 +312,7 @@ proc new*(
       taskpool = taskpool)
 
     restServer = RestServerRef.new(
-      codexNode.initRestApi(config, repoStore),
+      codexNode.initRestApi(config, repoStore, config.apiCorsAllowedOrigin),
       initTAddress(config.apiBindAddress , config.apiPort),
       bufferSize = (1024 * 64),
       maxRequestBodySize = int.high)

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -190,6 +190,12 @@ type
       name: "api-port"
       abbr: "p" }: Port
 
+    apiCorsAllowedOrigin* {.
+      desc: "The REST Api CORS allowed origin for downloading data. '*' will allow all origins, '' will allow none.",
+      defaultValue: string.none
+      defaultValueDesc: "Disallow all cross origin requests to download data"
+      name: "api-cors-origin" }: Option[string]
+
     repoKind* {.
       desc: "Backend for main repo store (fs, sqlite, leveldb)"
       defaultValueDesc: "fs"


### PR DESCRIPTION
This is needed when downloading data from a browser, eg the [ethcc-demo](https://github.com/codex-storage/ethcc-demo)