### PR TITLE
feat: expose underlying nim-ethers errors to logs

### DIFF
--- a/codex/contracts/clock.nim
+++ b/codex/contracts/clock.nim
@@ -1,5 +1,6 @@
 import std/times
 import pkg/ethers
+import pkg/questionable
 import pkg/chronos
 import pkg/stint
 import ../clock
@@ -45,7 +46,11 @@ method start*(clock: OnChainClock) {.async.} =
   if clock.started:
     return
 
-  proc onBlock(_: Block) =
+  proc onBlock(blckResult: ?!Block) =
+    if eventError =? blckResult.errorOption:
+      error "There was an error in block subscription", msg=eventError.msg
+      return
+
     # ignore block parameter; hardhat may call this with pending blocks
     asyncSpawn clock.update()
 

--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -277,7 +277,11 @@ method canReserveSlot*(
 method subscribeRequests*(market: OnChainMarket,
                          callback: OnRequest):
                         Future[MarketSubscription] {.async.} =
-  proc onEvent(event: StorageRequested) {.upraises:[].} =
+  proc onEvent(eventResult: ?!StorageRequested) {.upraises:[].} =
+    without event =? eventResult, eventErr:
+      error "There was an error in Request subscription", msg = eventErr.msg
+      return
+
     callback(event.requestId,
              event.ask,
              event.expiry)
@@ -289,7 +293,11 @@ method subscribeRequests*(market: OnChainMarket,
 method subscribeSlotFilled*(market: OnChainMarket,
                             callback: OnSlotFilled):
                            Future[MarketSubscription] {.async.} =
-  proc onEvent(event: SlotFilled) {.upraises:[].} =
+  proc onEvent(eventResult: ?!SlotFilled) {.upraises:[].} =
+    without event =? eventResult, eventErr:
+      error "There was an error in SlotFilled subscription", msg = eventErr.msg
+      return
+
     callback(event.requestId, event.slotIndex)
 
   convertEthersError:
@@ -311,7 +319,11 @@ method subscribeSlotFilled*(market: OnChainMarket,
 method subscribeSlotFreed*(market: OnChainMarket,
                            callback: OnSlotFreed):
                           Future[MarketSubscription] {.async.} =
-  proc onEvent(event: SlotFreed) {.upraises:[].} =
+  proc onEvent(eventResult: ?!SlotFreed) {.upraises:[].} =
+    without event =? eventResult, eventErr:
+      error "There was an error in SlotFreed subscription", msg = eventErr.msg
+      return
+
     callback(event.requestId, event.slotIndex)
 
   convertEthersError:
@@ -322,7 +334,11 @@ method subscribeSlotReservationsFull*(
   market: OnChainMarket,
   callback: OnSlotReservationsFull): Future[MarketSubscription] {.async.} =
 
-  proc onEvent(event: SlotReservationsFull) {.upraises:[].} =
+  proc onEvent(eventResult: ?!SlotReservationsFull) {.upraises:[].} =
+    without event =? eventResult, eventErr:
+      error "There was an error in SlotReservationsFull subscription", msg = eventErr.msg
+      return
+
     callback(event.requestId, event.slotIndex)
 
   convertEthersError:
@@ -332,7 +348,11 @@ method subscribeSlotReservationsFull*(
 method subscribeFulfillment(market: OnChainMarket,
                             callback: OnFulfillment):
                            Future[MarketSubscription] {.async.} =
-  proc onEvent(event: RequestFulfilled) {.upraises:[].} =
+  proc onEvent(eventResult: ?!RequestFulfilled) {.upraises:[].} =
+    without event =? eventResult, eventErr:
+      error "There was an error in RequestFulfillment subscription", msg = eventErr.msg
+      return
+
     callback(event.requestId)
 
   convertEthersError:
@@ -343,7 +363,11 @@ method subscribeFulfillment(market: OnChainMarket,
                             requestId: RequestId,
                             callback: OnFulfillment):
                            Future[MarketSubscription] {.async.} =
-  proc onEvent(event: RequestFulfilled) {.upraises:[].} =
+  proc onEvent(eventResult: ?!RequestFulfilled) {.upraises:[].} =
+    without event =? eventResult, eventErr:
+      error "There was an error in RequestFulfillment subscription", msg = eventErr.msg
+      return
+
     if event.requestId == requestId:
       callback(event.requestId)
 
@@ -354,7 +378,11 @@ method subscribeFulfillment(market: OnChainMarket,
 method subscribeRequestCancelled*(market: OnChainMarket,
                                   callback: OnRequestCancelled):
                                 Future[MarketSubscription] {.async.} =
-  proc onEvent(event: RequestCancelled) {.upraises:[].} =
+  proc onEvent(eventResult: ?!RequestCancelled) {.upraises:[].} =
+    without event =? eventResult, eventErr:
+      error "There was an error in RequestCancelled subscription", msg = eventErr.msg
+      return
+
     callback(event.requestId)
 
   convertEthersError:
@@ -365,7 +393,11 @@ method subscribeRequestCancelled*(market: OnChainMarket,
                                   requestId: RequestId,
                                   callback: OnRequestCancelled):
                                 Future[MarketSubscription] {.async.} =
-  proc onEvent(event: RequestCancelled) {.upraises:[].} =
+  proc onEvent(eventResult: ?!RequestCancelled) {.upraises:[].} =
+    without event =? eventResult, eventErr:
+      error "There was an error in RequestCancelled subscription", msg = eventErr.msg
+      return
+
     if event.requestId == requestId:
       callback(event.requestId)
 
@@ -376,7 +408,11 @@ method subscribeRequestCancelled*(market: OnChainMarket,
 method subscribeRequestFailed*(market: OnChainMarket,
                               callback: OnRequestFailed):
                             Future[MarketSubscription] {.async.} =
-  proc onEvent(event: RequestFailed) {.upraises:[]} =
+  proc onEvent(eventResult: ?!RequestFailed) {.upraises:[]} =
+    without event =? eventResult, eventErr:
+      error "There was an error in RequestFailed subscription", msg = eventErr.msg
+      return
+
     callback(event.requestId)
 
   convertEthersError:
@@ -387,7 +423,11 @@ method subscribeRequestFailed*(market: OnChainMarket,
                               requestId: RequestId,
                               callback: OnRequestFailed):
                             Future[MarketSubscription] {.async.} =
-  proc onEvent(event: RequestFailed) {.upraises:[]} =
+  proc onEvent(eventResult: ?!RequestFailed) {.upraises:[]} =
+    without event =? eventResult, eventErr:
+      error "There was an error in RequestFailed subscription", msg = eventErr.msg
+      return
+
     if event.requestId == requestId:
       callback(event.requestId)
 
@@ -398,7 +438,11 @@ method subscribeRequestFailed*(market: OnChainMarket,
 method subscribeProofSubmission*(market: OnChainMarket,
                                  callback: OnProofSubmitted):
                                 Future[MarketSubscription] {.async.} =
-  proc onEvent(event: ProofSubmitted) {.upraises: [].} =
+  proc onEvent(eventResult: ?!ProofSubmitted) {.upraises: [].} =
+    without event =? eventResult, eventErr:
+      error "There was an error in ProofSubmitted subscription", msg = eventErr.msg
+      return
+
     callback(event.id)
 
   convertEthersError:

--- a/tests/integration/testecbug.nim
+++ b/tests/integration/testecbug.nim
@@ -33,9 +33,9 @@ marketplacesuite "Bug #821 - node crashes during erasure coding":
     let cid = clientApi.upload(data).get
 
     var requestId = none RequestId
-    proc onStorageRequested(eventRes: ?!StorageRequested)=
-      if event =? eventRes:
-        requestId = event.requestId.some
+    proc onStorageRequested(eventResult: ?!StorageRequested)=
+      assert not eventResult.isErr
+      requestId = some (!eventResult).requestId
 
     let subscription = await marketplace.subscribe(StorageRequested, onStorageRequested)
 

--- a/tests/integration/testecbug.nim
+++ b/tests/integration/testecbug.nim
@@ -33,8 +33,9 @@ marketplacesuite "Bug #821 - node crashes during erasure coding":
     let cid = clientApi.upload(data).get
 
     var requestId = none RequestId
-    proc onStorageRequested(event: StorageRequested) {.raises:[].} =
-      requestId = event.requestId.some
+    proc onStorageRequested(eventRes: ?!StorageRequested)=
+      if event =? eventRes:
+        requestId = event.requestId.some
 
     let subscription = await marketplace.subscribe(StorageRequested, onStorageRequested)
 

--- a/tests/integration/testmarketplace.nim
+++ b/tests/integration/testmarketplace.nim
@@ -135,8 +135,9 @@ marketplacesuite "Marketplace payouts":
     let cid = clientApi.upload(data).get
 
     var slotIdxFilled = none UInt256
-    proc onSlotFilled(event: SlotFilled) =
-      slotIdxFilled = some event.slotIndex
+    proc onSlotFilled(eventRes: ?!SlotFilled) =
+      if event =? eventRes:
+        slotIdxFilled = some event.slotIndex
 
     let subscription = await marketplace.subscribe(SlotFilled, onSlotFilled)
 

--- a/tests/integration/testmarketplace.nim
+++ b/tests/integration/testmarketplace.nim
@@ -135,9 +135,9 @@ marketplacesuite "Marketplace payouts":
     let cid = clientApi.upload(data).get
 
     var slotIdxFilled = none UInt256
-    proc onSlotFilled(eventRes: ?!SlotFilled) =
-      if event =? eventRes:
-        slotIdxFilled = some event.slotIndex
+    proc onSlotFilled(eventResult: ?!SlotFilled) =
+      assert not eventResult.isErr
+      slotIdxFilled = some (!eventResult).slotIndex
 
     let subscription = await marketplace.subscribe(SlotFilled, onSlotFilled)
 

--- a/tests/integration/testproofs.nim
+++ b/tests/integration/testproofs.nim
@@ -1,4 +1,5 @@
 from std/times import inMilliseconds
+import pkg/questionable
 import pkg/codex/logutils
 import pkg/stew/byteutils
 import ../contracts/time
@@ -176,7 +177,10 @@ marketplacesuite "Simulate invalid proofs":
     let requestId = client0.requestId(purchaseId).get
 
     var slotWasFilled = false
-    proc onSlotFilled(event: SlotFilled) =
+    proc onSlotFilled(eventResult: ?!SlotFilled) =
+      assert not eventResult.isErr
+      let event = !eventResult
+
       if event.requestId == requestId:
         slotWasFilled = true
     let filledSubscription = await marketplace.subscribe(SlotFilled, onSlotFilled)

--- a/tests/integration/testproofs.nim
+++ b/tests/integration/testproofs.nim
@@ -54,8 +54,8 @@ marketplacesuite "Hosts submit regular proofs":
     check eventually(client0.purchaseStateIs(purchaseId, "started"), timeout = expiry.int * 1000)
 
     var proofWasSubmitted = false
-    proc onProofSubmitted(event: ProofSubmitted) =
-      proofWasSubmitted = true
+    proc onProofSubmitted(event: ?!ProofSubmitted) =
+      proofWasSubmitted = event.isOk
 
     let subscription = await marketplace.subscribe(ProofSubmitted, onProofSubmitted)
 
@@ -120,8 +120,8 @@ marketplacesuite "Simulate invalid proofs":
     check eventually(client0.purchaseStateIs(purchaseId, "started"), timeout = expiry.int * 1000)
 
     var slotWasFreed = false
-    proc onSlotFreed(event: SlotFreed) =
-      if event.requestId == requestId:
+    proc onSlotFreed(event: ?!SlotFreed) =
+      if event.isOk and event.value.requestId == requestId:
         slotWasFreed = true
 
     let subscription = await marketplace.subscribe(SlotFreed, onSlotFreed)
@@ -185,8 +185,8 @@ marketplacesuite "Simulate invalid proofs":
     check eventually(slotWasFilled, timeout = expiry.int * 1000)
 
     var slotWasFreed = false
-    proc onSlotFreed(event: SlotFreed) =
-      if event.requestId == requestId:
+    proc onSlotFreed(event: ?!SlotFreed) =
+      if event.isOk and event.value.requestId == requestId:
         slotWasFreed = true
     let freedSubscription = await marketplace.subscribe(SlotFreed, onSlotFreed)
 


### PR DESCRIPTION
Brings in a version of nim-ethers where subscription callbacks are returned Result, which will give an error when there is some underlying problem in the subscription mechanisms. This PR exposes these errors through logging.