### PR TITLE
fix(slot-reservations): Avoid slot filled cancellations

### DIFF
--- a/codex/sales/states/filling.nim
+++ b/codex/sales/states/filling.nim
@@ -6,6 +6,8 @@ import ./errorhandling
 import ./filled
 import ./cancelled
 import ./failed
+import ./ignored
+import ./errored
 
 logScope:
   topics = "marketplace sales filling"
@@ -21,10 +23,6 @@ method onCancelled*(state: SaleFilling, request: StorageRequest): ?State =
 
 method onFailed*(state: SaleFilling, request: StorageRequest): ?State =
   return some State(SaleFailed())
-
-method onSlotFilled*(state: SaleFilling, requestId: RequestId,
-                     slotIndex: UInt256): ?State =
-  return some State(SaleFilled())
 
 method run(state: SaleFilling, machine: Machine): Future[?State] {.async.} =
   let data = SalesAgent(machine).data

--- a/codex/sales/states/slotreserving.nim
+++ b/codex/sales/states/slotreserving.nim
@@ -28,10 +28,6 @@ method onCancelled*(state: SaleSlotReserving, request: StorageRequest): ?State =
 method onFailed*(state: SaleSlotReserving, request: StorageRequest): ?State =
   return some State(SaleFailed())
 
-method onSlotFilled*(state: SaleSlotReserving, requestId: RequestId,
-                     slotIndex: UInt256): ?State =
-  return some State(SaleFilled())
-
 method run*(state: SaleSlotReserving, machine: Machine): Future[?State] {.async.} =
   let agent = SalesAgent(machine)
   let data = agent.data

--- a/codex/utils/asyncstatemachine.nim
+++ b/codex/utils/asyncstatemachine.nim
@@ -75,7 +75,7 @@ proc scheduler(machine: Machine) {.async.} =
           await running.cancelAndWait()
         let fromState = if machine.state.isNil: "<none>" else: $machine.state
         machine.state = next
-        debug "enter state", state = machine.state, fromState
+        debug "enter state", state = fromState & " => " & $machine.state
         running = machine.run(machine.state)
         running
           .track(machine)

--- a/tests/codex/sales/states/testfilling.nim
+++ b/tests/codex/sales/states/testfilling.nim
@@ -24,7 +24,3 @@ checksuite "sales state 'filling'":
   test "switches to failed state when request fails":
     let next = state.onFailed(request)
     check !next of SaleFailed
-
-  test "switches to filled state when slot is filled":
-    let next = state.onSlotFilled(request.id, slotIndex)
-    check !next of SaleFilled

--- a/tests/codex/sales/states/testslotreserving.nim
+++ b/tests/codex/sales/states/testslotreserving.nim
@@ -51,10 +51,6 @@ asyncchecksuite "sales state 'SlotReserving'":
     let next = state.onFailed(request)
     check !next of SaleFailed
 
-  test "switches to filled state when slot is filled":
-    let next = state.onSlotFilled(request.id, slotIndex)
-    check !next of SaleFilled
-
   test "run switches to downloading when slot successfully reserved":
     let next = await state.run(agent)
     check !next of SaleDownloading

--- a/tests/integration/hardhatprocess.nim
+++ b/tests/integration/hardhatprocess.nim
@@ -115,7 +115,7 @@ method onOutputLineCaptured(node: HardhatProcess, line: string) =
     return
 
   if error =? logFile.writeFile(line & "\n").errorOption:
-    error "failed to write to hardhat file", errorCode = error
+    error "failed to write to hardhat file", errorCode = $error
     discard logFile.closeFile()
     node.logFile = none IoHandle
 

--- a/tests/integration/nodeprocess.nim
+++ b/tests/integration/nodeprocess.nim
@@ -128,7 +128,7 @@ method stop*(node: NodeProcess) {.base, async.} =
     try:
       trace "terminating node process..."
       if errCode =? node.process.terminate().errorOption:
-        error "failed to terminate process", errCode
+        error "failed to terminate process", errCode = $errCode
 
       trace "waiting for node process to exit"
       let exitCode = await node.process.waitForExit(3.seconds)


### PR DESCRIPTION
This PR does two things which we have seen cause issues in the testnet:
1. Avoids cancelled `SaleReserving` and `SaleFilling` states when slots are filled. The cancellations were bubbling into `nim-ethers` and causing issues with nonce management.
2. Improves logging for situations where a sale should be ignored instead of being considered an error, including when a reservation is not allowed and when a slot was filled by another host.