### PR TITLE
Run release tests for docker images

### DIFF
--- a/.github/workflows/docker-dist-tests.yml
+++ b/.github/workflows/docker-dist-tests.yml
@@ -17,17 +17,38 @@ on:
       - '!docker/codex.Dockerfile'
       - '!docker/docker-entrypoint.sh'
   workflow_dispatch:
+    inputs:
+      run_release_tests:
+        description: Run Release tests
+        required: false
+        type: boolean
+        default: false
+
+
+env:
+  run_release_tests: false
 
 
 jobs:
+  compute-inputs:
+    name: Compute inputs
+    runs-on: ubuntu-latest
+    outputs:
+      run_release_tests: ${{ steps.compute.outputs.run_release_tests }}
+    steps:
+      - name: Compute inputs
+        id: compute
+        run: |
+          [[ -n "${{ inputs.run_release_tests }}" ]] && echo "run_release_tests=${{ inputs.run_release_tests }}" >>"$GITHUB_OUTPUT" || echo "run_release_tests=${{ env.run_release_tests }}" >>"$GITHUB_OUTPUT"
+
   build-and-push:
     name: Build and Push
+    needs: compute-inputs
     uses: ./.github/workflows/docker-reusable.yml
     with:
       nimflags: '-d:disableMarchNative -d:codex_enable_api_debug_peers=true -d:codex_enable_proof_failures=true -d:codex_enable_log_counter=true -d:verify_circuit=true'
       nat_ip_auto: true
       tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
       tag_suffix: dist-tests
-      continuous_tests_list: PeersTest HoldMyBeerTest
-      continuous_tests_duration: 12h
+      run_release_tests: ${{ needs.compute-inputs.outputs.run_release_tests }}
     secrets: inherit

--- a/.github/workflows/docker-dist-tests.yml
+++ b/.github/workflows/docker-dist-tests.yml
@@ -25,30 +25,14 @@ on:
         default: false
 
 
-env:
-  run_release_tests: false
-
-
 jobs:
-  compute-inputs:
-    name: Compute inputs
-    runs-on: ubuntu-latest
-    outputs:
-      run_release_tests: ${{ steps.compute.outputs.run_release_tests }}
-    steps:
-      - name: Compute inputs
-        id: compute
-        run: |
-          [[ -n "${{ inputs.run_release_tests }}" ]] && echo "run_release_tests=${{ inputs.run_release_tests }}" >>"$GITHUB_OUTPUT" || echo "run_release_tests=${{ env.run_release_tests }}" >>"$GITHUB_OUTPUT"
-
   build-and-push:
     name: Build and Push
-    needs: compute-inputs
     uses: ./.github/workflows/docker-reusable.yml
     with:
       nimflags: '-d:disableMarchNative -d:codex_enable_api_debug_peers=true -d:codex_enable_proof_failures=true -d:codex_enable_log_counter=true -d:verify_circuit=true'
       nat_ip_auto: true
       tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
       tag_suffix: dist-tests
-      run_release_tests: ${{ needs.compute-inputs.outputs.run_release_tests }}
+      run_release_tests: ${{ inputs.run_release_tests }}
     secrets: inherit

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -54,6 +54,11 @@ on:
         description: Continuous Tests duration
         required: false
         type: string
+      run_release_tests:
+        description: Run Release tests
+        required: false
+        type: string
+        default: false
 
 
 env:
@@ -67,7 +72,7 @@ env:
   TAG_SHA: ${{ inputs.tag_sha }}
   TAG_SUFFIX: ${{ inputs.tag_suffix }}
   # Tests
-  CONTINUOUS_TESTS_SOURCE: codex-storage/cs-codex-dist-tests
+  TESTS_SOURCE: codex-storage/cs-codex-dist-tests
   CONTINUOUS_TESTS_BRANCH: master
   CONTINUOUS_TESTS_LIST: ${{ inputs.continuous_tests_list }}
   CONTINUOUS_TESTS_DURATION: ${{ inputs.continuous_tests_duration }}
@@ -219,49 +224,71 @@ jobs:
           docker buildx imagetools inspect ${{ env.DOCKER_REPO }}:${{ steps.meta.outputs.version }}
 
 
-  # Compute Continuous Tests inputs
+  # Compute Tests inputs
   compute-tests-inputs:
-    name: Compute Continuous Tests list
-    if: ${{ inputs.continuous_tests_list != '' && github.ref_name == github.event.repository.default_branch }}
+    name: Compute Tests inputs
+    if: ${{ inputs.continuous_tests_list != '' || inputs.run_release_tests == 'true' }}
     runs-on: ubuntu-latest
     needs: publish
     outputs:
-      source: ${{ steps.compute.outputs.source }}
-      branch: ${{ steps.compute.outputs.branch }}
       codexdockerimage: ${{ steps.compute.outputs.codexdockerimage }}
-      nameprefix: ${{ steps.compute.outputs.nameprefix }}
-      continuous_tests_list: ${{ steps.compute.outputs.continuous_tests_list }}
-      continuous_tests_duration: ${{ steps.compute.outputs.continuous_tests_duration }}
-      continuous_tests_workflow: ${{ steps.compute.outputs.continuous_tests_workflow }}
-      workflow_source: ${{ steps.compute.outputs.workflow_source }}
+      workflow_source: ${{ env.TESTS_SOURCE }}
     steps:
-      - name: Compute Continuous Tests list
+      - name: Compute Tests inputs
         id: compute
         run: |
-          echo "source=${{ format('{0}/{1}', github.server_url, env.CONTINUOUS_TESTS_SOURCE) }}" >> "$GITHUB_OUTPUT"
-          echo "branch=${{ env.CONTINUOUS_TESTS_BRANCH }}" >> "$GITHUB_OUTPUT"
           echo "codexdockerimage=${{ inputs.docker_repo }}:${{ needs.publish.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+
+  # Compute Continuous Tests inputs
+  compute-continuous-tests-inputs:
+    name: Compute Continuous Tests inputs
+    if: ${{ inputs.continuous_tests_list != '' && github.ref_name == github.event.repository.default_branch }}
+    runs-on: ubuntu-latest
+    needs: compute-tests-inputs
+    outputs:
+      source: ${{ steps.compute.outputs.source }}
+      branch: ${{ env.CONTINUOUS_TESTS_BRANCH }}
+      nameprefix: ${{ steps.compute.outputs.nameprefix }}
+      continuous_tests_list: ${{ steps.compute.outputs.continuous_tests_list }}
+      continuous_tests_duration: ${{ env.CONTINUOUS_TESTS_DURATION }}
+      continuous_tests_workflow: ${{ steps.compute.outputs.continuous_tests_workflow }}
+    steps:
+      - name: Compute Continuous Tests inputs
+        id: compute
+        run: |
+          echo "source=${{ format('{0}/{1}', github.server_url, env.TESTS_SOURCE) }}" >> "$GITHUB_OUTPUT"
           echo "nameprefix=$(awk '{ print tolower($0) }' <<< ${{ env.CONTINUOUS_TESTS_NAMEPREFIX }})" >> "$GITHUB_OUTPUT"
           echo "continuous_tests_list=$(jq -cR 'split(" ")' <<< '${{ env.CONTINUOUS_TESTS_LIST }}')" >> "$GITHUB_OUTPUT"
-          echo "continuous_tests_duration=${{ env.CONTINUOUS_TESTS_DURATION }}" >> "$GITHUB_OUTPUT"
-          echo "workflow_source=${{ env.CONTINUOUS_TESTS_SOURCE }}" >> "$GITHUB_OUTPUT"
 
 
   # Run Continuous Tests
-  run-tests:
+  run-continuous-tests:
     name: Run Continuous Tests
-    needs: [publish, compute-tests-inputs]
+    needs: [compute-tests-inputs, compute-continuous-tests-inputs]
     strategy:
       max-parallel: 1
       matrix:
-        tests: ${{ fromJSON(needs.compute-tests-inputs.outputs.continuous_tests_list) }}
+        tests: ${{ fromJSON(needs.compute-continuous-tests-inputs.outputs.continuous_tests_list) }}
     uses: codex-storage/cs-codex-dist-tests/.github/workflows/run-continuous-tests.yaml@master
     with:
-      source: ${{ needs.compute-tests-inputs.outputs.source }}
-      branch: ${{ needs.compute-tests-inputs.outputs.branch }}
+      source: ${{ needs.compute-continuous-tests-inputs.outputs.source }}
+      branch: ${{ needs.compute-continuous-tests-inputs.outputs.branch }}
       codexdockerimage: ${{ needs.compute-tests-inputs.outputs.codexdockerimage }}
-      nameprefix: ${{ needs.compute-tests-inputs.outputs.nameprefix }}-${{ matrix.tests }}-${{ needs.compute-tests-inputs.outputs.continuous_tests_duration }}
+      nameprefix: ${{ needs.compute-continuous-tests-inputs.outputs.nameprefix }}-${{ matrix.tests }}-${{ needs.compute-continuous-tests-inputs.outputs.continuous_tests_duration }}
       tests_filter: ${{ matrix.tests }}
       tests_target_duration: ${{ needs.compute-tests-inputs.outputs.continuous_tests_duration }}
+      workflow_source: ${{ needs.compute-tests-inputs.outputs.workflow_source }}
+    secrets: inherit
+
+
+  # Run Release Tests
+  run-release-tests:
+    name: Run Release Tests
+    needs: [compute-tests-inputs]
+    if: ${{ inputs.run_release_tests == 'true' }}
+    uses: codex-storage/cs-codex-dist-tests/.github/workflows/run-release-tests.yaml@master
+    with:
+      codexdockerimage: ${{ needs.compute-tests-inputs.outputs.codexdockerimage }}
       workflow_source: ${{ needs.compute-tests-inputs.outputs.workflow_source }}
     secrets: inherit

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -73,7 +73,7 @@ env:
   TAG_SUFFIX: ${{ inputs.tag_suffix }}
   # Tests
   TESTS_SOURCE: codex-storage/cs-codex-dist-tests
-  CONTINUOUS_TESTS_BRANCH: master
+  TESTS_BRANCH: master
   CONTINUOUS_TESTS_LIST: ${{ inputs.continuous_tests_list }}
   CONTINUOUS_TESTS_DURATION: ${{ inputs.continuous_tests_duration }}
   CONTINUOUS_TESTS_NAMEPREFIX: c-tests-ci
@@ -231,12 +231,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish
     outputs:
-      codexdockerimage: ${{ steps.compute.outputs.codexdockerimage }}
+      source: ${{ steps.compute.outputs.source }}
+      branch: ${{ env.TESTS_BRANCH }}
       workflow_source: ${{ env.TESTS_SOURCE }}
+      codexdockerimage: ${{ steps.compute.outputs.codexdockerimage }}
     steps:
       - name: Compute Tests inputs
         id: compute
         run: |
+          echo "source=${{ format('{0}/{1}', github.server_url, env.TESTS_SOURCE) }}" >> "$GITHUB_OUTPUT"
           echo "codexdockerimage=${{ inputs.docker_repo }}:${{ needs.publish.outputs.version }}" >> "$GITHUB_OUTPUT"
 
 
@@ -247,8 +250,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: compute-tests-inputs
     outputs:
-      source: ${{ steps.compute.outputs.source }}
-      branch: ${{ env.CONTINUOUS_TESTS_BRANCH }}
       nameprefix: ${{ steps.compute.outputs.nameprefix }}
       continuous_tests_list: ${{ steps.compute.outputs.continuous_tests_list }}
       continuous_tests_duration: ${{ env.CONTINUOUS_TESTS_DURATION }}
@@ -257,7 +258,6 @@ jobs:
       - name: Compute Continuous Tests inputs
         id: compute
         run: |
-          echo "source=${{ format('{0}/{1}', github.server_url, env.TESTS_SOURCE) }}" >> "$GITHUB_OUTPUT"
           echo "nameprefix=$(awk '{ print tolower($0) }' <<< ${{ env.CONTINUOUS_TESTS_NAMEPREFIX }})" >> "$GITHUB_OUTPUT"
           echo "continuous_tests_list=$(jq -cR 'split(" ")' <<< '${{ env.CONTINUOUS_TESTS_LIST }}')" >> "$GITHUB_OUTPUT"
 
@@ -272,8 +272,8 @@ jobs:
         tests: ${{ fromJSON(needs.compute-continuous-tests-inputs.outputs.continuous_tests_list) }}
     uses: codex-storage/cs-codex-dist-tests/.github/workflows/run-continuous-tests.yaml@master
     with:
-      source: ${{ needs.compute-continuous-tests-inputs.outputs.source }}
-      branch: ${{ needs.compute-continuous-tests-inputs.outputs.branch }}
+      source: ${{ needs.compute-tests-inputs.outputs.source }}
+      branch: ${{ needs.compute-tests-inputs.outputs.branch }}
       codexdockerimage: ${{ needs.compute-tests-inputs.outputs.codexdockerimage }}
       nameprefix: ${{ needs.compute-continuous-tests-inputs.outputs.nameprefix }}-${{ matrix.tests }}-${{ needs.compute-continuous-tests-inputs.outputs.continuous_tests_duration }}
       tests_filter: ${{ matrix.tests }}
@@ -289,6 +289,8 @@ jobs:
     if: ${{ inputs.run_release_tests == 'true' }}
     uses: codex-storage/cs-codex-dist-tests/.github/workflows/run-release-tests.yaml@master
     with:
+      source: ${{ needs.compute-tests-inputs.outputs.source }}
+      branch: ${{ needs.compute-tests-inputs.outputs.branch }}
       codexdockerimage: ${{ needs.compute-tests-inputs.outputs.codexdockerimage }}
       workflow_source: ${{ needs.compute-tests-inputs.outputs.workflow_source }}
     secrets: inherit

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -98,7 +98,7 @@ jobs:
           - target:
               os: linux
               arch: arm64
-            builder: buildjet-4vcpu-ubuntu-2204-arm
+            builder: buildjet-8vcpu-ubuntu-2204-arm
 
     name: Build ${{ matrix.target.os }}/${{ matrix.target.arch }}
     runs-on: ${{ matrix.builder }}


### PR DESCRIPTION
This is a https://github.com/codex-storage/cs-codex-dist-tests/issues/108 follow up and it would be usefully to simplify release tests run via a "true" single button.

PR add an option to the [Docker - Dist-Tests](https://github.com/codex-storage/nim-codex/actions/workflows/docker-dist-tests.yml) workflow in nim-codex repository to be able to run release tests from [cs-codex-dist-tests](https://github.com/codex-storage/cs-codex-dist-tests) repository as a part of the Docker images build process.

<img width="329" alt="Screenshot 2024-12-03 at 20 23 03" src="https://github.com/user-attachments/assets/df288a3d-455c-44ab-9f22-74aa3e254866">
