### PR TITLE
fix(nodeprocess): asyncspawn capture output

### DIFF
--- a/tests/integration/codexprocess.nim
+++ b/tests/integration/codexprocess.nim
@@ -34,10 +34,10 @@ method startedOutput(node: CodexProcess): string =
 method processOptions(node: CodexProcess): set[AsyncProcessOption] =
   return {AsyncProcessOption.StdErrToStdOut}
 
-method outputLineEndings(node: CodexProcess): string =
+method outputLineEndings(node: CodexProcess): string {.raises: [].} =
   return "\n"
 
-method onOutputLineCaptured(node: CodexProcess, line: string) =
+method onOutputLineCaptured(node: CodexProcess, line: string) {.raises: [].} =
   discard
 
 proc dataDir(node: CodexProcess): string =

--- a/tests/integration/hardhatprocess.nim
+++ b/tests/integration/hardhatprocess.nim
@@ -37,7 +37,7 @@ method startedOutput(node: HardhatProcess): string =
 method processOptions(node: HardhatProcess): set[AsyncProcessOption] =
   return {}
 
-method outputLineEndings(node: HardhatProcess): string =
+method outputLineEndings(node: HardhatProcess): string {.raises: [].} =
   return "\n"
 
 proc openLogFile(node: HardhatProcess, logFilePath: string): IoHandle =

--- a/tests/integration/nodeprocess.nim
+++ b/tests/integration/nodeprocess.nim
@@ -38,10 +38,10 @@ method startedOutput(node: NodeProcess): string {.base.} =
 method processOptions(node: NodeProcess): set[AsyncProcessOption] {.base.} =
   raiseAssert "not implemented"
 
-method outputLineEndings(node: NodeProcess): string {.base.} =
+method outputLineEndings(node: NodeProcess): string {.base, raises: [].} =
   raiseAssert "not implemented"
 
-method onOutputLineCaptured(node: NodeProcess, line: string) {.base.} =
+method onOutputLineCaptured(node: NodeProcess, line: string) {.base, raises: [].} =
   raiseAssert "not implemented"
 
 method start*(node: NodeProcess) {.base, async.} =
@@ -74,7 +74,7 @@ proc captureOutput(
   node: NodeProcess,
   output: string,
   started: Future[void]
-) {.async.} =
+) {.async: (raises: []).} =
 
   logScope:
     nodeName = node.name
@@ -98,7 +98,10 @@ proc captureOutput(
         await sleepAsync(1.millis)
       await sleepAsync(1.millis)
 
-  except AsyncStreamReadError as e:
+  except CancelledError:
+    discard # do not propagate as captureOutput was asyncSpawned
+
+  except AsyncStreamError as e:
     error "error reading output stream", error = e.msgDetail
 
 proc startNode*[T: NodeProcess](
@@ -155,7 +158,8 @@ proc waitUntilStarted*(node: NodeProcess) {.async.} =
 
   let started = newFuture[void]()
   try:
-    discard node.captureOutput(node.startedOutput, started).track(node)
+    let fut = node.captureOutput(node.startedOutput, started).track(node)
+    asyncSpawn fut
     await started.wait(60.seconds) # allow enough time for proof generation
     trace "node started"
   except AsyncTimeoutError:


### PR DESCRIPTION
- Ensures no exceptions are raised from `captureOutput`
- Asyncspawns the future to ensure errors are not silently swallowed