### PR TITLE
chore: warning cleanup

### DIFF
--- a/codex.nim
+++ b/codex.nim
@@ -28,7 +28,6 @@ import ./codex/codextypes
 export codex, conf, libp2p, chronos, logutils
 
 when isMainModule:
-  import std/sequtils
   import std/os
   import pkg/confutils/defs
   import ./codex/utils/fileutils

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -10,7 +10,11 @@
 {.push raises: [].}
 
 import std/os
-import std/terminal
+
+{.push warning[UnusedImport]: on.}
+import std/terminal # Is not used in tests
+{.pop.}
+
 import std/options
 import std/strutils
 import std/typetraits

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -6,7 +6,6 @@ import pkg/nimcrypto
 import pkg/ethers/fields
 import pkg/questionable/results
 import pkg/stew/byteutils
-import pkg/upraises
 import ../logutils
 import ../utils/json
 

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -45,7 +45,6 @@ import ./indexingstrategy
 import ./utils
 import ./errors
 import ./logutils
-import ./utils/poseidon2digest
 import ./utils/asynciter
 
 export logutils

--- a/codex/purchasing/purchaseid.nim
+++ b/codex/purchasing/purchaseid.nim
@@ -1,5 +1,4 @@
 import std/hashes
-import pkg/nimcrypto
 import ../logutils
 
 type PurchaseId* = distinct array[32, byte]

--- a/codex/purchasing/states/started.nim
+++ b/codex/purchasing/states/started.nim
@@ -34,8 +34,8 @@ method run*(state: PurchaseStarted, machine: Machine): Future[?State] {.async.} 
   let fut = await one(ended, failed)
   await subscription.unsubscribe()
   if fut.id == failed.id:
-    ended.cancel()
+    ended.cancelSoon()
     return some State(PurchaseFailed())
   else:
-    failed.cancel()
+    failed.cancelSoon()
     return some State(PurchaseFinished())

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -100,7 +100,7 @@ proc subscribeCancellation(agent: SalesAgent) {.async.} =
 method onFulfilled*(agent: SalesAgent, requestId: RequestId) {.base, gcsafe, upraises: [].} =
   if agent.data.requestId == requestId and
      not agent.data.cancelled.isNil:
-    agent.data.cancelled.cancel()
+    agent.data.cancelled.cancelSoon()
 
 method onFailed*(agent: SalesAgent, requestId: RequestId) {.base, gcsafe, upraises: [].} =
   without request =? agent.data.request:

--- a/codex/sales/states/filled.nim
+++ b/codex/sales/states/filled.nim
@@ -10,7 +10,8 @@ import ./errored
 import ./cancelled
 import ./failed
 import ./proving
-import ./provingsimulated
+import ./provingsimulated # used in tests
+{.push warning[UnusedImport]:off.}
 
 logScope:
   topics = "marketplace sales filled"

--- a/codex/sales/states/filled.nim
+++ b/codex/sales/states/filled.nim
@@ -10,8 +10,10 @@ import ./errored
 import ./cancelled
 import ./failed
 import ./proving
-import ./provingsimulated # used in tests
+
 {.push warning[UnusedImport]:off.}
+import ./provingsimulated # used in tests
+{.pop.}
 
 logScope:
   topics = "marketplace sales filled"

--- a/codex/sales/states/filled.nim
+++ b/codex/sales/states/filled.nim
@@ -11,9 +11,8 @@ import ./cancelled
 import ./failed
 import ./proving
 
-{.push warning[UnusedImport]:off.}
-import ./provingsimulated # used in tests
-{.pop.}
+when codex_enable_proof_failures:
+  import ./provingsimulated
 
 logScope:
   topics = "marketplace sales filled"

--- a/codex/sales/states/provingsimulated.nim
+++ b/codex/sales/states/provingsimulated.nim
@@ -3,7 +3,6 @@ when codex_enable_proof_failures:
   import std/strutils
   import pkg/stint
   import pkg/ethers
-  import pkg/ethers/testing
 
   import ../../contracts/requests
   import ../../logutils

--- a/codex/sales/states/slotreserving.nim
+++ b/codex/sales/states/slotreserving.nim
@@ -1,5 +1,4 @@
 import pkg/questionable
-import pkg/questionable/results
 import pkg/metrics
 
 import ../../logutils
@@ -9,7 +8,6 @@ import ../statemachine
 import ./errorhandling
 import ./cancelled
 import ./failed
-import ./filled
 import ./ignored
 import ./downloading
 import ./errored

--- a/codex/slots/builder/builder.nim
+++ b/codex/slots/builder/builder.nim
@@ -24,7 +24,6 @@ import ../../utils
 import ../../stores
 import ../../manifest
 import ../../merkletree
-import ../../utils/digest
 import ../../utils/asynciter
 import ../../indexingstrategy
 

--- a/codex/slots/proofs/prover.nim
+++ b/codex/slots/proofs/prover.nim
@@ -27,7 +27,6 @@ import ../builder
 import ../sampler
 
 import ./backends
-import ./backendfactory
 import ../types
 
 export backends

--- a/codex/units.nim
+++ b/codex/units.nim
@@ -11,8 +11,6 @@
 import std/hashes
 import std/strutils
 
-import pkg/upraises
-
 import ./logutils
 
 type

--- a/codex/utils/asyncstatemachine.nim
+++ b/codex/utils/asyncstatemachine.nim
@@ -1,4 +1,3 @@
-import std/sugar
 import pkg/questionable
 import pkg/chronos
 import ../logutils

--- a/codex/utils/options.nim
+++ b/codex/utils/options.nim
@@ -1,5 +1,4 @@
-import macros
-import strutils
+import std/macros
 import pkg/questionable
 import pkg/questionable/operators
 

--- a/tests/codex/blockexchange/discovery/testdiscoveryengine.nim
+++ b/tests/codex/blockexchange/discovery/testdiscoveryengine.nim
@@ -1,5 +1,4 @@
 import std/sequtils
-import std/sugar
 import std/tables
 
 import pkg/chronos

--- a/tests/codex/blockexchange/engine/testadvertiser.nim
+++ b/tests/codex/blockexchange/engine/testadvertiser.nim
@@ -1,6 +1,3 @@
-import std/sequtils
-import std/random
-
 import pkg/chronos
 import pkg/libp2p/routing_record
 import pkg/codexdht/discv5/protocol as discv5
@@ -49,7 +46,7 @@ asyncchecksuite "Advertiser":
   teardown:
     await advertiser.stop()
 
-  proc waitTillQueueEmpty() {.async.} = 
+  proc waitTillQueueEmpty() {.async.} =
     check eventually advertiser.advertiseQueue.len == 0
 
   test "blockStored should queue manifest Cid for advertising":
@@ -70,7 +67,7 @@ asyncchecksuite "Advertiser":
 
   test "blockStored should not queue non-manifest non-tree CIDs for discovery":
     let blk = bt.Block.example
-      
+
     (await localStore.putBlock(blk)).tryGet()
 
     await waitTillQueueEmpty()

--- a/tests/codex/blockexchange/engine/testblockexc.nim
+++ b/tests/codex/blockexchange/engine/testblockexc.nim
@@ -4,7 +4,6 @@ import std/algorithm
 import pkg/chronos
 import pkg/stew/byteutils
 
-import pkg/codex/rng
 import pkg/codex/stores
 import pkg/codex/blockexchange
 import pkg/codex/chunker

--- a/tests/codex/blockexchange/engine/testengine.nim
+++ b/tests/codex/blockexchange/engine/testengine.nim
@@ -15,7 +15,6 @@ import pkg/codex/chunker
 import pkg/codex/discovery
 import pkg/codex/blocktype
 import pkg/codex/utils/asyncheapqueue
-import pkg/codex/manifest
 
 import ../../../asynctest
 import ../../helpers

--- a/tests/codex/helpers/mockchunker.nim
+++ b/tests/codex/helpers/mockchunker.nim
@@ -1,9 +1,5 @@
-import std/sequtils
-
 import pkg/chronos
-
 import pkg/codex/chunker
-import pkg/codex/rng
 
 export chunker
 
@@ -19,10 +15,10 @@ proc new*(
   ## Create a chunker that produces data
   ##
 
-  let 
+  let
     chunkSize = chunkSize.NBytes
     dataset = @dataset
-  
+
   var consumed = 0
   proc reader(data: ChunkBuffer, len: int): Future[int] {.async, gcsafe, raises: [Defect].} =
 
@@ -30,12 +26,12 @@ proc new*(
       return 0
 
     var read = 0
-    while read < len and 
+    while read < len and
       read < chunkSize.int and
       (consumed + read) < dataset.len:
       data[read] = dataset[consumed + read]
       read.inc
-    
+
     consumed += read
     return read
 

--- a/tests/codex/helpers/mockrepostore.nim
+++ b/tests/codex/helpers/mockrepostore.nim
@@ -8,7 +8,6 @@
 ## those terms.
 
 import std/sequtils
-import std/sugar
 import pkg/chronos
 import pkg/libp2p
 import pkg/questionable

--- a/tests/codex/merkletree/generictreetests.nim
+++ b/tests/codex/merkletree/generictreetests.nim
@@ -1,5 +1,4 @@
 import std/unittest
-import std/sequtils
 
 import pkg/codex/merkletree
 

--- a/tests/codex/merkletree/testcodexcoders.nim
+++ b/tests/codex/merkletree/testcodexcoders.nim
@@ -1,5 +1,4 @@
 import std/unittest
-import std/sequtils
 
 import pkg/questionable/results
 import pkg/stew/byteutils

--- a/tests/codex/merkletree/testcodextree.nim
+++ b/tests/codex/merkletree/testcodextree.nim
@@ -1,10 +1,8 @@
 import std/unittest
 import std/sequtils
-import std/tables
 
 import pkg/questionable/results
 import pkg/stew/byteutils
-import pkg/nimcrypto/sha2
 import pkg/libp2p
 
 import pkg/codex/codextypes

--- a/tests/codex/merkletree/testmerkledigest.nim
+++ b/tests/codex/merkletree/testmerkledigest.nim
@@ -2,16 +2,12 @@ import std/unittest
 import std/sequtils
 import std/random
 
-import pkg/constantine/math/arithmetic
-
 import pkg/poseidon2
-import pkg/poseidon2/io
 import pkg/poseidon2/sponge
 
 import pkg/questionable/results
 
 import pkg/codex/merkletree
-import pkg/codex/utils/digest
 import pkg/codex/utils/poseidon2digest
 
 import ./helpers

--- a/tests/codex/merkletree/testposeidon2tree.nim
+++ b/tests/codex/merkletree/testposeidon2tree.nim
@@ -1,6 +1,5 @@
 import std/unittest
 import std/sequtils
-import std/sugar
 
 import pkg/poseidon2
 import pkg/poseidon2/io
@@ -8,10 +7,6 @@ import pkg/questionable/results
 import pkg/results
 import pkg/stew/byteutils
 import pkg/stew/arrayops
-import constantine/math/arithmetic
-import constantine/math/io/io_bigints
-import pkg/constantine/math/io/io_fields
-import pkg/constantine/platforms/abstractions
 
 import pkg/codex/merkletree
 

--- a/tests/codex/node/helpers.nim
+++ b/tests/codex/node/helpers.nim
@@ -1,14 +1,11 @@
 import std/tables
 import std/times
-import std/cpuinfo
 
 import pkg/libp2p
 import pkg/chronos
-import pkg/taskpools
 import pkg/codex/codextypes
 import pkg/codex/chunker
 import pkg/codex/stores
-import pkg/codex/slots
 
 import ../../asynctest
 

--- a/tests/codex/node/testcontracts.nim
+++ b/tests/codex/node/testcontracts.nim
@@ -1,20 +1,15 @@
 import std/os
 import std/options
-import std/math
 import std/times
-import std/sequtils
 import std/importutils
 import std/cpuinfo
 
 import pkg/chronos
-import pkg/stew/byteutils
 import pkg/datastore
 import pkg/datastore/typedds
 import pkg/questionable
 import pkg/questionable/results
 import pkg/stint
-import pkg/poseidon2
-import pkg/poseidon2/io
 import pkg/taskpools
 
 import pkg/nitro
@@ -31,7 +26,6 @@ import pkg/codex/slots
 import pkg/codex/manifest
 import pkg/codex/discovery
 import pkg/codex/erasure
-import pkg/codex/merkletree
 import pkg/codex/blocktype as bt
 import pkg/codex/stores/repostore/coders
 import pkg/codex/utils/asynciter

--- a/tests/codex/node/testnode.nim
+++ b/tests/codex/node/testnode.nim
@@ -1,8 +1,6 @@
 import std/os
 import std/options
 import std/math
-import std/times
-import std/sequtils
 import std/importutils
 import std/cpuinfo
 

--- a/tests/codex/sales/states/testdownloading.nim
+++ b/tests/codex/sales/states/testdownloading.nim
@@ -3,7 +3,6 @@ import pkg/questionable
 import pkg/codex/contracts/requests
 import pkg/codex/sales/states/cancelled
 import pkg/codex/sales/states/downloading
-import pkg/codex/sales/states/errored
 import pkg/codex/sales/states/failed
 import pkg/codex/sales/states/filled
 import ../../examples

--- a/tests/codex/sales/states/testfilled.nim
+++ b/tests/codex/sales/states/testfilled.nim
@@ -8,7 +8,6 @@ import pkg/codex/sales/salescontext
 import pkg/codex/sales/states/filled
 import pkg/codex/sales/states/errored
 import pkg/codex/sales/states/proving
-import pkg/codex/sales/states/finished
 
 import ../../../asynctest
 import ../../helpers/mockmarket

--- a/tests/codex/sales/states/testfilling.nim
+++ b/tests/codex/sales/states/testfilling.nim
@@ -4,7 +4,6 @@ import pkg/codex/contracts/requests
 import pkg/codex/sales/states/filling
 import pkg/codex/sales/states/cancelled
 import pkg/codex/sales/states/failed
-import pkg/codex/sales/states/filled
 import ../../examples
 import ../../helpers
 

--- a/tests/codex/sales/states/testpreparing.nim
+++ b/tests/codex/sales/states/testpreparing.nim
@@ -1,7 +1,6 @@
 import pkg/chronos
 import pkg/questionable
 import pkg/datastore
-import pkg/stew/byteutils
 import pkg/codex/contracts/requests
 import pkg/codex/sales/states/preparing
 import pkg/codex/sales/states/slotreserving

--- a/tests/codex/sales/states/testslotreserving.nim
+++ b/tests/codex/sales/states/testslotreserving.nim
@@ -5,7 +5,6 @@ import pkg/codex/sales/states/slotreserving
 import pkg/codex/sales/states/downloading
 import pkg/codex/sales/states/cancelled
 import pkg/codex/sales/states/failed
-import pkg/codex/sales/states/filled
 import pkg/codex/sales/states/ignored
 import pkg/codex/sales/states/errored
 import pkg/codex/sales/salesagent
@@ -16,7 +15,6 @@ import ../../../asynctest
 import ../../helpers
 import ../../examples
 import ../../helpers/mockmarket
-import ../../helpers/mockreservations
 import ../../helpers/mockclock
 
 asyncchecksuite "sales state 'SlotReserving'":

--- a/tests/codex/sales/testreservations.nim
+++ b/tests/codex/sales/testreservations.nim
@@ -1,5 +1,4 @@
 import std/random
-import std/sequtils
 
 import pkg/questionable
 import pkg/questionable/results

--- a/tests/codex/sales/testslotqueue.nim
+++ b/tests/codex/sales/testslotqueue.nim
@@ -1,6 +1,5 @@
 import std/sequtils
 import pkg/chronos
-import pkg/datastore
 import pkg/questionable
 import pkg/questionable/results
 

--- a/tests/codex/slots/backends/helpers.nim
+++ b/tests/codex/slots/backends/helpers.nim
@@ -1,6 +1,4 @@
-
 import std/sequtils
-import std/sugar
 import std/strutils
 import std/options
 

--- a/tests/codex/slots/backends/testcircomcompat.nim
+++ b/tests/codex/slots/backends/testcircomcompat.nim
@@ -1,12 +1,9 @@
-import std/sequtils
-import std/sugar
 import std/options
 
 import ../../../asynctest
 
 import pkg/chronos
 import pkg/poseidon2
-import pkg/datastore
 import pkg/serde/json
 
 import pkg/codex/slots {.all.}

--- a/tests/codex/slots/helpers.nim
+++ b/tests/codex/slots/helpers.nim
@@ -13,7 +13,6 @@ import pkg/codex/chunker
 import pkg/codex/indexingstrategy
 import pkg/codex/slots
 import pkg/codex/rng
-import pkg/codex/utils/poseidon2digest
 
 import ../helpers
 

--- a/tests/codex/slots/sampler/testsampler.nim
+++ b/tests/codex/slots/sampler/testsampler.nim
@@ -1,14 +1,10 @@
 import std/sequtils
 import std/options
-import std/importutils
 
 import ../../../asynctest
 
-import pkg/questionable
 import pkg/questionable/results
-import pkg/datastore
 
-import pkg/codex/rng
 import pkg/codex/stores
 import pkg/codex/merkletree
 import pkg/codex/utils/json
@@ -20,7 +16,6 @@ import pkg/codex/slots/sampler/utils
 
 import pkg/constantine/math/arithmetic
 import pkg/constantine/math/io/io_bigints
-import pkg/constantine/math/io/io_fields
 
 import ../backends/helpers
 import ../helpers

--- a/tests/codex/slots/sampler/testutils.nim
+++ b/tests/codex/slots/sampler/testutils.nim
@@ -1,7 +1,4 @@
-import std/sequtils
 import std/sugar
-import std/random
-import std/strutils
 
 import ../../../asynctest
 

--- a/tests/codex/slots/testprover.nim
+++ b/tests/codex/slots/testprover.nim
@@ -1,16 +1,9 @@
-import std/sequtils
-import std/sugar
-import std/math
-
 import ../../asynctest
 
 import pkg/chronos
 import pkg/libp2p/cid
-import pkg/datastore
 
 import pkg/codex/merkletree
-import pkg/codex/rng
-import pkg/codex/manifest
 import pkg/codex/chunker
 import pkg/codex/blocktype as bt
 import pkg/codex/slots
@@ -18,11 +11,9 @@ import pkg/codex/stores
 import pkg/codex/conf
 import pkg/confutils/defs
 import pkg/poseidon2/io
-import pkg/codex/utils/poseidon2digest
 
 import ./helpers
 import ../helpers
-import ./backends/helpers
 
 suite "Test Prover":
   let

--- a/tests/codex/slots/testslotbuilder.nim
+++ b/tests/codex/slots/testslotbuilder.nim
@@ -1,7 +1,5 @@
-import std/sequtils
 import std/math
 import std/importutils
-import std/sugar
 
 import ../../asynctest
 
@@ -15,11 +13,8 @@ import pkg/codex/merkletree
 import pkg/codex/manifest {.all.}
 import pkg/codex/utils
 import pkg/codex/utils/digest
-import pkg/codex/utils/poseidon2digest
-import pkg/datastore
 import pkg/poseidon2
 import pkg/poseidon2/io
-import pkg/constantine/math/io/io_fields
 
 import ./helpers
 import ../helpers

--- a/tests/codex/stores/testkeyutils.nim
+++ b/tests/codex/stores/testkeyutils.nim
@@ -10,7 +10,6 @@
 import std/random
 import std/sequtils
 import pkg/chronos
-import pkg/questionable
 import pkg/questionable/results
 import pkg/codex/blocktype as bt
 import pkg/codex/stores/repostore

--- a/tests/codex/stores/testmaintenance.nim
+++ b/tests/codex/stores/testmaintenance.nim
@@ -8,7 +8,6 @@
 ## those terms.
 
 import pkg/chronos
-import pkg/questionable/results
 import pkg/codex/blocktype as bt
 import pkg/codex/stores/repostore
 import pkg/codex/clock

--- a/tests/codex/stores/testrepostore.nim
+++ b/tests/codex/stores/testrepostore.nim
@@ -7,7 +7,6 @@ import pkg/questionable/results
 
 import pkg/chronos
 import pkg/stew/byteutils
-import pkg/stew/endians2
 import pkg/datastore
 
 import pkg/codex/stores/cachestore
@@ -22,8 +21,6 @@ import ../helpers
 import ../helpers/mockclock
 import ../examples
 import ./commonstoretests
-
-import ./repostore/testcoders
 
 checksuite "Test RepoStore start/stop":
 

--- a/tests/codex/testerasure.nim
+++ b/tests/codex/testerasure.nim
@@ -3,7 +3,6 @@ import std/sugar
 import std/cpuinfo
 
 import pkg/chronos
-import pkg/datastore
 import pkg/questionable/results
 
 import pkg/codex/erasure

--- a/tests/codex/testmanifest.nim
+++ b/tests/codex/testmanifest.nim
@@ -1,5 +1,3 @@
-import std/sequtils
-
 import pkg/chronos
 import pkg/questionable/results
 import pkg/codex/chunker

--- a/tests/codex/teststorestream.nim
+++ b/tests/codex/teststorestream.nim
@@ -1,5 +1,4 @@
 import pkg/chronos
-import pkg/questionable/results
 
 import pkg/codex/[
   streams,

--- a/tests/codex/utils/testasynciter.nim
+++ b/tests/codex/utils/testasynciter.nim
@@ -1,5 +1,3 @@
-import std/sugar
-
 import pkg/questionable
 import pkg/chronos
 import pkg/codex/utils/asynciter

--- a/tests/codex/utils/testkeyutils.nim
+++ b/tests/codex/utils/testkeyutils.nim
@@ -1,6 +1,5 @@
 import std/unittest
 import std/os
-import pkg/questionable
 import codex/utils/keyutils
 import ../helpers
 


### PR DESCRIPTION
I was fed up with so long build logs full of warnings, so did small cleanup mainly for `UnusedImports`, during which I discovered an actually bug in Nim: https://github.com/nim-lang/Nim/issues/24552

There are a few more areas that would be good to clean up that I listed here: https://github.com/codex-storage/nim-codex/issues/1054

Unfortunately this PR mainly helped the Test's build logs, where there were lot of unused imports. For normal compile logs the main source of the warnings is from Chronos's async-raises and deprected `cid` that I skipped for now.