### PR TITLE
Add ETH_PRIVATE_KEY to Docker entrypoint

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -48,6 +48,7 @@ fi
 for key in PRIV_KEY ETH_PRIVATE_KEY; do
   keyfile="private.key"
   if [[ -n "${!key}" ]]; then
+    [[ "${key}" == "PRIV_KEY" ]] && echo "PRIV_KEY variable is deprecated and will be removed in the next releases, please use ETH_PRIVATE_KEY instead!"
     echo "${!key}" > "${keyfile}"
     chmod 600 "${keyfile}"
     export CODEX_ETH_PRIVATE_KEY="${keyfile}"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -45,12 +45,15 @@ fi
 
 # If marketplace is enabled from the testing environment,
 # The file has to be written before Codex starts.
-if [ -n "${PRIV_KEY}" ]; then
-  echo ${PRIV_KEY} > "private.key"
-  chmod 600 "private.key"
-  export CODEX_ETH_PRIVATE_KEY="private.key"
-  echo "Private key set"
-fi
+for key in PRIV_KEY ETH_PRIVATE_KEY; do
+  keyfile="private.key"
+  if [[ -n "${!key}" ]]; then
+    echo "${!key}" > "${keyfile}"
+    chmod 600 "${keyfile}"
+    export CODEX_ETH_PRIVATE_KEY="${keyfile}"
+    echo "Private key set"
+  fi
+done
 
 # Circuit downloader
 # cirdl [circuitPath] [rpcEndpoint] [marketplaceAddress]


### PR DESCRIPTION
This is a quick PR to add `ETH_PRIVATE_KEY` to the Docker entrypoint for variables names consistency.

During transition period we can use both, `PRIV_KEY` and `ETH_PRIVATE_KEY`, to the pass Ethereum private key.

After we will change all the code to use new variable, the old one will be removed.

