### PR TITLE
Send pluralized wantBlock messages

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -127,7 +127,7 @@ proc stop*(b: BlockExcEngine) {.async.} =
 
   trace "NetworkStore stopped"
 
-proc `$`*(blkAddrs: seq[BlockAddress]): string =
+proc formatAddrs(blkAddrs: seq[BlockAddress]): string =
   result &= "["
   for addr in blkAddrs:
     result &= ($addr & " ")
@@ -142,7 +142,7 @@ proc sendWantHave(
   for p in peers:
     if p notin excluded:
       let toAsk = addresses.filterIt(it notin p.peerHave)
-      trace "Sending wantHave request", toAsk, peer = p.id
+      trace "Sending wantHave request", toAsk = formatAddrs(toAsk), peer = p.id
       await b.network.request.sendWantList(
         p.id,
         toAsk,
@@ -152,7 +152,7 @@ proc sendWantBlock(
   b: BlockExcEngine,
   addresses: seq[BlockAddress],
   blockPeer: BlockExcPeerCtx): Future[void] {.async.} =
-  trace "Sending wantBlock request to", addresses, peer = blockPeer.id
+  trace "Sending wantBlock request to", addrs = formatAddrs(addresses), peer = blockPeer.id
   await b.network.request.sendWantList(
     blockPeer.id,
     addresses,

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -127,28 +127,35 @@ proc stop*(b: BlockExcEngine) {.async.} =
 
   trace "NetworkStore stopped"
 
+proc `$`*(blkAddrs: seq[BlockAddress]): string =
+  result &= "["
+  for addr in blkAddrs:
+    result &= ($addr & " ")
+  result &= "]"
+
 proc sendWantHave(
   b: BlockExcEngine,
-  address: BlockAddress, # pluralize this entire call chain, please
+  addresses: seq[BlockAddress],
   excluded: seq[BlockExcPeerCtx],
   peers: seq[BlockExcPeerCtx]): Future[void] {.async.} =
-  trace "Sending wantHave request to peers", address
+  trace "Sending wantHave request to peers", numBlkAddrs = addresses.len, numPeers = peers.len - excluded.len
   for p in peers:
     if p notin excluded:
-      if address notin p.peerHave:
-        await b.network.request.sendWantList(
-          p.id,
-          @[address],
-          wantType = WantType.WantHave) # we only want to know if the peer has the block
+      let toAsk = addresses.filterIt(it notin p.peerHave)
+      trace "Sending wantHave request", toAsk, peer = p.id
+      await b.network.request.sendWantList(
+        p.id,
+        toAsk,
+        wantType = WantType.WantHave)
 
 proc sendWantBlock(
   b: BlockExcEngine,
-  address: BlockAddress, # pluralize this entire call chain, please
+  addresses: seq[BlockAddress],
   blockPeer: BlockExcPeerCtx): Future[void] {.async.} =
-  trace "Sending wantBlock request to", peer = blockPeer.id, address
+  trace "Sending wantBlock request to", addresses, peer = blockPeer.id
   await b.network.request.sendWantList(
     blockPeer.id,
-    @[address],
+    addresses,
     wantType = WantType.WantBlock) # we want this remote to send us a block
 
 proc monitorBlockHandle(
@@ -197,9 +204,10 @@ proc requestBlock*(
     if peer =? maybePeer:
       asyncSpawn b.monitorBlockHandle(blockFuture, address, peer.id)
       b.pendingBlocks.setInFlight(address)
-      await b.sendWantBlock(address, peer)
+      # TODO: Send more block addresses if at all sensible.
+      await b.sendWantBlock(@[address], peer)
       codex_block_exchange_want_block_lists_sent.inc()
-      await b.sendWantHave(address, @[peer], toSeq(b.peers))
+      await b.sendWantHave(@[address], @[peer], toSeq(b.peers))
       codex_block_exchange_want_have_lists_sent.inc()
 
   # Don't let timeouts bubble up. We can't be too broad here or we break
@@ -246,8 +254,7 @@ proc blockPresenceHandler*(
 
   if wantCids.len > 0:
     trace "Peer has blocks in our wantList", peer, wantCount = wantCids.len
-    discard await allFinished(
-      wantCids.mapIt(b.sendWantBlock(it, peerCtx)))
+    await b.sendWantBlock(wantCids, peerCtx)
 
   # if none of the connected peers report our wants in their have list,
   # fire up discovery

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -127,12 +127,6 @@ proc stop*(b: BlockExcEngine) {.async.} =
 
   trace "NetworkStore stopped"
 
-proc formatAddrs(blkAddrs: seq[BlockAddress]): string =
-  result &= "["
-  for addr in blkAddrs:
-    result &= ($addr & " ")
-  result &= "]"
-
 proc sendWantHave(
   b: BlockExcEngine,
   addresses: seq[BlockAddress],
@@ -142,7 +136,7 @@ proc sendWantHave(
   for p in peers:
     if p notin excluded:
       let toAsk = addresses.filterIt(it notin p.peerHave)
-      trace "Sending wantHave request", toAsk = formatAddrs(toAsk), peer = p.id
+      trace "Sending wantHave request", toAsk, peer = p.id
       await b.network.request.sendWantList(
         p.id,
         toAsk,
@@ -152,7 +146,7 @@ proc sendWantBlock(
   b: BlockExcEngine,
   addresses: seq[BlockAddress],
   blockPeer: BlockExcPeerCtx): Future[void] {.async.} =
-  trace "Sending wantBlock request to", addrs = formatAddrs(addresses), peer = blockPeer.id
+  trace "Sending wantBlock request to", addresses, peer = blockPeer.id
   await b.network.request.sendWantList(
     blockPeer.id,
     addresses,

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -132,7 +132,6 @@ proc sendWantHave(
   addresses: seq[BlockAddress],
   excluded: seq[BlockExcPeerCtx],
   peers: seq[BlockExcPeerCtx]): Future[void] {.async.} =
-  trace "Sending wantHave request to peers", numBlkAddrs = addresses.len, numPeers = peers.len - excluded.len
   for p in peers:
     if p notin excluded:
       let toAsk = addresses.filterIt(it notin p.peerHave)

--- a/codex/logutils.nim
+++ b/codex/logutils.nim
@@ -98,7 +98,6 @@ import pkg/questionable/results
 import ./utils/json except formatIt # TODO: remove exception?
 import pkg/stew/byteutils
 import pkg/stint
-import pkg/upraises
 
 export byteutils
 export chronicles except toJson, formatIt, `%`
@@ -107,7 +106,6 @@ export sequtils
 export json except formatIt
 export strutils
 export sugar
-export upraises
 export results
 
 func shortLog*(long: string, ellipses = "*", start = 3, stop = 6): string =
@@ -184,12 +182,12 @@ template formatIt*(format: LogFormat, T: typedesc, body: untyped) =
       let v = opts.map(opt => opt.formatJsonOption)
       setProperty(r, key, json.`%`(v))
 
-    proc setProperty*(r: var JsonRecord, key: string, val: seq[T]) {.upraises:[ValueError, IOError].} =
+    proc setProperty*(r: var JsonRecord, key: string, val: seq[T]) {.raises:[ValueError, IOError].} =
       var it {.inject, used.}: T
       let v = val.map(it => body)
       setProperty(r, key, json.`%`(v))
 
-    proc setProperty*(r: var JsonRecord, key: string, val: T) {.upraises:[ValueError, IOError].} =
+    proc setProperty*(r: var JsonRecord, key: string, val: T) {.raises:[ValueError, IOError].} =
       var it {.inject, used.}: T = val
       let v = body
       setProperty(r, key, json.`%`(v))
@@ -220,12 +218,12 @@ template formatIt*(format: LogFormat, T: typedesc, body: untyped) =
       let v = opts.map(opt => opt.formatTextLineOption)
       setProperty(r, key, v.formatTextLineSeq)
 
-    proc setProperty*(r: var TextLineRecord, key: string, val: seq[T]) {.upraises:[ValueError, IOError].} =
+    proc setProperty*(r: var TextLineRecord, key: string, val: seq[T]) {.raises:[ValueError, IOError].} =
       var it {.inject, used.}: T
       let v = val.map(it => body)
       setProperty(r, key, v.formatTextLineSeq)
 
-    proc setProperty*(r: var TextLineRecord, key: string, val: T) {.upraises:[ValueError, IOError].} =
+    proc setProperty*(r: var TextLineRecord, key: string, val: T) {.raises:[ValueError, IOError].} =
       var it {.inject, used.}: T = val
       let v = body
       setProperty(r, key, v)

--- a/codex/logutils.nim
+++ b/codex/logutils.nim
@@ -184,7 +184,7 @@ template formatIt*(format: LogFormat, T: typedesc, body: untyped) =
       let v = opts.map(opt => opt.formatJsonOption)
       setProperty(r, key, json.`%`(v))
 
-    proc setProperty*(r: var JsonRecord, key: string, val: seq[T]) =
+    proc setProperty*(r: var JsonRecord, key: string, val: seq[T]) {.upraises:[ValueError, IOError].} =
       var it {.inject, used.}: T
       let v = val.map(it => body)
       setProperty(r, key, json.`%`(v))

--- a/codex/logutils.nim
+++ b/codex/logutils.nim
@@ -220,7 +220,7 @@ template formatIt*(format: LogFormat, T: typedesc, body: untyped) =
       let v = opts.map(opt => opt.formatTextLineOption)
       setProperty(r, key, v.formatTextLineSeq)
 
-    proc setProperty*(r: var TextLineRecord, key: string, val: seq[T]) =
+    proc setProperty*(r: var TextLineRecord, key: string, val: seq[T]) {.upraises:[ValueError, IOError].} =
       var it {.inject, used.}: T
       let v = val.map(it => body)
       setProperty(r, key, v.formatTextLineSeq)


### PR DESCRIPTION
Previously:
```
    discard await allFinished(
      wantCids.mapIt(b.sendWantBlock(it, peerCtx)))
```

This gives 1 wantBlock message per entry in wantCid blockAddress. But, message format supports multiple addresses.

New:
```
    await b.sendWantBlock(wantCids, peerCtx)
```

Todo, not in this PR: initial calls to send wantHave and wantBlock messages can be pluralized as well.
