### PR TITLE
fix: unhide log-format cli flag

### DIFF
--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -100,7 +100,6 @@ type
       name: "log-level" }: string
 
     logFormat* {.
-      hidden
       desc: "Specifies what kind of logs should be written to stdout (auto, " &
         "colors, nocolors, json)"
       defaultValueDesc: "auto"
@@ -316,7 +315,7 @@ type
         defaultValue: ValidationGroups.none
         name: "validator-groups"
       .}: Option[ValidationGroups]
-      
+
       validatorGroupIndex* {.
         desc: "Slot validation group index"
         longDesc: "The value provided must be in the range " &


### PR DESCRIPTION
"Unhide" log-format CLI flag. Generally this should be left on default value, but there are cases when overriding this is helpful (for example running in Interactive Docker gives you color output, even though maybe you do not want it etc.).