### PR TITLE
ci: split nim-matrix workflow

### DIFF
--- a/.github/workflows/nim-matrix.yml
+++ b/.github/workflows/nim-matrix.yml
@@ -20,7 +20,10 @@ jobs:
       uses: fabiocaccamo/create-matrix-action@v4
       with:
         matrix: |
-          os {linux}, cpu {amd64}, builder {ubuntu-20.04}, tests {all}, nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {linux}, cpu {amd64}, builder {ubuntu-20.04}, tests {unittest},    nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {linux}, cpu {amd64}, builder {ubuntu-20.04}, tests {contract},    nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {linux}, cpu {amd64}, builder {ubuntu-20.04}, tests {integration}, nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {linux}, cpu {amd64}, builder {ubuntu-20.04}, tests {tools},       nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}
 
   build:
     needs: matrix


### PR DESCRIPTION
A quick PR which splits [Nim matrix](../../actions/workflows/nim-matrix.yml) workflow, to decrease its run duration by 20-30 minutes.