### PR TITLE
Adds log to CIRDL to show URL

### DIFF
--- a/tools/cirdl/cirdl.nim
+++ b/tools/cirdl/cirdl.nim
@@ -99,6 +99,7 @@ proc main() {.async.} =
   debug "Got circuithash", circuitHash
 
   let url = formatUrl(circuitHash)
+  info "Download URL", url
   if dlErr =? (await downloadZipfile(url, zipfile)).errorOption:
     error "Failed to download circuit file", msg = dlErr.msg
     return


### PR DESCRIPTION
Useful for debugging testnet cloud nodes.