### PR TITLE
feat(rest): add default content-disposition header for stream download 

### DIFF
--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -102,7 +102,8 @@ proc retrieveCid(
 
     if manifest.filename.isSome:
       resp.setHeader("Content-Disposition", "attachment; filename=\"" & manifest.filename.get() & "\"")
-
+    else:
+      resp.setHeader("Content-Disposition", "attachment")
 
     await resp.prepareChunked()
 


### PR DESCRIPTION
This PR adds `Content-Disposition` header, even if the filename does not exist in the metadata, to force the browser to download the file.