### PR TITLE
feat(slot-reservations): Support reserving slots

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -247,11 +247,14 @@ method canProofBeMarkedAsMissing*(
     trace "Proof cannot be marked as missing", msg = e.msg
     return false
 
-method reserveSlot*(id: SlotId): Future[bool] {.async.} =
+method reserveSlot*(market: OnChainMarket, id: SlotId) {.async.} =
   discard await market.contract.reserveSlot(id).confirm(0)
 
-method canReserveSlot*(id: SlotId): Future[bool] {.async.} =
-  discard await market.contract.canReserveSlot(id).confirm(0)
+method canReserveSlot*(
+  market: OnChainMarket,
+  id: SlotId): Future[bool] {.async.} =
+
+  await market.contract.canReserveSlot(id)
 
 method subscribeRequests*(market: OnChainMarket,
                          callback: OnRequest):

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -247,6 +247,12 @@ method canProofBeMarkedAsMissing*(
     trace "Proof cannot be marked as missing", msg = e.msg
     return false
 
+method reserveSlot*(id: SlotId): Future[bool] {.async.} =
+  discard await market.contract.reserveSlot(id).confirm(0)
+
+method canReserveSlot*(id: SlotId): Future[bool] {.async.} =
+  discard await market.contract.canReserveSlot(id).confirm(0)
+
 method subscribeRequests*(market: OnChainMarket,
                          callback: OnRequest):
                         Future[MarketSubscription] {.async.} =

--- a/codex/contracts/marketplace.nim
+++ b/codex/contracts/marketplace.nim
@@ -51,3 +51,6 @@ proc getPointer*(marketplace: Marketplace, id: SlotId): uint8 {.contract, view.}
 
 proc submitProof*(marketplace: Marketplace, id: SlotId, proof: Groth16Proof): ?TransactionResponse {.contract.}
 proc markProofAsMissing*(marketplace: Marketplace, id: SlotId, period: UInt256): ?TransactionResponse {.contract.}
+
+proc reserveSlot*(marketplace: Marketplace, id: SlotId): bool {.contract.}
+proc canReserveSlot*(marketplace: Marketplace, id: SlotId): bool {.contract, view.}

--- a/codex/contracts/marketplace.nim
+++ b/codex/contracts/marketplace.nim
@@ -52,5 +52,5 @@ proc getPointer*(marketplace: Marketplace, id: SlotId): uint8 {.contract, view.}
 proc submitProof*(marketplace: Marketplace, id: SlotId, proof: Groth16Proof): ?TransactionResponse {.contract.}
 proc markProofAsMissing*(marketplace: Marketplace, id: SlotId, period: UInt256): ?TransactionResponse {.contract.}
 
-proc reserveSlot*(marketplace: Marketplace, id: SlotId): bool {.contract.}
+proc reserveSlot*(marketplace: Marketplace, id: SlotId): ?TransactionResponse {.contract.}
 proc canReserveSlot*(marketplace: Marketplace, id: SlotId): bool {.contract, view.}

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -161,10 +161,16 @@ method canProofBeMarkedAsMissing*(market: Market,
                                   period: Period): Future[bool] {.base, async.} =
   raiseAssert("not implemented")
 
-method reserveSlot*(id: SlotId): Future[bool] {.base, async.} =
+method reserveSlot*(
+  market: Market,
+  id: SlotId) {.base, async.} =
+
   raiseAssert("not implemented")
 
-method canReserveSlot*(id: SlotId): Future[bool] {.base, async.} =
+method canReserveSlot*(
+  market: Market,
+  id: SlotId): Future[bool] {.base, async.} =
+
   raiseAssert("not implemented")
 
 method subscribeFulfillment*(market: Market,

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -161,6 +161,12 @@ method canProofBeMarkedAsMissing*(market: Market,
                                   period: Period): Future[bool] {.base, async.} =
   raiseAssert("not implemented")
 
+method reserveSlot*(id: SlotId): Future[bool] {.base, async.} =
+  raiseAssert("not implemented")
+
+method canReserveSlot*(id: SlotId): Future[bool] {.base, async.} =
+  raiseAssert("not implemented")
+
 method subscribeFulfillment*(market: Market,
                              callback: OnFulfillment):
                             Future[Subscription] {.base, async.} =


### PR DESCRIPTION
Closes #898.

These functions are not called yet. They are being implemented as part of a [longer list of tasks for slot reservations](https://github.com/codex-storage/codex-pm/issues/45) to prevent PRs from being too large.

Wire up reserveSlot and canReserveSlot contract calls, but don't call them

NOTE: This uses updated contracts pointing to a branch in https://github.com/codex-storage/codex-contracts-eth/pull/176. It's probably best to merge that PR first, then update this PR to point to the master branch of `codex-contracts-eth`