### PR TITLE
chore: ignoring style formatting commit for git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Formatted with nph v0.6.1-0-g0d8000e
+e5df8c50d3b6e70e6eec1ff031657d2b7bb6fe63


### PR DESCRIPTION
This is follow-up PR for https://github.com/codex-storage/nim-codex/pull/1067 that makes the styling commit being ignored for Git blame.