### PR TITLE
refactor(marketplace): generic querying of historical marketplace events

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -349,7 +349,7 @@ method unsubscribe*(subscription: OnChainMarketSubscription) {.async.} =
 
 method queryPastStorageRequests*(market: OnChainMarket,
                                  blocksAgo: int):
-                                Future[seq[PastStorageRequest]] {.async.} =
+                                Future[seq[StorageRequested]] {.async.} =
   convertEthersError:
     let contract = market.contract
     let provider = contract.provider
@@ -361,7 +361,7 @@ method queryPastStorageRequests*(market: OnChainMarket,
                                             fromBlock,
                                             BlockTag.latest)
     return events.map(event =>
-      PastStorageRequest(
+      StorageRequested(
         requestId: event.requestId,
         ask: event.ask,
         expiry: event.expiry

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -357,13 +357,6 @@ method queryPastStorageRequests*(market: OnChainMarket,
     let head = await provider.getBlockNumber()
     let fromBlock = BlockTag.init(head - blocksAgo.abs.u256)
 
-    let events = await contract.queryFilter(StorageRequested,
-                                            fromBlock,
-                                            BlockTag.latest)
-    return events.map(event =>
-      StorageRequested(
-        requestId: event.requestId,
-        ask: event.ask,
-        expiry: event.expiry
-      )
-    )
+    return await contract.queryFilter(StorageRequested,
+                                      fromBlock,
+                                      BlockTag.latest)

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -347,9 +347,11 @@ method subscribeProofSubmission*(market: OnChainMarket,
 method unsubscribe*(subscription: OnChainMarketSubscription) {.async.} =
   await subscription.eventSubscription.unsubscribe()
 
-method queryPastStorageRequests*(market: OnChainMarket,
-                                 blocksAgo: int):
-                                Future[seq[StorageRequested]] {.async.} =
+method queryPastEvents*[T: MarketplaceEvent](
+  market: OnChainMarket,
+  _: type T,
+  blocksAgo: int): Future[seq[T]] {.async.} =
+
   convertEthersError:
     let contract = market.contract
     let provider = contract.provider
@@ -357,6 +359,6 @@ method queryPastStorageRequests*(market: OnChainMarket,
     let head = await provider.getBlockNumber()
     let fromBlock = BlockTag.init(head - blocksAgo.abs.u256)
 
-    return await contract.queryFilter(StorageRequested,
+    return await contract.queryFilter(T,
                                       fromBlock,
                                       BlockTag.latest)

--- a/codex/contracts/marketplace.nim
+++ b/codex/contracts/marketplace.nim
@@ -16,25 +16,6 @@ export requests
 
 type
   Marketplace* = ref object of Contract
-  StorageRequested* = object of Event
-    requestId*: RequestId
-    ask*: StorageAsk
-    expiry*: UInt256
-  SlotFilled* = object of Event
-    requestId* {.indexed.}: RequestId
-    slotIndex*: UInt256
-  SlotFreed* = object of Event
-    requestId* {.indexed.}: RequestId
-    slotIndex*: UInt256
-  RequestFulfilled* = object of Event
-    requestId* {.indexed.}: RequestId
-  RequestCancelled* = object of Event
-    requestId* {.indexed.}: RequestId
-  RequestFailed* = object of Event
-    requestId* {.indexed.}: RequestId
-  ProofSubmitted* = object of Event
-    id*: SlotId
-
 
 proc config*(marketplace: Marketplace): MarketplaceConfig {.contract, view.}
 proc token*(marketplace: Marketplace): Address {.contract, view.}

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -28,11 +28,27 @@ type
   OnRequestCancelled* = proc(requestId: RequestId) {.gcsafe, upraises:[].}
   OnRequestFailed* = proc(requestId: RequestId) {.gcsafe, upraises:[].}
   OnProofSubmitted* = proc(id: SlotId) {.gcsafe, upraises:[].}
-  PastStorageRequest* = object
+  ProofChallenge* = array[32, byte]
+
+  # Marketplace events -- located here due to the Market abstraction
+  StorageRequested* = object of Event
     requestId*: RequestId
     ask*: StorageAsk
     expiry*: UInt256
-  ProofChallenge* = array[32, byte]
+  SlotFilled* = object of Event
+    requestId* {.indexed.}: RequestId
+    slotIndex*: UInt256
+  SlotFreed* = object of Event
+    requestId* {.indexed.}: RequestId
+    slotIndex*: UInt256
+  RequestFulfilled* = object of Event
+    requestId* {.indexed.}: RequestId
+  RequestCancelled* = object of Event
+    requestId* {.indexed.}: RequestId
+  RequestFailed* = object of Event
+    requestId* {.indexed.}: RequestId
+  ProofSubmitted* = object of Event
+    id*: SlotId
 
 method getZkeyHash*(market: Market): Future[?string] {.base, async.} =
   raiseAssert("not implemented")
@@ -204,5 +220,5 @@ method unsubscribe*(subscription: Subscription) {.base, async, upraises:[].} =
 
 method queryPastStorageRequests*(market: Market,
                                  blocksAgo: int):
-                                Future[seq[PastStorageRequest]] {.base, async.} =
+                                Future[seq[StorageRequested]] {.base, async.} =
   raiseAssert("not implemented")

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -31,6 +31,7 @@ type
   ProofChallenge* = array[32, byte]
 
   # Marketplace events -- located here due to the Market abstraction
+  MarketplaceEvent* = Event
   StorageRequested* = object of Event
     requestId*: RequestId
     ask*: StorageAsk
@@ -218,7 +219,8 @@ method subscribeProofSubmission*(market: Market,
 method unsubscribe*(subscription: Subscription) {.base, async, upraises:[].} =
   raiseAssert("not implemented")
 
-method queryPastStorageRequests*(market: Market,
-                                 blocksAgo: int):
-                                Future[seq[StorageRequested]] {.base, async.} =
+method queryPastEvents*[T: MarketplaceEvent](
+  market: Market,
+  _: type T,
+  blocksAgo: int): Future[seq[T]] {.base, async.} =
   raiseAssert("not implemented")

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -32,23 +32,23 @@ type
 
   # Marketplace events -- located here due to the Market abstraction
   MarketplaceEvent* = Event
-  StorageRequested* = object of Event
+  StorageRequested* = object of MarketplaceEvent
     requestId*: RequestId
     ask*: StorageAsk
     expiry*: UInt256
-  SlotFilled* = object of Event
+  SlotFilled* = object of MarketplaceEvent
     requestId* {.indexed.}: RequestId
     slotIndex*: UInt256
-  SlotFreed* = object of Event
+  SlotFreed* = object of MarketplaceEvent
     requestId* {.indexed.}: RequestId
     slotIndex*: UInt256
-  RequestFulfilled* = object of Event
+  RequestFulfilled* = object of MarketplaceEvent
     requestId* {.indexed.}: RequestId
-  RequestCancelled* = object of Event
+  RequestCancelled* = object of MarketplaceEvent
     requestId* {.indexed.}: RequestId
-  RequestFailed* = object of Event
+  RequestFailed* = object of MarketplaceEvent
     requestId* {.indexed.}: RequestId
-  ProofSubmitted* = object of Event
+  ProofSubmitted* = object of MarketplaceEvent
     id*: SlotId
 
 method getZkeyHash*(market: Market): Future[?string] {.base, async.} =

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -420,16 +420,21 @@ method subscribeProofSubmission*(mock: MockMarket,
   mock.subscriptions.onProofSubmitted.add(subscription)
   return subscription
 
-method queryPastStorageRequests*(market: MockMarket,
-                                 blocksAgo: int):
-                                Future[seq[StorageRequested]] {.async.} =
-  # MockMarket does not have the concept of blocks, so simply return all
-  # previous events
-  return market.requested.map(request =>
-    StorageRequested(requestId: request.id,
+method queryPastEvents*[T: MarketplaceEvent](
+  market: MockMarket,
+  _: type T,
+  blocksAgo: int): Future[seq[T]] {.async.} =
+
+  if T of StorageRequested:
+    return market.requested.map(request =>
+      StorageRequested(requestId: request.id,
                        ask: request.ask,
                        expiry: request.expiry)
-  )
+    )
+  elif T of SlotFilled:
+    return market.filled.map(slot =>
+      SlotFilled(requestId: slot.requestId, slotIndex: slot.slotIndex)
+    )
 
 method unsubscribe*(subscription: RequestSubscription) {.async.} =
   subscription.market.subscriptions.onRequest.keepItIf(it != subscription)

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -422,11 +422,11 @@ method subscribeProofSubmission*(mock: MockMarket,
 
 method queryPastStorageRequests*(market: MockMarket,
                                  blocksAgo: int):
-                                Future[seq[PastStorageRequest]] {.async.} =
+                                Future[seq[StorageRequested]] {.async.} =
   # MockMarket does not have the concept of blocks, so simply return all
   # previous events
   return market.requested.map(request =>
-    PastStorageRequest(requestId: request.id,
+    StorageRequested(requestId: request.id,
                        ask: request.ask,
                        expiry: request.expiry)
   )


### PR DESCRIPTION
Allows querying of past Marketplace events using a generic routine.

Also moves marketplace contract events to the Market abstraction so the types can be shared across all modules that call the Market abstraction.