### PR TITLE
Add nix service definition for codex

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,17 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1736348751,
+        "lastModified": 1736521871,
         "narHash": "sha256-d34XNLg9NGPEOARHW+BIOAWalkHdEUAwsv3mpLZQxds=",
         "owner": "codex-storage",
         "repo": "circom-compat-ffi",
-        "rev": "afadf4d9a411ce0589f6b4c1858a9a5a4e7f4661",
+        "rev": "8cd4ed44fdafe59d4ec1184420639cae4c4dbab9",
         "type": "github"
       },
       "original": {
         "owner": "codex-storage",
         "repo": "circom-compat-ffi",
-        "rev": "afadf4d9a411ce0589f6b4c1858a9a5a4e7f4661",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -2,50 +2,37 @@
   "nodes": {
     "circom-compat": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1732627240,
-        "narHash": "sha256-GvJTiBWBv799i5ZCCc4gF86bnQY/nZvx0vCPi1+OPD4=",
+        "lastModified": 1736348751,
+        "narHash": "sha256-d34XNLg9NGPEOARHW+BIOAWalkHdEUAwsv3mpLZQxds=",
         "owner": "codex-storage",
         "repo": "circom-compat-ffi",
-        "rev": "297c46fdc7d8a8fd53c8076b0be77334e4a54447",
+        "rev": "afadf4d9a411ce0589f6b4c1858a9a5a4e7f4661",
         "type": "github"
       },
       "original": {
         "owner": "codex-storage",
         "repo": "circom-compat-ffi",
+        "rev": "afadf4d9a411ce0589f6b4c1858a9a5a4e7f4661",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731386116,
-        "narHash": "sha256-lKA770aUmjPHdTaJWnP3yQ9OI1TigenUqVC3wweqZuI=",
+        "lastModified": 1736200483,
+        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "689fed12a013f56d4c4d3f612489634267d86529",
+        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1729449015,
-        "narHash": "sha256-Gf04dXB0n4q0A9G5nTGH3zuMGr6jtJppqdeljxua1fo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "89172919243df199fe237ba0f776c3e3e3d72367",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -53,7 +40,7 @@
     "root": {
       "inputs": {
         "circom-compat": "circom-compat",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,11 @@
   description = "Codex build flake";
   
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
-    circom-compat.url = "github:codex-storage/circom-compat-ffi";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    circom-compat = {
+      url = "github:codex-storage/circom-compat-ffi/afadf4d9a411ce0589f6b4c1858a9a5a4e7f4661";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { self, nixpkgs, circom-compat}:

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,10 @@
 {
-  description = "Codex build flake";
-  
+  description = "Nim Codex build flake";
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     circom-compat = {
-      url = "github:codex-storage/circom-compat-ffi/afadf4d9a411ce0589f6b4c1858a9a5a4e7f4661";
+      url = "github:codex-storage/circom-compat-ffi";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -20,26 +20,56 @@
     in rec {
       packages = forAllSystems (system: let
         circomCompatPkg = circom-compat.packages.${system}.default;
-        buildTarget = pkgsFor.${system}.callPackage ./nix/default.nix {
+        buildTarget = pkgsFor.${system}.callPackage ./nix/default.nix rec {
           inherit stableSystems circomCompatPkg;
-          src = self;
+          src = pkgsFor.${system}.lib.traceValFn (v: "self.submodules: ${toString v.submodules}") self;
         };
         build = targets: buildTarget.override { inherit targets; };
       in rec {
-        codex   = build ["all"];
-        default = codex;
+        nim-codex   = build ["all"];
+        default = nim-codex;
       });
+
+      nixosModules.nim-codex = { config, lib, pkgs, ... }: import ./nix/service.nix {
+        inherit config lib pkgs self;
+        circomCompatPkg = circom-compat.packages.${pkgs.system}.default;
+      };
 
       devShells = forAllSystems (system: let
         pkgs = pkgsFor.${system};
       in {
         default = pkgs.mkShell {
           inputsFrom = [
-            packages.${system}.codex
+            packages.${system}.nim-codex
             circom-compat.packages.${system}.default
           ];
           # Not using buildInputs to override fakeGit and fakeCargo.
           nativeBuildInputs = with pkgs; [ git cargo nodejs_18 ];
+        };
+      });
+
+      checks = forAllSystems (system: let
+        pkgs = pkgsFor.${system};
+      in {
+        nim-codex-test = pkgs.nixosTest {
+          name = "nim-codex-test";
+          nodes = {
+            server = { config, pkgs, ... }: {
+              imports = [ self.nixosModules.nim-codex ];
+              services.nim-codex.enable = true;
+              services.nim-codex.settings = {
+                data-dir = "/var/lib/nim-codex-test";
+              };
+              systemd.services.nim-codex.serviceConfig.StateDirectory = "nim-codex-test";
+            };
+          };
+          testScript = ''
+            print("Starting test: nim-codex-test")
+            machine.start()
+            machine.wait_for_unit("nim-codex.service")
+            machine.succeed("test -d /var/lib/nim-codex-test")
+            machine.wait_until_succeeds("journalctl -u nim-codex.service | grep 'Started codex node'", 10)
+          '';
         };
       });
     };

--- a/nix/README.md
+++ b/nix/README.md
@@ -11,7 +11,7 @@ nix develop
 
 To build a Codex you can use:
 ```sh
-nix build '.?submodules=1#codex'
+nix build '.?submodules=1#default'
 ```
 The `?submodules=1` part should eventually not be necessary.
 For more details see:
@@ -19,11 +19,17 @@ https://github.com/NixOS/nix/issues/4423
 
 It can be also done without even cloning the repo:
 ```sh
-nix build 'github:codex-storage/nim-codex?submodules=1'
+nix build 'git+https://github.com/codex-storage/nim-codex?submodules=1#'
 ```
 
 ## Running
 
 ```sh
-nix run 'github:codex-storage/nim-codex?submodules=1'
+nix run 'git+https://github.com/codex-storage/nim-codex?submodules=1#''
+```
+
+## Testing
+
+```sh
+nix flake check ".?submodules=1#"
 ```

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,18 +17,21 @@
   ).packages.${builtins.currentSystem}.default
 }:
 
+assert pkgs.lib.assertMsg ((src.submodules or true) == true)
+  "Unable to build without submodules. Append '?submodules=1#' to the URI.";
+
 let
   inherit (pkgs) stdenv lib writeScriptBin callPackage;
-  
+
   revision = lib.substring 0 8 (src.rev or "dirty");
 
   tools = callPackage ./tools.nix {};
 in pkgs.gcc11Stdenv.mkDerivation rec {
-  
+
   pname = "codex";
 
   version = "${tools.findKeyValue "version = \"([0-9]+\.[0-9]+\.[0-9]+)\"" ../codex.nimble}-${revision}";
-  
+
   inherit src;
 
   # Dependencies that should exist in the runtime environment.
@@ -69,14 +72,14 @@ in pkgs.gcc11Stdenv.mkDerivation rec {
   configurePhase = ''
     patchShebangs . > /dev/null
   '';
- 
+
   installPhase = ''
     mkdir -p $out/bin
     cp build/codex $out/bin/
   '';
 
   meta = with pkgs.lib; {
-    description = "Codex storage system";
+    description = "Nim Codex storage system";
     homepage = "https://github.com/codex-storage/nim-codex";
     license = licenses.mit;
     platforms = stableSystems;

--- a/nix/service.nix
+++ b/nix/service.nix
@@ -1,0 +1,57 @@
+{ self, config, lib, pkgs, circomCompatPkg, ... }:
+
+let
+  inherit (lib)
+    types mkEnableOption mkOption mkIf literalExpression
+    mdDoc;
+
+  toml = pkgs.formats.toml { };
+
+  cfg = config.services.nim-codex;
+in
+{
+  options = {
+    services.nim-codex = {
+      enable = mkEnableOption "Nim Codex Node service.";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.callPackage ./default.nix { src = self; inherit circomCompatPkg; };
+        defaultText = literalExpression "pkgs.codex";
+        description = mdDoc "Package to use as Nim Codex node.";
+      };
+
+      settings = mkOption {
+        default = { };
+        type = toml.type;
+        description = ''Structured settings object that will be used to generate a TOML config file.'';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc = {
+      "nim-codex/config.toml".source = toml.generate "config.toml" cfg.settings;
+    };
+    systemd.services.nim-codex = {
+      description = "Nim Codex Node";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "network.target" ];
+      serviceConfig = {
+        DynamicUser = true;
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectSystem = "full";
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        MemoryDenyWriteExecute = true;
+        ExecStart = "${cfg.package}/bin/codex --config-file=/etc/nim-codex/config.toml";
+        Restart = "on-failure";
+      };
+      restartIfChanged = true;
+      restartTriggers = [
+        "/etc/nim-codex/config.toml"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
Added service definition for Nim Codex and tests.
The service can be instantiated by including it in flake inputs:
```nix
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
    codex-flake.url = "git+https://github.com/codex-storage/nim-codex?submodules=1#";
  };
```

and configuring the service:
```nix
services.nim-codex = {
   enable = true;
   settings = {
       data-dir = "/var/lib/codex-test";
   };
};
```
