### PR TITLE
chore(marketplace): use custom error message when reservation is not allowed

### DIFF
--- a/codex/sales/states/slotreserving.nim
+++ b/codex/sales/states/slotreserving.nim
@@ -42,7 +42,7 @@ method run*(state: SaleSlotReserving, machine: Machine): Future[?State] {.async.
       trace "Reserving slot"
       await market.reserveSlot(data.requestId, data.slotIndex)
     except MarketError as e:
-      if e.msg.contains "Reservation not allowed":
+      if e.msg.contains "SlotReservations_ReservationNotAllowed":
         debug "Slot cannot be reserved, ignoring", error = e.msg
         return some State( SaleIgnored(reprocessSlot: false, returnBytes: true) )
       else:

--- a/tests/codex/sales/states/testslotreserving.nim
+++ b/tests/codex/sales/states/testslotreserving.nim
@@ -65,3 +65,11 @@ asyncchecksuite "sales state 'SlotReserving'":
     check next of SaleErrored
     let errored = SaleErrored(next)
     check errored.error == error
+
+  test "catches reservation not allowed error":
+    let error = newException(MarketError, "SlotReservations_ReservationNotAllowed")
+    market.setReserveSlotThrowError(some error)
+    let next = !(await state.run(agent))
+    check next of SaleIgnored
+    check SaleIgnored(next).reprocessSlot == false
+    check SaleIgnored(next).returnBytes


### PR DESCRIPTION
This PR replaces the previous message ""Reservation not allowed" to the custom error message "SlotReservations_ReservationNotAllowed".