### PR TITLE
fix slotqueue worker starvation

### DIFF
--- a/codex/sales/slotqueue.nim
+++ b/codex/sales/slotqueue.nim
@@ -421,6 +421,8 @@ proc run(self: SlotQueue) {.async: (raises: []).} =
         trace "readding seen item back into the queue"
         discard self.push(item) # on error, drop the item and continue
         worker.doneProcessing.complete()
+        if err =? self.addWorker().errorOption:
+          error "error adding new worker", error = err.msg
         await sleepAsync(1.millis) # poll
         continue
 

--- a/tests/codex/sales/testslotqueue.nim
+++ b/tests/codex/sales/testslotqueue.nim
@@ -511,6 +511,10 @@ suite "Slot queue":
       ]
     )
 
+  test "queue starts paused":
+    newSlotQueue(maxSize = 4, maxWorkers = 4)
+    check queue.paused
+
   test "pushing items to queue unpauses queue":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
     queue.pause
@@ -581,13 +585,17 @@ suite "Slot queue":
       request.expiry,
       seen = true
     )
-    # push seen item
+    # push seen item to ensure that queue is pausing
     check queue.push(seen).isSuccess
     # unpause and pause a number of times
     for _ in 0..<10:
+      # push unseen item to unpause the queue
       check queue.push(unseen).isSuccess
+      # wait for unseen item to be processed
       check eventually queue.len == 1
+      # wait for queue to pause because of seen item
       check eventually queue.paused
+      # check that the number of workers equals maximimum workers
       check eventually queue.activeWorkers == 0
 
   test "item 'seen' flags can be cleared":

--- a/tests/codex/sales/testslotqueue.nim
+++ b/tests/codex/sales/testslotqueue.nim
@@ -549,18 +549,10 @@ suite "Slot queue":
   test "processing a 'seen' item pauses the queue":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
     let request = StorageRequest.example
-    let unseen = SlotQueueItem.init(
-      request.id, 0'u16,
-      request.ask,
-      request.expiry,
-      seen = false
-    )
-    let seen = SlotQueueItem.init(
-      request.id, 1'u16,
-      request.ask,
-      request.expiry,
-      seen = true
-    )
+    let unseen =
+      SlotQueueItem.init(request.id, 0'u16, request.ask, request.expiry, seen = false)
+    let seen =
+      SlotQueueItem.init(request.id, 1'u16, request.ask, request.expiry, seen = true)
     # push causes unpause
     check queue.push(unseen).isSuccess
     # check all items processed
@@ -573,22 +565,14 @@ suite "Slot queue":
   test "processing a 'seen' item does not decrease the number of workers":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
     let request = StorageRequest.example
-    let unseen = SlotQueueItem.init(
-      request.id, 0'u16,
-      request.ask,
-      request.expiry,
-      seen = false
-    )
-    let seen = SlotQueueItem.init(
-      request.id, 1'u16,
-      request.ask,
-      request.expiry,
-      seen = true
-    )
+    let unseen =
+      SlotQueueItem.init(request.id, 0'u16, request.ask, request.expiry, seen = false)
+    let seen =
+      SlotQueueItem.init(request.id, 1'u16, request.ask, request.expiry, seen = true)
     # push seen item to ensure that queue is pausing
     check queue.push(seen).isSuccess
     # unpause and pause a number of times
-    for _ in 0..<10:
+    for _ in 0 ..< 10:
       # push unseen item to unpause the queue
       check queue.push(unseen).isSuccess
       # wait for unseen item to be processed


### PR DESCRIPTION
When an item in the slotqueue is already seen, then a worker got popped from the list of workers, and was not added back again. This meant that the number of workers steadily declined as the queue was paused and unpaused.

possible fix for #1072