### PR TITLE
Fix sending of WantBlocks messages and tracking of peerWants

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -412,8 +412,15 @@ proc wantListHandler*(
       if not e.cancel:
         peerCtx.peerWants.add(e)
 
+      # Important TODO! (See https://github.com/codex-storage/nim-codex/pull/1019#issuecomment-2525089803 )
+      # The if type==WantHave (below) is NOT nested behind the if not cancel (above) on purpose!
+      # This means we send presence-lists in response to cancel messages.
+      # Not doing so will degrade the performance by more than an order of magnitude.
+      # TODO: Investigate WHY the presence list has such a performance impact.
+      # (Sending a presence-list in response to a cancel is not according to spec and should be removed
+      # once the performance impact mystery is understood and solved.)
       if e.wantType == WantType.WantHave:
-        # does this happen for cancels?!
+        # Respond to wantHaves immediately.
         let
           have = await e.address in b.localStore
           price = @(

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -240,7 +240,7 @@ proc blockPresenceHandler*(
     )
 
   if wantCids.len > 0:
-    trace "Peer has blocks in our wantList", peer, wantCount = wantCids.len
+    trace "Peer has blocks in our wantList", peer, wants = wantCids
     await b.sendWantBlock(wantCids, peerCtx)
 
   # if none of the connected peers report our wants in their have list,
@@ -336,7 +336,7 @@ proc blocksDeliveryHandler*(
   b: BlockExcEngine,
   peer: PeerId,
   blocksDelivery: seq[BlockDelivery]) {.async.} =
-  trace "Received blocks from peer", peer, blocks = (blocksDelivery.mapIt($it.address)).join(",")
+  trace "Received blocks from peer", peer, blocks = (blocksDelivery.mapIt(it.address))
 
   var validatedBlocksDelivery: seq[BlockDelivery]
   for bd in blocksDelivery:
@@ -557,7 +557,7 @@ proc taskHandler*(b: BlockExcEngine, task: BlockExcPeerCtx) {.gcsafe, async.} =
     updateInFlight(failedAddresses, false)
 
     if blocksDelivery.len > 0:
-      trace "Sending blocks to peer", peer = task.id, blocks = (blocksDelivery.mapIt($it.address)).join(",")
+      trace "Sending blocks to peer", peer = task.id, blocks = (blocksDelivery.mapIt(it.address))
       await b.network.request.sendBlocksDelivery(
         task.id,
         blocksDelivery

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -399,7 +399,9 @@ proc wantListHandler*(
       address   = e.address
       wantType  = $e.wantType
 
-    if idx < 0: # updating entry
+    if idx < 0: # new entry
+      peerCtx.peerWants.add(e)
+
       let
         have = await e.address in b.localStore
         price = @(
@@ -408,6 +410,8 @@ proc wantListHandler*(
 
       if e.wantType == WantType.WantHave:
         codex_block_exchange_want_have_lists_received.inc()
+      elif e.wantType == WantType.WantBlock:
+        codex_block_exchange_want_block_lists_received.inc()
 
       if not have and e.sendDontHave:
         presence.add(
@@ -421,10 +425,8 @@ proc wantListHandler*(
           address: e.address,
           `type`: BlockPresenceType.Have,
           price: price))
-      elif e.wantType == WantType.WantBlock:
-        peerCtx.peerWants.add(e)
-        codex_block_exchange_want_block_lists_received.inc()
-    else:
+      
+    else: # update existing entry
       # peer doesn't want this block anymore
       if e.cancel:
         peerCtx.peerWants.del(idx)

--- a/codex/blockexchange/peers/peerctxstore.nim
+++ b/codex/blockexchange/peers/peerctxstore.nim
@@ -32,7 +32,7 @@ logScope:
 type
   PeerCtxStore* = ref object of RootObj
     peers*: OrderedTable[PeerId, BlockExcPeerCtx]
-  PeersForBlock* = ref object of RootObj
+  PeersForBlock* = object of RootObj
     with*: seq[BlockExcPeerCtx]
     without*: seq[BlockExcPeerCtx]
 

--- a/codex/blockexchange/peers/peerctxstore.nim
+++ b/codex/blockexchange/peers/peerctxstore.nim
@@ -82,33 +82,6 @@ proc getPeersForBlock*(self: PeerCtxStore, address: BlockAddress): PeersForBlock
       res.without.add(peer)
   res
 
-func selectCheapest*(self: PeerCtxStore, address: BlockAddress): seq[BlockExcPeerCtx] =
-  # assume that the price for all leaves in a tree is the same
-  let rootAddress = BlockAddress(leaf: false, cid: address.cidOrTreeCid)
-  var peers = self.peersHave(rootAddress)
-
-  func cmp(a, b: BlockExcPeerCtx): int =
-    var
-      priceA = 0.u256
-      priceB = 0.u256
-
-    a.blocks.withValue(rootAddress, precense):
-      priceA = precense[].price
-
-    b.blocks.withValue(rootAddress, precense):
-      priceB = precense[].price
-
-    if priceA == priceB:
-      0
-    elif priceA > priceB:
-      1
-    else:
-      -1
-
-  peers.sort(cmp)
-  trace "Selected cheapest peers", peers = peers.len
-  return peers
-
 proc new*(T: type PeerCtxStore): PeerCtxStore =
   ## create new instance of a peer context store
   PeerCtxStore(peers: initOrderedTable[PeerId, BlockExcPeerCtx]())

--- a/tests/integration/testsales.nim
+++ b/tests/integration/testsales.nim
@@ -19,7 +19,7 @@ multinodesuite "Sales":
     clients: CodexConfigs.init(nodes=1).some,
     providers: CodexConfigs.init(nodes=1).some,
   )
-  
+
   var host: CodexClient
   var client: CodexClient
 


### PR DESCRIPTION
In the current situation when we initiate a block request, we send a wantBlock to one peer (even if they don't have the block, so it will be ignored) and we send wantHave messages to others, which are then discarded.

This PR fixes two issues:
- We only send wantBlock messages to peers who have the block. We use the same pseudo-random method for selecting a peer if multiple peers have the block.
- We track all peerWants instead of only the wantBlocks. This is according to spec, and solves an issue in the case where a block is received/detected after the want-list message.

I did not want to solve both issues in the same PR. But test `NetworkStore - multiple nodes` in testblockexc.nim failed because of the second issue after I fixed the first one. So instead of having to "break" a correct test, I figured it was better to fix the actual problem.
