### PR TITLE
chore(tests): fix unneeded async

### DIFF
--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -189,14 +189,16 @@ asyncchecksuite "Sales":
     await repoTmp.destroyDb()
     await metaTmp.destroyDb()
 
-  proc isInState(idx: int, state: string): Future[bool] {.async.} =
+  proc isInState(idx: int, state: string): bool =
     proc description(state: State): string =
       $state
-    check eventually sales.agents.len > idx
+
+    if idx >= sales.agents.len:
+      return false
     sales.agents[idx].query(description) == state.some
 
   proc allowRequestToStart {.async.} =
-    check eventually (await isInState(0, "SaleInitialProving"))
+    check eventually isInState(0, "SaleInitialProving")
     # it won't start proving until the next period
     await clock.advanceToNextPeriod(market)
 


### PR DESCRIPTION
Removes an unneeded `check eventually` inside a helper proc, removing the need for the proc to be async.