### PR TITLE
feat(slot-reservations): support SlotReservationsFull event

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -307,6 +307,17 @@ method subscribeSlotFreed*(market: OnChainMarket,
     let subscription = await market.contract.subscribe(SlotFreed, onEvent)
     return OnChainMarketSubscription(eventSubscription: subscription)
 
+method subscribeSlotReservationsFull*(
+  market: OnChainMarket,
+  callback: OnSlotReservationsFull): Future[MarketSubscription] {.async.} =
+
+  proc onEvent(event: SlotReservationsFull) {.upraises:[].} =
+    callback(event.requestId, event.slotIndex)
+
+  convertEthersError:
+    let subscription = await market.contract.subscribe(SlotReservationsFull, onEvent)
+    return OnChainMarketSubscription(eventSubscription: subscription)
+
 method subscribeFulfillment(market: OnChainMarket,
                             callback: OnFulfillment):
                            Future[MarketSubscription] {.async.} =

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -25,6 +25,7 @@ type
   OnFulfillment* = proc(requestId: RequestId) {.gcsafe, upraises: [].}
   OnSlotFilled* = proc(requestId: RequestId, slotIndex: UInt256) {.gcsafe, upraises:[].}
   OnSlotFreed* = proc(requestId: RequestId, slotIndex: UInt256) {.gcsafe, upraises: [].}
+  OnSlotReservationsFull* = proc(requestId: RequestId, slotIndex: UInt256) {.gcsafe, upraises: [].}
   OnRequestCancelled* = proc(requestId: RequestId) {.gcsafe, upraises:[].}
   OnRequestFailed* = proc(requestId: RequestId) {.gcsafe, upraises:[].}
   OnProofSubmitted* = proc(id: SlotId) {.gcsafe, upraises:[].}
@@ -40,6 +41,9 @@ type
     requestId* {.indexed.}: RequestId
     slotIndex*: UInt256
   SlotFreed* = object of MarketplaceEvent
+    requestId* {.indexed.}: RequestId
+    slotIndex*: UInt256
+  SlotReservationsFull* = object of MarketplaceEvent
     requestId* {.indexed.}: RequestId
     slotIndex*: UInt256
   RequestFulfilled* = object of MarketplaceEvent
@@ -201,6 +205,12 @@ method subscribeSlotFilled*(market: Market,
 method subscribeSlotFreed*(market: Market,
                            callback: OnSlotFreed):
                           Future[Subscription] {.base, async.} =
+  raiseAssert("not implemented")
+
+method subscribeSlotReservationsFull*(
+  market: Market,
+  callback: OnSlotReservationsFull): Future[Subscription] {.base, async.} =
+
   raiseAssert("not implemented")
 
 method subscribeRequestCancelled*(market: Market,

--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -270,6 +270,12 @@ asyncchecksuite "Sales":
     let expected = SlotQueueItem.init(request1, 1'u16)
     check always (not itemsProcessed.contains(expected))
 
+  test "removes slot index from slot queue once SlotReservationsFull emitted":
+    let request1 = await addRequestToSaturatedQueue()
+    market.emitSlotReservationsFull(request1.id, 1.u256)
+    let expected = SlotQueueItem.init(request1, 1'u16)
+    check always (not itemsProcessed.contains(expected))
+
   test "adds slot index to slot queue once SlotFreed emitted":
     queue.onProcessSlot = proc(item: SlotQueueItem, done: Future[void]) {.async.} =
       itemsProcessed.add item


### PR DESCRIPTION
Closes #931.

This is being implemented as part of a [longer list of tasks for slot reservations](https://github.com/codex-storage/codex-pm/issues/45) to prevent PRs from being too large.

Subscribes to the `SlotReserverationsFull` contract event. Once the event is triggered, the slot is removed from the node's slot queue.