### PR TITLE
[BUG] prevent node crashing with `not val.isNil`

### DIFF
--- a/codex/node.nim
+++ b/codex/node.nim
@@ -257,7 +257,10 @@ proc streamEntireDataset(
             leoDecoderProvider,
             self.taskpool)
         without _ =? (await erasure.decode(manifest)), error:
-          trace "Unable to erasure decode manifest", manifestCid, exc = error.msg
+          error "Unable to erasure decode manifest", manifestCid, exc = error.msg
+          return failure(error)
+
+        return success()
       # --------------------------------------------------------------------------
       # FIXME this is a HACK so that the node does not crash during the workshop.
       #   We should NOT catch Defect.


### PR DESCRIPTION
Node was crashing with:

```
TRC 2024-06-26 12:38:07.334+10:00 Unable to erasure decode manifest          topics="codex node" tid=25906173 manifestCid=zDv*Zkg5qb exc="Original tree root differs from the tree root computed out of recovered data"

ERR 2024-06-26 12:38:07.334+10:00 Unhandled exception in async proc, aborting topics="codex" tid=25906173 msg="/Users/egonat/repos/codex-storage/nim-codex/vendor/nimbus-build-system/vendor/Nim/lib/pure/options.nim(133, 5) `not val.isNil` "
```