### PR TITLE
ci: create jenkins pipeline and enable build of nim compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 !LICENSE*
 !Makefile
+!Jenkinsfile
 
 nimcache/
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 
 nimcache/
 
+# Executables when using nix will be stored in result/ directory
+result/
+
 # Executables shall be put in an ignored build/ directory
 build/
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,37 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.9.13'
+
+pipeline {
+  agent { label 'linux && x86_64 && nix-2.24' }
+
+  options {
+    disableConcurrentBuilds()
+    /* manage how many builds we keep */
+    buildDiscarder(logRotator(
+      numToKeepStr: '20',
+      daysToKeepStr: '30',
+    ))
+  }
+
+  stages {
+    stage('Build') {
+      steps {
+        script {
+          nix.flake("default")
+        }
+      }
+    }
+
+    stage('Check') {
+      steps {
+        script {
+          sh './result/bin/codex --version'
+        }
+      }
+    }
+  }
+
+  post {
+    cleanup { cleanWs() }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         circomCompatPkg = circom-compat.packages.${system}.default;
         buildTarget = pkgsFor.${system}.callPackage ./nix/default.nix rec {
           inherit stableSystems circomCompatPkg;
-          src = pkgsFor.${system}.lib.traceValFn (v: "self.submodules: ${toString v.submodules}") self;
+          src = self;
         };
         build = targets: buildTarget.override { inherit targets; };
       in rec {

--- a/nix/README.md
+++ b/nix/README.md
@@ -4,7 +4,7 @@
 
 A development shell can be started using:
 ```sh
-nix develop
+nix develop '.?submodules=1#'
 ```
 
 ## Building

--- a/nix/checksums.nix
+++ b/nix/checksums.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  tools = pkgs.callPackage ./tools.nix {};
+  sourceFile = ../vendor/nimbus-build-system/vendor/Nim/koch.nim;
+in pkgs.fetchFromGitHub {
+  owner = "nim-lang";
+  repo = "checksums";
+  rev = tools.findKeyValue "^ +ChecksumsStableCommit = \"([a-f0-9]+)\"$" sourceFile;
+  # WARNING: Requires manual updates when Nim compiler version changes.
+  hash = "sha256-Bm5iJoT2kAvcTexiLMFBa9oU5gf7d4rWjo3OiN7obWQ=";
+}

--- a/nix/csources.nix
+++ b/nix/csources.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  tools = pkgs.callPackage ./tools.nix {};
+  sourceFile = ../vendor/nimbus-build-system/vendor/Nim/config/build_config.txt;
+in pkgs.fetchFromGitHub {
+  owner = "nim-lang";
+  repo = "csources_v2";
+  rev = tools.findKeyValue "^nim_csourcesHash=([a-f0-9]+)$" sourceFile;
+  # WARNING: Requires manual updates when Nim compiler version changes.
+  hash = "sha256-UCLtoxOcGYjBdvHx7A47x6FjLMi6VZqpSs65MN7fpBs=";
+}

--- a/nix/nimble.nix
+++ b/nix/nimble.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  tools = pkgs.callPackage ./tools.nix {};
+  sourceFile = ../vendor/nimbus-build-system/vendor/Nim/koch.nim;
+in pkgs.fetchFromGitHub {
+  owner = "nim-lang";
+  repo = "nimble";
+  fetchSubmodules = true;
+  rev = tools.findKeyValue "^ +NimbleStableCommit = \"([a-f0-9]+)\".+" sourceFile;
+  # WARNING: Requires manual updates when Nim compiler version changes.
+  hash = "sha256-Rz48sGUKZEAp+UySla+MlsOfsERekuGKw69Tm11fDz8=";
+}


### PR DESCRIPTION
Because of the recent bump of Nim compiler for codex to >2 version, using the system Nim provided by nixpkgs became unusable since the nim-codex couldn't build. Because of this I've adapted the derivation to be similar to the one of [nimbus-eth2](https://github.com/status-im/nimbus-eth2) where we build Nim compiler using nimbus-build-system.  

The pipeline on Jenkins is currently set to build nim-codex through flake, but there is a possibility to run the nix tests in the pipeline with slight modifications of the ci agents([the error](https://ci.status.im/job/nim-codex/job/systems/job/linux/job/x86_64/job/package/58/console) when running nix tests).
```shell
error: a 'x86_64-linux' with features {kvm, nixos-test} is required to build '/nix/store/9avanzkwb8f25c0az0f3f8jv2mkm4gfq-vm-test-run-nim-codex-test.drv', but I am a 'x86_64-linux' with features {benchmark, big-parallel, nixos-test, uid-range}
```

P.S. Unfortunately it is not possible anymore(to my knowledge) to instantiate the nix shell without specifying additionally `'.?submodules=1#'`. Cause of this is that the `callPackage` from `preBuild` phase is being called and all three calls  require submodules to be present.