### PR TITLE
Adds log to dialPeer

### DIFF
--- a/codex/blockexchange/network/network.nim
+++ b/codex/blockexchange/network/network.nim
@@ -290,6 +290,7 @@ proc dialPeer*(b: BlockExcNetwork, peer: PeerRecord) {.async.} =
     trace "Skipping dialing self", peer = peer.peerId
     return
 
+  trace "Dialing peer...", peer = peer.peerId
   await b.switch.connect(peer.peerId, peer.addresses.mapIt(it.address))
 
 proc dropPeer*(b: BlockExcNetwork, peer: PeerId) =


### PR DESCRIPTION
This will help us see who is initiating connection with who during our tests.
(We can already see when a connection is established. But we can't see who initiates it.)