### PR TITLE
ci: install rust 1.7.9 as required by packages

### DIFF
--- a/.github/actions/nimbus-build-system/action.yml
+++ b/.github/actions/nimbus-build-system/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: "version-1-6"
   rust_version:
     description: "Rust version"
-    default: "1.78.0"
+    default: "1.79.0"
   shell:
     description: "Shell to run commands in"
     default: "bash --noprofile --norc -e -o pipefail"


### PR DESCRIPTION
This pR is to fix Linux builds we mentioned in the https://github.com/codex-storage/nim-codex/pull/993#issuecomment-2490242484.