### PR TITLE
feat: repair is rewarded

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -84,6 +84,11 @@ method proofTimeout*(market: OnChainMarket): Future[UInt256] {.async.} =
     let config = await market.config()
     return config.proofs.timeout
 
+method repairRewardPercentage*(market: OnChainMarket): Future[uint8] {.async.} =
+  convertEthersError:
+    let config = await market.contract.configuration()
+    return config.collateral.repairRewardPercentage
+
 method proofDowntime*(market: OnChainMarket): Future[uint8] {.async.} =
   convertEthersError:
     let config = await market.config()

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -49,6 +49,7 @@ type
     Failed
     Paid
     Cancelled
+    Repair
 
 proc `==`*(x, y: Nonce): bool {.borrow.}
 proc `==`*(x, y: RequestId): bool {.borrow.}

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -67,6 +67,9 @@ method periodicity*(market: Market): Future[Periodicity] {.base, async.} =
 method proofTimeout*(market: Market): Future[UInt256] {.base, async.} =
   raiseAssert("not implemented")
 
+method repairRewardPercentage*(market: Market): Future[uint8] {.base, async.} =
+  raiseAssert("not implemented")
+
 method proofDowntime*(market: Market): Future[uint8] {.base, async.} =
   raiseAssert("not implemented")
 

--- a/codex/sales/states/filling.nim
+++ b/codex/sales/states/filling.nim
@@ -1,3 +1,4 @@
+import pkg/stint
 import ../../logutils
 import ../../market
 import ../statemachine
@@ -27,12 +28,22 @@ method onFailed*(state: SaleFilling, request: StorageRequest): ?State =
 method run(state: SaleFilling, machine: Machine): Future[?State] {.async.} =
   let data = SalesAgent(machine).data
   let market = SalesAgent(machine).context.market
-  without (collateral =? data.request.?ask.?collateral):
+  without (fullCollateral =? data.request.?ask.?collateral):
     raiseAssert "Request not set"
 
   logScope:
     requestId = data.requestId
     slotIndex = data.slotIndex
+
+  let slotState = await market.slotState(slotId(data.requestId, data.slotIndex))
+  var collateral: Uint256
+
+  if slotState == SlotState.Repair:
+    # When repairing the node gets "discount" on the collateral that it needs to
+    let repairRewardPercentage = (await market.repairRewardPercentage).u256
+    collateral = fullCollateral - ((fullCollateral * repairRewardPercentage)).div(100.u256)
+  else:
+    collateral = fullCollateral
 
   debug "Filling slot"
   try:

--- a/codex/sales/states/preparing.nim
+++ b/codex/sales/states/preparing.nim
@@ -49,7 +49,7 @@ method run*(state: SalePreparing, machine: Machine): Future[?State] {.async.} =
 
   let slotId = slotId(data.requestId, data.slotIndex)
   let state = await market.slotState(slotId)
-  if state != SlotState.Free:
+  if state != SlotState.Free and state != SlotState.Repair:
     return some State(SaleIgnored(reprocessSlot: false, returnBytes: false))
 
   # TODO: Once implemented, check to ensure the host is allowed to fill the slot,

--- a/codex/sales/states/proving.nim
+++ b/codex/sales/states/proving.nim
@@ -16,6 +16,7 @@ logScope:
   topics = "marketplace sales proving"
 
 type
+  SlotFreedError* = object of CatchableError
   SlotNotFilledError* = object of CatchableError
   SaleProving* = ref object of ErrorHandlingState
     loop: Future[void]
@@ -82,6 +83,10 @@ proc proveLoop(
     of SlotState.Cancelled:
       debug "Slot reached cancelled state"
       # do nothing, let onCancelled callback take care of it
+    of SlotState.Repair:
+      warn "Slot was forcible freed"
+      let message = "Slot was forcible freed and host was removed from its hosting"
+      raise newException(SlotFreedError, message)
     of SlotState.Failed:
       debug "Slot reached failed state"
       # do nothing, let onFailed callback take care of it

--- a/codex/sales/states/unknown.nim
+++ b/codex/sales/states/unknown.nim
@@ -51,7 +51,7 @@ method run*(state: SaleUnknown, machine: Machine): Future[?State] {.async.} =
   of SlotState.Cancelled:
     return some State(SaleCancelled())
   of SlotState.Repair:
-    # TODO: What to do? It could really mean that he was offline for that long that he was kicked out
-    # from the slot and lost all the collateral. Should we simply "give up" on the slot? Or try
-    # to "repair" (there is some chance that the dataset is still locally saved) the slot?
+    # This should never really happen as the Slot is removed from the node's onchain slots tracking
+    # upon freeing the slot. Hence upon node's restart the slot with the Repair state should not
+    # be loaded from the onchain.
     discard

--- a/codex/sales/states/unknown.nim
+++ b/codex/sales/states/unknown.nim
@@ -50,3 +50,8 @@ method run*(state: SaleUnknown, machine: Machine): Future[?State] {.async.} =
     return some State(SaleFailed())
   of SlotState.Cancelled:
     return some State(SaleCancelled())
+  of SlotState.Repair:
+    # TODO: What to do? It could really mean that he was offline for that long that he was kicked out
+    # from the slot and lost all the collateral. Should we simply "give up" on the slot? Or try
+    # to "repair" (there is some chance that the dataset is still locally saved) the slot?
+    discard

--- a/codex/sales/states/unknown.nim
+++ b/codex/sales/states/unknown.nim
@@ -5,6 +5,7 @@ import ./filled
 import ./finished
 import ./failed
 import ./errored
+import ./proving
 import ./cancelled
 import ./payout
 
@@ -38,7 +39,7 @@ method run*(state: SaleUnknown, machine: Machine): Future[?State] {.async.} =
   case slotState
   of SlotState.Free:
     let error = newException(UnexpectedSlotError,
-      "slot state on chain should not be 'free'")
+      "Slot state on chain should not be 'free'")
     return some State(SaleErrored(error: error))
   of SlotState.Filled:
     return some State(SaleFilled())
@@ -51,7 +52,6 @@ method run*(state: SaleUnknown, machine: Machine): Future[?State] {.async.} =
   of SlotState.Cancelled:
     return some State(SaleCancelled())
   of SlotState.Repair:
-    # This should never really happen as the Slot is removed from the node's onchain slots tracking
-    # upon freeing the slot. Hence upon node's restart the slot with the Repair state should not
-    # be loaded from the onchain.
-    discard
+    let error = newException(SlotFreedError,
+      "Slot was forcible freed and host was removed from its hosting")
+    return some State(SaleErrored(error: error))

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -125,6 +125,9 @@ method proofTimeout*(market: MockMarket): Future[UInt256] {.async.} =
 method proofDowntime*(market: MockMarket): Future[uint8] {.async.} =
   return market.config.proofs.downtime
 
+method repairRewardPercentage*(market: MockMarket): Future[uint8] {.async.} =
+  return market.config.collateral.repairRewardPercentage
+
 method getPointer*(market: MockMarket, slotId: SlotId): Future[uint8] {.async.} =
   return market.proofPointer
 

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -303,7 +303,7 @@ ethersuite "On-Chain Market":
       let slotId = request.slotId(slotIndex.u256)
       while true:
         let slotState = await marketplace.slotState(slotId)
-        if slotState == SlotState.Free:
+        if slotState == SlotState.Repair or slotState == SlotState.Failed:
           break
         await waitUntilProofRequired(slotId)
         let missingPeriod = periodicity.periodOf(await ethProvider.currentTime())


### PR DESCRIPTION
Adds support for changes in the contract that introduce repair reward as described here: https://github.com/codex-storage/codex-contracts-eth/issues/154

There is one question to be answered about what the node should do when it restarts (after an outage for example) and finds his slot to be in `Repair` state. For more see bellow.