### PR TITLE
expose some metrics over HTTP (Prometheus)

### DIFF
--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -25,6 +25,7 @@ import pkg/datastore
 import pkg/ethers except Rng
 import pkg/stew/io2
 import pkg/taskpools
+import pkg/metrics, pkg/metrics/chronos_httpserver
 
 import ./node
 import ./conf
@@ -147,6 +148,8 @@ proc bootstrapInteractions(
 
 proc start*(s: CodexServer) {.async.} =
   trace "Starting codex node", config = $s.config
+
+  startMetricsHttpServer()
 
   await s.repoStore.start()
   s.maintenance.start()


### PR DESCRIPTION
This is just to start exposing the metrics that are already there from libp2p.
Further changes are needed to make sure the right metrics are collected and exposed.