### PR TITLE
Use CLI args when passed for cirdl in Docker entrypoint

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -26,7 +26,7 @@ jobs:
 
     name: '${{ matrix.os }}-${{ matrix.cpu }}-${{ matrix.nim_version }}-${{ matrix.tests }}'
     runs-on: ${{ matrix.builder }}
-    timeout-minutes: 90
+    timeout-minutes: 100
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
We recently discovered that existing [`docker-entrypoint.sh`](https://github.com/codex-storage/nim-codex/blob/264bfa17f54b7973432d000446a725a4b5a6134a/docker/docker-entrypoint.sh#L53-L66) does not support CLI arg for `cirld` and only env vars are supported. And in case when we run Codex only using args, it is required to pass additionally duplicate env vars for `cirdl`.

PR implements parsing of the CLI arguments and passes them to the `cirdl`.