### PR TITLE
Add OPTIONS endpoint to allow the content-type header for the upload endpoint

### DIFF
--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -110,6 +110,20 @@ proc retrieveCid(
 proc initDataApi(node: CodexNodeRef, repoStore: RepoStore, router: var RestRouter) =
   let allowedOrigin = router.allowedOrigin # prevents capture inside of api defintion
 
+  router.api(
+    MethodOptions,
+    "/api/codex/v1/data") do (
+       resp: HttpResponseRef) -> RestApiResponse:
+
+      if corsOrigin =? allowedOrigin:
+        resp.setHeader("Access-Control-Allow-Origin", corsOrigin)
+        resp.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS")
+        resp.setHeader("Access-Control-Headers", "X-Requested-With")
+        resp.setHeader("Access-Control-Allow-Headers", "content-type")
+
+      resp.status = Http204
+      await resp.sendBody("")
+
   router.rawApi(
     MethodPost,
     "/api/codex/v1/data") do (

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -118,8 +118,8 @@ proc initDataApi(node: CodexNodeRef, repoStore: RepoStore, router: var RestRoute
       if corsOrigin =? allowedOrigin:
         resp.setHeader("Access-Control-Allow-Origin", corsOrigin)
         resp.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS")
-        resp.setHeader("Access-Control-Headers", "X-Requested-With")
         resp.setHeader("Access-Control-Allow-Headers", "content-type")
+        resp.setHeader("Access-Control-Max-Age", "86400")
 
       resp.status = Http204
       await resp.sendBody("")


### PR DESCRIPTION
This PR was created from the discussion in #866. 

The browser adds a content-type header when trying to upload the file, but the Codex client does not handle it. So this PR adds an OPTIONS endpoint to add this header and allow the preflight request.