### PR TITLE
Enables stacktrace in docker images

### DIFF
--- a/docker/codex.Dockerfile
+++ b/docker/codex.Dockerfile
@@ -5,6 +5,7 @@ ARG RUST_VERSION=${RUST_VERSION:-1.79.0}
 ARG BUILD_HOME=/src
 ARG MAKE_PARALLEL=${MAKE_PARALLEL:-4}
 ARG NIMFLAGS="${NIMFLAGS:-"-d:disableMarchNative"}"
+ARG USE_LIBBACKTRACE=${USE_LIBBACKTRACE:-1}
 ARG APP_HOME=/codex
 ARG NAT_IP_AUTO=${NAT_IP_AUTO:-false}
 
@@ -14,7 +15,7 @@ ARG RUST_VERSION
 ARG BUILD_HOME
 ARG MAKE_PARALLEL
 ARG NIMFLAGS
-ARG USE_LIBBACKTRACE=1
+ARG USE_LIBBACKTRACE
 
 RUN apt-get update && apt-get install -y git cmake curl make bash lcov build-essential
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --default-toolchain=${RUST_VERSION} -y

--- a/docker/codex.Dockerfile
+++ b/docker/codex.Dockerfile
@@ -14,6 +14,7 @@ ARG RUST_VERSION
 ARG BUILD_HOME
 ARG MAKE_PARALLEL
 ARG NIMFLAGS
+ARG USE_LIBBACKTRACE=1
 
 RUN apt-get update && apt-get install -y git cmake curl make bash lcov build-essential
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --default-toolchain=${RUST_VERSION} -y


### PR DESCRIPTION
We've seen crashes without stack traces from cluster deployments. This should help with debugging.
