### PR TITLE
nix: make derivation and update shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ifeq ($(OS),Windows_NT)
         ARCH = arm64
     endif
 else
-    UNAME_P := $(shell uname -p)
+    UNAME_P := $(shell uname -m)
     ifneq ($(filter $(UNAME_P), i686 i386 x86_64),)
         ARCH = x86_64
     endif

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,40 @@
 {
   "nodes": {
+    "circom-compat": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1732627240,
+        "narHash": "sha256-GvJTiBWBv799i5ZCCc4gF86bnQY/nZvx0vCPi1+OPD4=",
+        "owner": "codex-storage",
+        "repo": "circom-compat-ffi",
+        "rev": "297c46fdc7d8a8fd53c8076b0be77334e4a54447",
+        "type": "github"
+      },
+      "original": {
+        "owner": "codex-storage",
+        "repo": "circom-compat-ffi",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1731386116,
+        "narHash": "sha256-lKA770aUmjPHdTaJWnP3yQ9OI1TigenUqVC3wweqZuI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "689fed12a013f56d4c4d3f612489634267d86529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1729449015,
         "narHash": "sha256-Gf04dXB0n4q0A9G5nTGH3zuMGr6jtJppqdeljxua1fo=",
@@ -18,7 +52,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "circom-compat": "circom-compat",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,29 @@
+# Usage
+
+## Shell
+
+A development shell can be started using:
+```sh
+nix develop
+```
+
+## Building
+
+To build a Codex you can use:
+```sh
+nix build '.?submodules=1#codex'
+```
+The `?submodules=1` part should eventually not be necessary.
+For more details see:
+https://github.com/NixOS/nix/issues/4423
+
+It can be also done without even cloning the repo:
+```sh
+nix build 'github:codex-storage/nim-codex?submodules=1'
+```
+
+## Running
+
+```sh
+nix run 'github:codex-storage/nim-codex?submodules=1'
+```

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,84 @@
+{
+  pkgs ? import <nixpkgs> { },
+  src ? ../.,
+  targets ? ["all"],
+  # Options: 0,1,2
+  verbosity ? 0,
+  # Use system Nim compiler instead of building it with nimbus-build-system
+  useSystemNim ? true,
+  commit ? builtins.substring 0 7 (src.rev or "dirty"),
+  # These are the only platforms tested in CI and considered stable.
+  stableSystems ? [
+    "x86_64-linux" "aarch64-linux"
+    "x86_64-darwin" "aarch64-darwin"
+  ],
+  circomCompatPkg ? (
+    builtins.getFlake "github:codex-storage/circom-compat-ffi"
+  ).packages.${builtins.currentSystem}.default
+}:
+
+let
+  inherit (pkgs) stdenv lib writeScriptBin callPackage;
+  
+  revision = lib.substring 0 8 (src.rev or "dirty");
+
+  tools = callPackage ./tools.nix {};
+in pkgs.gcc11Stdenv.mkDerivation rec {
+  
+  pname = "codex";
+
+  version = "${tools.findKeyValue "version = \"([0-9]+\.[0-9]+\.[0-9]+)\"" ../codex.nimble}-${revision}";
+  
+  inherit src;
+
+  # Dependencies that should exist in the runtime environment.
+  buildInputs = with pkgs; [
+    openssl
+    gmp
+  ];
+
+  # Dependencies that should only exist in the build environment.
+  nativeBuildInputs = let
+    # Fix for Nim compiler calling 'git rev-parse' and 'lsb_release'.
+    fakeGit = writeScriptBin "git" "echo ${version}";
+    # Fix for the nim-circom-compat-ffi package that is built with cargo.
+    fakeCargo = writeScriptBin "cargo" "echo ${version}";
+  in
+    with pkgs; [
+      cmake
+      pkg-config
+      nimble
+      which
+      nim-unwrapped-1
+      lsb-release
+      circomCompatPkg
+      fakeGit
+      fakeCargo
+  ];
+
+  # Disable CPU optmizations that make binary not portable.
+  NIMFLAGS = "-d:disableMarchNative -d:git_revision_override=${revision}";
+  # Avoid Nim cache permission errors.
+  XDG_CACHE_HOME = "/tmp";
+
+  makeFlags = targets ++ [
+    "V=${toString verbosity}"
+    "USE_SYSTEM_NIM=${if useSystemNim then "1" else "0"}"
+  ];
+
+  configurePhase = ''
+    patchShebangs . > /dev/null
+  '';
+ 
+  installPhase = ''
+    mkdir -p $out/bin
+    cp build/codex $out/bin/
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Codex storage system";
+    homepage = "https://github.com/codex-storage/nim-codex";
+    license = licenses.mit;
+    platforms = stableSystems;
+  };
+}

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+
+  inherit (pkgs.lib) fileContents last splitString flatten remove;
+  inherit (builtins) map match;
+in {
+  findKeyValue = regex: sourceFile:
+    let
+      linesFrom = file: splitString "\n" (fileContents file);
+      matching = regex: lines: map (line: match regex line) lines;
+      extractMatch = matches: last (flatten (remove null matches));
+    in
+      extractMatch (matching regex (linesFrom sourceFile));
+}


### PR DESCRIPTION
Create a structure for nix files. Add the derivation file which is using system Nim to compile Codex. Move shell definition to a specific file.

Referenced issue: https://github.com/codex-storage/nim-codex/issues/940