### PR TITLE
feat: switch to github arm runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Compute matrix
         id: matrix
-        uses: fabiocaccamo/create-matrix-action@v4
+        uses: fabiocaccamo/create-matrix-action@v5
         with:
           matrix: |
             os {linux},   cpu {amd64}, builder {ubuntu-latest},   tests {unittest},    nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -98,7 +98,7 @@ jobs:
           - target:
               os: linux
               arch: arm64
-            builder: buildjet-8vcpu-ubuntu-2204-arm
+            builder: ubuntu-22.04-arm
 
     name: Build ${{ matrix.target.os }}/${{ matrix.target.arch }}
     runs-on: ${{ matrix.builder }}

--- a/.github/workflows/nim-matrix.yml
+++ b/.github/workflows/nim-matrix.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - name: Compute matrix
       id: matrix
-      uses: fabiocaccamo/create-matrix-action@v4
+      uses: fabiocaccamo/create-matrix-action@v5
       with:
         matrix: |
           os {linux}, cpu {amd64}, builder {ubuntu-20.04}, tests {unittest},    nim_version {${{ env.nim_version }}}, shell {bash --noprofile --norc -e -o pipefail}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
       uses: fabiocaccamo/create-matrix-action@v4
       with:
         matrix: |
-          os {linux},   cpu {amd64}, builder {ubuntu-20.04},                   nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
-          os {linux},   cpu {arm64}, builder {buildjet-4vcpu-ubuntu-2204-arm}, nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
-          os {macos},   cpu {amd64}, builder {macos-13},                       nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
-          os {macos},   cpu {arm64}, builder {macos-14},                       nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
-          os {windows}, cpu {amd64}, builder {windows-latest},                 nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {msys2}
+          os {linux},   cpu {amd64}, builder {ubuntu-20.04},     nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {linux},   cpu {arm64}, builder {ubuntu-22.04-arm}, nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {macos},   cpu {amd64}, builder {macos-13},         nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {macos},   cpu {arm64}, builder {macos-14},         nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {windows}, cpu {amd64}, builder {windows-latest},   nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {msys2}
 
   # Build
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: Compute matrix
       id: matrix
-      uses: fabiocaccamo/create-matrix-action@v4
+      uses: fabiocaccamo/create-matrix-action@v5
       with:
         matrix: |
           os {linux},   cpu {amd64}, builder {ubuntu-20.04},     nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}


### PR DESCRIPTION
GitHub just announced [Linux arm64 hosted runners now available for free in public repositories (Public Preview)](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).

This is similar to https://github.com/codex-storage/github-actions/pull/1 and we would like to switch Codex arm builds to GitHub hosted runners.

| Runner                           | Architecture | CPU | Memory  |
| -------------------------------- | ------------ | --- | ------- |
| `ubuntu-22-04`                   | `x86_amd64`  | `4` | `16 GB` |
| `buildjet-8vcpu-ubuntu-2204-arm` | `arm64`      | `8` | `12 GB` |
| `ubuntu-22-04-arm`               | `arm64`      | `4` | `16 GB` |

First round of comparison shows the following, for [Docker - Dist-Tests](https://github.com/codex-storage/nim-codex/actions/workflows/docker-dist-tests.yml) builds
| Runner                           | Run 1     | Run 2      | Run 3     |
| -------------------------------- | --------- | ---------- | --------- |
| `ubuntu-22-04`                   | `18m 47s` | `17m 30s ` | `18m 46s` |
| `buildjet-8vcpu-ubuntu-2204-arm` | `47m 25s` | `20m 40s`  | `20m 58s` |
|                                  |           |            |           |
| `ubuntu-22-04`                   | `18m 39s` | `18m 43s`  | `18m 46s` |
| `ubuntu-22-04-arm`               | `18m 36s` | `19m 15s`  | `18m 39s` |

Even, if BuildJet has more vCPU's, builds are faster on GitHub.