### PR TITLE
feat(slot-reservations): Add SaleSlotReserving state

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -260,7 +260,8 @@ method canReserveSlot*(
   requestId: RequestId,
   slotIndex: UInt256): Future[bool] {.async.} =
 
-  await market.contract.canReserveSlot(requestId, slotIndex)
+  convertEthersError:
+    return await market.contract.canReserveSlot(requestId, slotIndex)
 
 method subscribeRequests*(market: OnChainMarket,
                          callback: OnRequest):

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -260,8 +260,7 @@ method canReserveSlot*(
   requestId: RequestId,
   slotIndex: UInt256): Future[bool] {.async.} =
 
-  convertEthersError:
-    return await market.contract.canReserveSlot(requestId, slotIndex)
+  await market.contract.canReserveSlot(requestId, slotIndex)
 
 method subscribeRequests*(market: OnChainMarket,
                          callback: OnRequest):

--- a/codex/sales/states/slotreserving.nim
+++ b/codex/sales/states/slotreserving.nim
@@ -1,0 +1,62 @@
+import pkg/questionable
+import pkg/questionable/results
+import pkg/metrics
+
+import ../../logutils
+import ../../market
+import ../salesagent
+import ../statemachine
+import ./errorhandling
+import ./cancelled
+import ./failed
+import ./filled
+import ./ignored
+import ./downloading
+import ./errored
+
+type
+  SaleSlotReserving* = ref object of ErrorHandlingState
+
+logScope:
+  topics = "marketplace sales reserving"
+
+method `$`*(state: SaleSlotReserving): string = "SaleSlotReserving"
+
+method onCancelled*(state: SaleSlotReserving, request: StorageRequest): ?State =
+  return some State(SaleCancelled())
+
+method onFailed*(state: SaleSlotReserving, request: StorageRequest): ?State =
+  return some State(SaleFailed())
+
+method onSlotFilled*(state: SaleSlotReserving, requestId: RequestId,
+                     slotIndex: UInt256): ?State =
+  return some State(SaleFilled())
+
+method run*(state: SaleSlotReserving, machine: Machine): Future[?State] {.async.} =
+  let agent = SalesAgent(machine)
+  let data = agent.data
+  let context = agent.context
+  let market = context.market
+  let slotId = slotId(data.requestId, data.slotIndex)
+
+  logScope:
+    slotIndex = data.slotIndex
+    slotId
+
+  let canReserve = await market.canReserveSlot(slotId)
+  if canReserve:
+    try:
+      trace "Reserving slot"
+      await market.reserveSlot(slotId)
+    except MarketError as e:
+      return some State( SaleErrored(error: e) )
+
+    trace "Slot successfully reserved"
+    return some State( SaleDownloading() )
+
+  else:
+    # do not re-add this slot to the queue, and return bytes from Reservation to
+    # the Availability
+    debug "Slot cannot be reserved, ignoring"
+    return some State( SaleIgnored(reprocessSlot: false, returnBytes: true) )
+

--- a/codex/sales/states/slotreserving.nim
+++ b/codex/sales/states/slotreserving.nim
@@ -37,17 +37,16 @@ method run*(state: SaleSlotReserving, machine: Machine): Future[?State] {.async.
   let data = agent.data
   let context = agent.context
   let market = context.market
-  let slotId = slotId(data.requestId, data.slotIndex)
 
   logScope:
+    requestId = data.requestId
     slotIndex = data.slotIndex
-    slotId
 
-  let canReserve = await market.canReserveSlot(slotId)
+  let canReserve = await market.canReserveSlot(data.requestId, data.slotIndex)
   if canReserve:
     try:
       trace "Reserving slot"
-      await market.reserveSlot(slotId)
+      await market.reserveSlot(data.requestId, data.slotIndex)
     except MarketError as e:
       return some State( SaleErrored(error: e) )
 

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -305,11 +305,19 @@ method canProofBeMarkedAsMissing*(market: MockMarket,
                                   period: Period): Future[bool] {.async.} =
   return market.canBeMarkedAsMissing.contains(id)
 
-method reserveSlot*(market: MockMarket, id: SlotId) {.async.} =
+method reserveSlot*(
+  market: MockMarket,
+  requestId: RequestId,
+  slotIndex: UInt256) {.async.} =
+
   if error =? market.reserveSlotThrowError:
     raise error
 
-method canReserveSlot*(market: MockMarket, id: SlotId): Future[bool] {.async.} =
+method canReserveSlot*(
+  market: MockMarket,
+  requestId: RequestId,
+  slotIndex: UInt256): Future[bool] {.async.} =
+
   return market.canReserveSlot
 
 func setCanReserveSlot*(market: MockMarket, canReserveSlot: bool) =

--- a/tests/codex/helpers/mockreservations.nim
+++ b/tests/codex/helpers/mockreservations.nim
@@ -6,6 +6,7 @@ import pkg/questionable/results
 type
   MockReservations* = ref object of Reservations
     createReservationThrowBytesOutOfBoundsError: bool
+    createReservationThrowError: ?(ref CatchableError)
 
 proc new*(
     T: type MockReservations,
@@ -14,8 +15,15 @@ proc new*(
   ## Create a mock clock instance
   MockReservations(availabilityLock: newAsyncLock(), repo: repo)
 
-proc setCreateReservationThrowBytesOutOfBoundsError*(self: MockReservations, flag: bool) =
+proc setCreateReservationThrowBytesOutOfBoundsError*(
+  self: MockReservations, flag: bool) =
+
   self.createReservationThrowBytesOutOfBoundsError = flag
+
+proc setCreateReservationThrowError*(
+  self: MockReservations, error: ?(ref CatchableError)) =
+
+  self.createReservationThrowError = error
 
 method createReservation*(
   self: MockReservations,
@@ -27,6 +35,9 @@ method createReservation*(
       let error = newException(
         BytesOutOfBoundsError,
         "trying to reserve an amount of bytes that is greater than the total size of the Availability")
+      return failure(error)
+
+    elif error =? self.createReservationThrowError:
       return failure(error)
 
     return await procCall createReservation(Reservations(self), availabilityId, slotSize, requestId, slotIndex)

--- a/tests/codex/sales/states/testignored.nim
+++ b/tests/codex/sales/states/testignored.nim
@@ -39,7 +39,8 @@ asyncchecksuite "sales state 'ignored'":
     agent.onCleanUp = onCleanUp
     state = SaleIgnored.new()
 
-  test "calls onCleanUp with returnBytes = false and reprocessSlot = true":
+  test "calls onCleanUp with values assigned to SaleIgnored":
+    state = SaleIgnored(reprocessSlot: true, returnBytes: true)
     discard await state.run(agent)
-    check eventually returnBytesWas == false
+    check eventually returnBytesWas == true
     check eventually reprocessSlotWas == true

--- a/tests/codex/sales/states/testslotreserving.nim
+++ b/tests/codex/sales/states/testslotreserving.nim
@@ -1,7 +1,5 @@
 import pkg/chronos
 import pkg/questionable
-import pkg/datastore
-import pkg/stew/byteutils
 import pkg/codex/contracts/requests
 import pkg/codex/sales/states/slotreserving
 import pkg/codex/sales/states/downloading
@@ -21,7 +19,7 @@ import ../../helpers/mockmarket
 import ../../helpers/mockreservations
 import ../../helpers/mockclock
 
-asyncchecksuite "sales state 'preparing'":
+asyncchecksuite "sales state 'SlotReserving'":
   let request = StorageRequest.example
   let slotIndex = (request.ask.slots div 2).u256
   var market: MockMarket

--- a/tests/codex/sales/states/testslotreserving.nim
+++ b/tests/codex/sales/states/testslotreserving.nim
@@ -1,0 +1,75 @@
+import pkg/chronos
+import pkg/questionable
+import pkg/datastore
+import pkg/stew/byteutils
+import pkg/codex/contracts/requests
+import pkg/codex/sales/states/slotreserving
+import pkg/codex/sales/states/downloading
+import pkg/codex/sales/states/cancelled
+import pkg/codex/sales/states/failed
+import pkg/codex/sales/states/filled
+import pkg/codex/sales/states/ignored
+import pkg/codex/sales/states/errored
+import pkg/codex/sales/salesagent
+import pkg/codex/sales/salescontext
+import pkg/codex/sales/reservations
+import pkg/codex/stores/repostore
+import ../../../asynctest
+import ../../helpers
+import ../../examples
+import ../../helpers/mockmarket
+import ../../helpers/mockreservations
+import ../../helpers/mockclock
+
+asyncchecksuite "sales state 'preparing'":
+  let request = StorageRequest.example
+  let slotIndex = (request.ask.slots div 2).u256
+  var market: MockMarket
+  var clock: MockClock
+  var agent: SalesAgent
+  var state: SaleSlotReserving
+  var context: SalesContext
+
+  setup:
+    market = MockMarket.new()
+    clock = MockClock.new()
+
+    state = SaleSlotReserving.new()
+    context = SalesContext(
+      market: market,
+      clock: clock
+    )
+
+    agent = newSalesAgent(context,
+                          request.id,
+                          slotIndex,
+                          request.some)
+
+  test "switches to cancelled state when request expires":
+    let next = state.onCancelled(request)
+    check !next of SaleCancelled
+
+  test "switches to failed state when request fails":
+    let next = state.onFailed(request)
+    check !next of SaleFailed
+
+  test "switches to filled state when slot is filled":
+    let next = state.onSlotFilled(request.id, slotIndex)
+    check !next of SaleFilled
+
+  test "run switches to downloading when slot successfully reserved":
+    let next = await state.run(agent)
+    check !next of SaleDownloading
+
+  test "run switches to ignored when slot reservation not allowed":
+    market.setCanReserveSlot(false)
+    let next = await state.run(agent)
+    check !next of SaleIgnored
+
+  test "run switches to errored when slot reservation errors":
+    let error = newException(MarketError, "some error")
+    market.setReserveSlotThrowError(some error)
+    let next = !(await state.run(agent))
+    check next of SaleErrored
+    let errored = SaleErrored(next)
+    check errored.error == error

--- a/tests/codex/sales/teststates.nim
+++ b/tests/codex/sales/teststates.nim
@@ -10,5 +10,6 @@ import ./states/testcancelled
 import ./states/testerrored
 import ./states/testignored
 import ./states/testpreparing
+import ./states/testslotreserving
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
Closes #916

This is being implemented as part of a [longer list of tasks for slot reservations](https://github.com/codex-storage/codex-pm/issues/45) to prevent PRs from being too large.

Adds a new state, `SaleSlotReserving`, that attempts to reserve a slot before downloading.
If the slot cannot be reserved, the state moves to SaleIgnored.
On error, the state moves to `SaleErrored`.

`SaleIgnored` is also updated to pass in `reprocessSlot` and `returnBytes`, controlling the behaviour in the sales module after the slot is ignored. This is because previously it was assumed that SaleIgnored was only reached when there was no availability. This is no longer the case, since `SaleIgnored` can now be reached when a slot cannot be reserved.