### PR TITLE
Add verify_circuit=true to the releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
   nim_version: v1.6.14
   rust_version: 1.78.0
   binary_base: codex
+  nim_flags: '-d:verify_circuit=true'
   upload_to_codex: false
 
 jobs:
@@ -74,7 +75,7 @@ jobs:
 
       - name: Release - Build
         run: |
-          make NIMFLAGS="--out:${{ env.binary }}"
+          make NIMFLAGS="--out:${{ env.binary }} ${{ env.nim_flags }}"
           
       - name: Release - Upload binaries
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
As we discussed with @benbierens and @gmega, it make sense to add `-d:verify_circuit=true` to the releases
> This way we can check if proofs are invalid when they are created, or whether the validation fails on-chain

This is a quick PR to adjust release workflow for that.