### PR TITLE
fix(build): compilation on macos when including nim-nat-traversal

### DIFF
--- a/build.nims
+++ b/build.nims
@@ -2,24 +2,8 @@ mode = ScriptMode.Verbose
 
 import std/os except commandLineParams
 
-const VendorPath = "vendor/nim-nat-traversal/vendor/libnatpmp-upstream"
-let 
-  oldVersionFile = joinPath(VendorPath, "VERSION")
-  newVersionFile = joinPath(VendorPath, "VERSION_temp")
-
-proc renameFile(oldName, newName: string) =
-  if fileExists(oldName):
-    mvFile(oldName, newName)
-  else:
-    echo "File ", oldName, " does not exist"
-
-
 ### Helper functions
 proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =
-  # This is a quick workaround to avoid VERSION file conflict on macOS
-  # More details here: https://github.com/codex-storage/nim-codex/issues/1059
-  if defined(macosx):
-    renameFile(oldVersionFile, newVersionFile)
 
   if not dirExists "build":
     mkDir "build"
@@ -37,11 +21,8 @@ proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =
     # Place build output in 'build' folder, even if name includes a longer path.
     outName = os.lastPathPart(name)
     cmd = "nim " & lang & " --out:build/" & outName & " " & extra_params & " " & srcDir & name & ".nim"
-  try:
-    exec(cmd)
-  finally:
-    if defined(macosx):
-      renameFile(newVersionFile, oldVersionFile)
+
+  exec(cmd)
 
 proc test(name: string, srcDir = "tests/", params = "", lang = "c") =
   buildBinary name, srcDir, params


### PR DESCRIPTION
Removes the `VERSION` rename to `VERSION_temp` in the Makefile, instead relying on a change in `nim-nat-traversal`.

The change in `nim-nat-traversal` uses `-iqoute` to include the `nim-nat-traversal/vendor/libnatpmp-upstream` directory in the search paths. `-iquote` will match the `vendor/libnatpmp-upstream/VERSION` file for `#include "version"` and not `#include <version>`, the latter being what is included by the macos sdk and was causing issues with `-I`. The [gcc 14.2 docs](https://gcc.gnu.org/onlinedocs/gcc-14.2.0/cpp/Invocation.html#index-I) describe how `-iquote` alleviates this issue:
> Directories specified with -iquote apply only to the quote form of the directive, #include "file". Directories specified with -I, -isystem, or -idirafter apply to lookup for both the #include "file" and #include <file> directives.

For more info, please see https://github.com/status-im/nim-nat-traversal/pull/34.

NOTE: This PR relies on a branch of `nim-nat-traversal` due to https://github.com/status-im/nim-nat-traversal/pull/34. It's probably best to wait for that to be merged first, before merging this PR.