### PR TITLE
Support CORS preflight requests when the storage request api returns an error 

### DIFF
--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -417,38 +417,45 @@ proc initPurchasingApi(node: CodexNodeRef, router: var RestRouter) =
       ## nodes            - number of nodes the content should be stored on
       ## tolerance        - allowed number of nodes that can be lost before content is lost
       ## colateral        - requested collateral from hosts when they fill slot
-
+      
+      let headers = [
+        ("Access-Control-Allow-Origin", "*"), 
+        ("Access-Control-Allow-Methods", "POST, OPTIONS"),
+        ("Access-Control-Allow-Headers", "content-type"),
+        ("Access-Control-Max-Age", "86400")
+      ]
+      
       try:
         without contracts =? node.contracts.client:
-          return RestApiResponse.error(Http503, "Purchasing unavailable")
+          return RestApiResponse.error(Http503, "Purchasing unavailable", headers = headers)
 
         without cid =? cid.tryGet.catch, error:
-          return RestApiResponse.error(Http400, error.msg)
+          return RestApiResponse.error(Http400, error.msg, headers = headers)
 
         let body = await request.getBody()
 
         without params =? StorageRequestParams.fromJson(body), error:
-          return RestApiResponse.error(Http400, error.msg)
+          return RestApiResponse.error(Http400, error.msg, headers = headers)
 
         let nodes = params.nodes |? 1
         let tolerance = params.tolerance |? 0
 
         # prevent underflow
         if tolerance > nodes:
-          return RestApiResponse.error(Http400, "Invalid parameters: `tolerance` cannot be greater than `nodes`")
+          return RestApiResponse.error(Http400, "Invalid parameters: `tolerance` cannot be greater than `nodes`", headers = headers)
 
         let ecK = nodes - tolerance
         let ecM = tolerance # for readability
 
         # ensure leopard constrainst of 1 < K ≥ M
         if ecK <= 1 or ecK < ecM:
-          return RestApiResponse.error(Http400, "Invalid parameters: parameters must satify `1 < (nodes - tolerance) ≥ tolerance`")
+          return RestApiResponse.error(Http400, "Invalid parameters: parameters must satify `1 < (nodes - tolerance) ≥ tolerance`", headers = headers)
 
         without expiry =? params.expiry:
-          return RestApiResponse.error(Http400, "Expiry required")
+          return RestApiResponse.error(Http400, "Expiry required", headers = headers)
 
         if expiry <= 0 or expiry >= params.duration:
-          return RestApiResponse.error(Http400, "Expiry needs value bigger then zero and smaller then the request's duration")
+          return RestApiResponse.error(Http400, "Expiry needs value bigger then zero and smaller then the request's duration", headers = headers)
 
         without purchaseId =? await node.requestStorage(
           cid,
@@ -463,14 +470,14 @@ proc initPurchasingApi(node: CodexNodeRef, router: var RestRouter) =
           if error of InsufficientBlocksError:
             return RestApiResponse.error(Http400,
             "Dataset too small for erasure parameters, need at least " &
-              $(ref InsufficientBlocksError)(error).minSize.int & " bytes")
+              $(ref InsufficientBlocksError)(error).minSize.int & " bytes", headers = headers)
 
-          return RestApiResponse.error(Http500, error.msg)
+          return RestApiResponse.error(Http500, error.msg, headers = headers)
 
         return RestApiResponse.response(purchaseId.toHex)
       except CatchableError as exc:
         trace "Excepting processing request", exc = exc.msg
-        return RestApiResponse.error(Http500)
+        return RestApiResponse.error(Http500, headers = headers)
 
   router.api(
     MethodGet,

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -404,6 +404,8 @@ proc initSalesApi(node: CodexNodeRef, router: var RestRouter) =
         return RestApiResponse.error(Http500)
 
 proc initPurchasingApi(node: CodexNodeRef, router: var RestRouter) =
+  let allowedOrigin = router.allowedOrigin
+
   router.rawApi(
     MethodPost,
     "/api/codex/v1/storage/request/{cid}") do (cid: Cid) -> RestApiResponse:
@@ -417,13 +419,13 @@ proc initPurchasingApi(node: CodexNodeRef, router: var RestRouter) =
       ## nodes            - number of nodes the content should be stored on
       ## tolerance        - allowed number of nodes that can be lost before content is lost
       ## colateral        - requested collateral from hosts when they fill slot
-      
-      let headers = [
-        ("Access-Control-Allow-Origin", "*"), 
-        ("Access-Control-Allow-Methods", "POST, OPTIONS"),
-        ("Access-Control-Allow-Headers", "content-type"),
-        ("Access-Control-Max-Age", "86400")
-      ]
+
+      var headers = newSeq[(string,string)]()
+
+      if corsOrigin =? allowedOrigin:
+        headers.add(("Access-Control-Allow-Origin", corsOrigin))
+        headers.add(("Access-Control-Allow-Methods", "POST, OPTIONS"))
+        headers.add(("Access-Control-Max-Age", "86400"))
       
       try:
         without contracts =? node.contracts.client:


### PR DESCRIPTION
When trying to create a new storage request with the API, the request can fail if the parameters are invalid due to some rules (for example, parameters must satisfy 1 < (nodes - tolerance) ≥ tolerance).

When the error is returned with the following code, the CORS headers are not included:

```
return RestApiResponse.error(Http400, error.msg)
```

This PR fix this issue and returns the CORS headers when the storage requests api returns an error. 