### PR TITLE
Bump Nim to 1.6.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 # If NIM_COMMIT is set to "nimbusbuild", this will use the
 # version pinned by nimbus-build-system.
-PINNED_NIM_VERSION := v1.6.14
+PINNED_NIM_VERSION := 38640664088251bbc88917b4bacfd86ec53014b8 # 1.6.21
 
 ifeq ($(NIM_COMMIT),)
 NIM_COMMIT := $(PINNED_NIM_VERSION)


### PR DESCRIPTION
This PR bumps Nim to 1.6.21 pre-release which [includes a fix for range types in Result](https://github.com/nim-lang/Nim/pull/23638), which affects Codex in multiple places.