### PR TITLE
Remove duplicate cors header for fetch manifest endpoint 

### DIFF
--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -280,10 +280,6 @@ proc initDataApi(node: CodexNodeRef, repoStore: RepoStore, router: var RestRoute
           Http400,
           $cid.error(), headers = headers)
 
-      if corsOrigin =? allowedOrigin:
-        resp.setCorsHeaders("GET", corsOrigin)
-        resp.setHeader("Access-Control-Headers", "X-Requested-With")
-
       without manifest =? (await node.fetchManifest(cid.get())), err:
         error "Failed to fetch manifest", err = err.msg
         return RestApiResponse.error(


### PR DESCRIPTION
The following lines are not needed: 

```
   if corsOrigin =? allowedOrigin:
      resp.setCorsHeaders("GET", corsOrigin)
      resp.setHeader("Access-Control-Headers", "X-Requested-With")
```

The reason is that the headers are explicitly added when the API returns an error response, but when the response is successful, nim-presto handles that. As a result, the previous lines are adding a duplicate Access-Control-Allow-Origin header in the browser, which raises an error.

This PR addresses this issue.