### PR TITLE
docs(openapi): provider better documentation for space endpoint parameters

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -330,7 +330,7 @@ components:
         quotaMaxBytes:
           type: integer
           format: int64
-          description: "Maximum storage space (in bytes) used by the node on the hard drive."
+          description: "Maximum storage space (in bytes) available for the node in Codex's local repository."
         quotaUsedBytes:
           type: integer
           format: int64

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -334,7 +334,7 @@ components:
         quotaUsedBytes:
           type: integer
           format: int64
-          description: "Amount of storage space (in bytes) currently in use by availabilities for existing files."
+          description: "Amount of storage space (in bytes) currently used for storing files in Codex's local repository."
         quotaReservedBytes:
           type: integer
           format: int64

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -330,15 +330,15 @@ components:
         quotaMaxBytes:
           type: integer
           format: int64
-          description: "Maximum storage space used by the node"
+          description: "Maximum storage space (in bytes) used by the node on the hard drive."
         quotaUsedBytes:
           type: integer
           format: int64
-          description: "Amount of storage space currently in use"
+          description: "Amount of storage space (in bytes) currently in use by availabilities for existing files."
         quotaReservedBytes:
           type: integer
           format: int64
-          description: "Amount of storage space reserved"
+          description: "Amount of storage allocated (in bytes) for the node by availabilities for future use when storage requests are fulfilled. This does not include the storage currently in use."
 
 servers:
   - url: "http://localhost:8080/api/codex/v1"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -338,7 +338,7 @@ components:
         quotaReservedBytes:
           type: integer
           format: int64
-          description: "Amount of storage allocated (in bytes) for the node by availabilities for future use when storage requests are fulfilled. This does not include the storage currently in use."
+          description: "Amount of storage reserved (in bytes) in the Codex's local repository for future use when storage requests will be picked up and hosted by the node using node's availabilities. This does not include the storage currently in use."
 
 servers:
   - url: "http://localhost:8080/api/codex/v1"


### PR DESCRIPTION
This PR is trying to improve the documentation for [space endpoint](https://api.codex.storage/#tag/Data/operation/space). It fixes #919.