### PR TITLE
chore: add `downtimeProduct` config parameter

### DIFF
--- a/codex/contracts/config.nim
+++ b/codex/contracts/config.nim
@@ -18,6 +18,10 @@ type
     timeout*: UInt256 # mark proofs as missing before the timeout (in seconds)
     downtime*: uint8 # ignore this much recent blocks for proof requirements
     zkeyHash*: string # hash of the zkey file which is linked to the verifier
+    # Ensures the pointer does not remain in downtime for many consecutive
+    # periods. For each period increase, move the pointer `pointerProduct`
+    # blocks. Should be a prime number to ensure there are no cycles.
+    downtimeProduct*: uint8
 
 
 func fromTuple(_: type ProofConfig, tupl: tuple): ProofConfig =
@@ -25,7 +29,8 @@ func fromTuple(_: type ProofConfig, tupl: tuple): ProofConfig =
     period: tupl[0],
     timeout: tupl[1],
     downtime: tupl[2],
-    zkeyHash: tupl[3]
+    zkeyHash: tupl[3],
+    downtimeProduct: tupl[4]
   )
 
 func fromTuple(_: type CollateralConfig, tupl: tuple): CollateralConfig =

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -101,7 +101,8 @@ proc new*(_: type MockMarket): MockMarket =
     proofs: ProofConfig(
       period: 10.u256,
       timeout: 5.u256,
-      downtime: 64.uint8
+      downtime: 64.uint8,
+      downtimeProduct: 67.uint8
     )
   )
   MockMarket(signer: Address.example, config: config)


### PR DESCRIPTION
Adds client support for https://github.com/codex-storage/codex-contracts-eth/issues/108.

Related to https://github.com/codex-storage/codex-contracts-eth/pull/138.