### PR TITLE
Downgrade to gcc 13 on Windows

### DIFF
--- a/.github/actions/nimbus-build-system/action.yml
+++ b/.github/actions/nimbus-build-system/action.yml
@@ -78,6 +78,12 @@ runs:
           mingw-w64-i686-ntldd-git
           mingw-w64-i686-rust
 
+    - name: MSYS2 (Windows All) - Downgrade to gcc 13
+      if: inputs.os == 'windows'
+      shell: ${{ inputs.shell }} {0}
+      run: |
+        pacman -U --noconfirm https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-gcc-13.2.0-6-any.pkg.tar.zst https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-gcc-libs-13.2.0-6-any.pkg.tar.zst
+
     - name: Derive environment variables
       shell: ${{ inputs.shell }} {0}
       run: |

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -26,7 +26,7 @@ jobs:
 
     name: '${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.nim_version }}-${{ matrix.tests }}'
     runs-on: ${{ matrix.builder }}
-    timeout-minutes: 80
+    timeout-minutes: 90
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
This is a quick and temporary fix until we will fix all dependencies to work with gcc 14.

@benbierens is working on the dependencies

| Dependency                                                          | Status                                                                       |
| ------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`status-im/nim-bearssl`](https://github.com/status-im/nim-bearssl) | Update submodule                                                             |
| [`vacp2p/nim-libp2p`](https://github.com/vacp2p/nim-libp2p)         | [In progress](https://github.com/vacp2p/nim-libp2p/tree/multihash-poseidon2) |
| [`nim-leopard`](https://github.com/codex-storage/nim-leopard)       | [PR](https://github.com/codex-storage/nim-leopard/pull/15)                   |
| [`nim-codex-dht`](https://github.com/codex-storage/nim-codex-dht)   | [In progress](https://github.com/codex-storage/nim-codex-dht/tree/gcc-14)    |
