### PR TITLE
Reliable transfer integration test.

### DIFF
--- a/tests/integration/codexclient.nim
+++ b/tests/integration/codexclient.nim
@@ -20,9 +20,11 @@ type CodexClient* = ref object
 
 type CodexClientError* = object of CatchableError
 
+const HttpClientTimeoutMs = 60 * 1000
+
 proc new*(_: type CodexClient, baseurl: string): CodexClient =
   CodexClient(
-    http: newHttpClient(),
+    http: newHttpClient(timeout=HttpClientTimeoutMs),
     baseurl: baseurl,
     session: HttpSessionRef.new({HttpClientFlag.Http11Pipeline})
   )
@@ -247,7 +249,7 @@ proc close*(client: CodexClient) =
 
 proc restart*(client: CodexClient) =
   client.http.close()
-  client.http = newHttpClient()
+  client.http = newHttpClient(timeout=HttpClientTimeoutMs)
 
 proc purchaseStateIs*(client: CodexClient, id: PurchaseId, state: string): bool =
   client.getPurchase(id).option.?state == some state

--- a/tests/integration/testupdownload.nim
+++ b/tests/integration/testupdownload.nim
@@ -1,5 +1,6 @@
 import pkg/codex/rest/json
 import ./twonodes
+import ../codex/examples
 import json
 from pkg/libp2p import Cid, `$`
 
@@ -80,3 +81,16 @@ twonodessuite "Uploads and downloads", debug1 = false, debug2 = false:
     let resp2 = client2.download(cid1, local = true).get
     check:
       content1 == resp2
+
+  test "reliable transfer test":
+    proc transferTest(a: CodexClient, b: CodexClient) {.async.} =
+      let data = await RandomChunker.example(blocks=8)
+      let cid = a.upload(data).get
+      let response = b.download(cid).get
+      check:
+        response == data
+
+    for run in 0..20:
+      echo "Run: " & $run
+      await transferTest(client1, client2)
+      await transferTest(client2, client1)


### PR DESCRIPTION
During the work on #1019 it was found that the integration tests for block exchange are not covering an aspect of reliability that other (marketplace) integration tests are relying on. In order to help focus debugging efforts, this adds a transfer test that checks this aspect.

Additionally: sets http timeout for the codex client. (Was infinite. Now 1 minute.)