### PR TITLE
Fix StoreStream so it doesn't return parity bytes 

### DIFF
--- a/codex/manifest/manifest.nim
+++ b/codex/manifest/manifest.nim
@@ -135,13 +135,6 @@ func isManifest*(mc: MultiCodec): ?!bool =
 # Various sizes and verification
 ############################################################
 
-func bytes*(self: Manifest, pad = true): NBytes =
-  ## Compute how many bytes corresponding StoreStream(Manifest, pad) will return
-  if pad or self.protected:
-    self.blocksCount.NBytes * self.blockSize
-  else:
-    self.datasetSize
-
 func rounded*(self: Manifest): int =
   ## Number of data blocks in *protected* manifest including padding at the end
   roundUp(self.originalBlocksCount, self.ecK)

--- a/tests/codex/teststorestream.nim
+++ b/tests/codex/teststorestream.nim
@@ -9,6 +9,7 @@ import pkg/codex/[
   blocktype as bt]
 
 import ../asynctest
+import ./examples
 import ./helpers
 
 asyncchecksuite "StoreStream":
@@ -111,7 +112,7 @@ suite "StoreStream - Size Tests":
 
   test "Should return dataset size as stream size":
     let manifest = Manifest.new(
-      treeCid = emptyCid(CIDv1, Sha256HashCodec, BlockCodec).get,
+      treeCid = Cid.example,
       datasetSize = 80.NBytes,
       blockSize = 10.NBytes
     )
@@ -121,10 +122,8 @@ suite "StoreStream - Size Tests":
     check stream.size == 80
 
   test "Should not count parity/padding bytes as part of stream size":
-    let mockCid = emptyCid(CIDv1, Sha256HashCodec, BlockCodec).get
-
     let protectedManifest = Manifest.new(
-      treeCid = mockCid,
+      treeCid = Cid.example,
       datasetSize = 120.NBytes, # size including parity bytes
       blockSize = 10.NBytes,
       version = CIDv1,
@@ -132,7 +131,7 @@ suite "StoreStream - Size Tests":
       codec = BlockCodec,
       ecK = 2,
       ecM = 1,
-      originalTreeCid = mockCid,
+      originalTreeCid = Cid.example,
       originalDatasetSize = 80.NBytes, # size without parity bytes
       strategy = StrategyType.SteppedStrategy
     )


### PR DESCRIPTION
This PR fixes `StoreStream` so it doesn't return parity bytes when one attempts to download a file by the CID of a protected of verifiable manifest. It also drops the `pad` option which was not used anywhere.