### PR TITLE
Use Ubuntu 20.04 for Linux amd64 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,9 @@ jobs:
             macos*)   os_name="darwin"  ;;
             windows*) os_name="windows" ;;
           esac
-          codex_binary="${{ env.codex_binary_base }}-${{ github.ref_name }}-${os_name}-${{ matrix.cpu }}"
-          cirdl_binary="${{ env.cirdl_binary_base }}-${{ github.ref_name }}-${os_name}-${{ matrix.cpu }}"
+          github_ref_name="${GITHUB_REF_NAME/\//-}"
+          codex_binary="${{ env.codex_binary_base }}-${github_ref_name}-${os_name}-${{ matrix.cpu }}"
+          cirdl_binary="${{ env.cirdl_binary_base }}-${github_ref_name}-${os_name}-${{ matrix.cpu }}"
           if [[ ${os_name} == "windows" ]]; then
             codex_binary="${codex_binary}.exe"
             cirdl_binary="${cirdl_binary}.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,14 +99,14 @@ jobs:
         with:
           name: release-${{ env.codex_binary }}
           path: ${{ env.build_dir }}/${{ env.codex_binary_base }}*
-          retention-days: 1
+          retention-days: 30
 
       - name: Release - Upload cirdl build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: release-${{ env.cirdl_binary }}
           path: ${{ env.build_dir }}/${{ env.cirdl_binary_base }}*
-          retention-days: 1
+          retention-days: 30
 
       - name: Release - Upload windows libs
         if: matrix.os == 'windows'
@@ -114,7 +114,7 @@ jobs:
         with:
           name: release-${{ matrix.os }}-libs
           path: ${{ env.build_dir }}/*.dll
-          retention-days: 1
+          retention-days: 30
 
   # Release
   release:
@@ -168,7 +168,7 @@ jobs:
         with:
           name: archives-and-checksums
           path: /tmp/release/
-          retention-days: 1
+          retention-days: 30
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       uses: fabiocaccamo/create-matrix-action@v4
       with:
         matrix: |
-          os {linux},   cpu {amd64}, builder {ubuntu-22.04},                   nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {linux},   cpu {amd64}, builder {ubuntu-20.04},                   nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
           os {linux},   cpu {arm64}, builder {buildjet-4vcpu-ubuntu-2204-arm}, nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
           os {macos},   cpu {amd64}, builder {macos-13},                       nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
           os {macos},   cpu {arm64}, builder {macos-14},                       nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}


### PR DESCRIPTION
This PR address the issue #932 and we are using a workaround and run release builds for Linux amd64 on [Ubuntu 20.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md).

For arm64 builds, we miss such an option on [BuildJet](https://buildjet.com/for-github-actions/docs/runners/hardware#arm), and by the end of the yer, we expect to switch to the [GitHub arm64 runners](https://github.blog/changelog/2024-06-03-actions-arm-based-linux-and-windows-runners-are-now-in-public-beta/). But it is not so clear now which Ubuntu versions will be available.
<details>
<summary>details</summary>

[About Ubuntu and Windows larger runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#about-ubuntu-and-windows-larger-runners)

<img width="937" alt="Screenshot 2024-10-04 at 10 48 56" src="https://github.com/user-attachments/assets/0f2117a6-02c6-4025-8460-581e9970cb10">
</details>

Other changes
- we also can handle branches with the slash in the name - `fix/use-ubuntu-20-for-linux-amd64-releases`, to generate intermediate/fixes releases for testing
- for testing purposes it might be sense to retain build artifacts for a longer period of time