### PR TITLE
Workaround for SIGSEGV failures when using `Iter[Natural]`

### DIFF
--- a/tests/codex/utils/testasynciter.nim
+++ b/tests/codex/utils/testasynciter.nim
@@ -158,3 +158,21 @@ asyncchecksuite "Test AsyncIter":
     check:
       collected == @["0", "1"]
       iter2.finished
+
+  test "Should not crash with range type":
+    let
+      iter1 = AsyncIter[Natural].new(0.Natural..<5.Natural).delayBy(10.millis)
+      iter2 = await filter[Natural](iter1,
+        proc (i: Natural): Future[bool] {.async.} =
+          (i mod 2) == 1
+      )
+
+    var collected: seq[Natural]
+
+    for fut in iter2:
+      collected.add(await fut)
+
+    check:
+      collected == @[Natural 1, 3]
+
+    GC_fullCollect()

--- a/tests/codex/utils/testiter.nim
+++ b/tests/codex/utils/testiter.nim
@@ -127,3 +127,13 @@ checksuite "Test Iter":
     check:
       collected == @["0", "1", "2"]
       iter2.finished
+
+  test "Should not crash with range type":
+    let
+      iter = Iter.new(0.Natural..<5.Natural)
+        .filter((i: Natural) => (i mod 2) == 1)
+
+    check:
+      iter.toSeq() == @[Natural 1, 3]
+
+    GC_fullCollect()


### PR DESCRIPTION
Same issue is not happening when using `AsyncIter[Natural]`, however I've added a test case to `testasynciter.nim` anyway, to ensure that it won't start happening in the future.