### PR TITLE
feat: multithreading support for erasure coding

### DIFF
--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -199,6 +199,7 @@ proc new*(
   var
     cache: CacheStore = nil
     taskpool: Taskpool
+
   try:
     if config.numThreads < 0:
       fatal "The number of threads --numThreads cannot be negative."
@@ -207,8 +208,7 @@ proc new*(
       taskpool = Taskpool.new(numThreads = min(countProcessors(), 16))
     else:
       taskpool = Taskpool.new(numThreads = config.numThreads)
-
-      info "Threadpool started", numThreads = taskpool.numThreads
+    info "Threadpool started", numThreads = taskpool.numThreads
   except Exception:
     raise newException(Defect, "Failure in taskpool initialization.")
 

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -201,18 +201,13 @@ proc new*(
     taskpool: Taskpool
 
   try:
-    if config.numThreads == 0:
+    if config.numThreads == ThreadCount(0):
       taskpool = Taskpool.new(numThreads = min(countProcessors(), 16))
-    elif config.numThreads < 2:
-      raise newException(
-        Defect, "The number of threads --numThreads cannot be less than two."
-      )
     else:
-      taskpool = Taskpool.new(numThreads = config.numThreads)
+      taskpool = Taskpool.new(numThreads = int(config.numThreads))
     info "Threadpool started", numThreads = taskpool.numThreads
-  except CatchableError as parent:
-    raise
-      newException(Defect, "Failure in taskpool initialization:" & parent.msg, parent)
+  except CatchableError as exc:
+    raiseAssert("Failure in taskpool initialization:" & exc.msg)
 
   if config.cacheSize > 0'nb:
     cache = CacheStore.new(cacheSize = config.cacheSize)

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -201,16 +201,18 @@ proc new*(
     taskpool: Taskpool
 
   try:
-    if config.numThreads < 0:
-      fatal "The number of threads --numThreads cannot be negative."
-      quit 1
-    elif config.numThreads == 0:
+    if config.numThreads == 0:
       taskpool = Taskpool.new(numThreads = min(countProcessors(), 16))
+    elif config.numThreads < 2:
+      raise newException(
+        Defect, "The number of threads --numThreads cannot be less than two."
+      )
     else:
       taskpool = Taskpool.new(numThreads = config.numThreads)
     info "Threadpool started", numThreads = taskpool.numThreads
-  except Exception:
-    raise newException(Defect, "Failure in taskpool initialization.")
+  except CatchableError as parent:
+    raise
+      newException(Defect, "Failure in taskpool initialization:" & parent.msg, parent)
 
   if config.cacheSize > 0'nb:
     cache = CacheStore.new(cacheSize = config.cacheSize)

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -53,6 +53,10 @@ export
   DefaultQuotaBytes, DefaultBlockTtl, DefaultBlockMaintenanceInterval,
   DefaultNumberOfBlocksToMaintainPerInterval
 
+type ThreadCount* = distinct Natural
+
+proc `==`*(a, b: ThreadCount): bool {.borrow.}
+
 proc defaultDataDir*(): string =
   let dataDir =
     when defined(windows):
@@ -71,6 +75,7 @@ const
 
   DefaultDataDir* = defaultDataDir()
   DefaultCircuitDir* = defaultDataDir() / "circuits"
+  DefaultThreadCount* = ThreadCount(0)
 
 type
   StartUpCmd* {.pure.} = enum
@@ -187,9 +192,9 @@ type
     numThreads* {.
       desc:
         "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)",
-      defaultValue: 0,
+      defaultValue: DefaultThreadCount,
       name: "num-threads"
-    .}: int
+    .}: ThreadCount
 
     agentString* {.
       defaultValue: "Codex",
@@ -489,6 +494,13 @@ proc parseCmdArg*(
     quit QuitFailure
   ma
 
+proc parseCmdArg*(T: type ThreadCount, input: string): T {.upraises: [ValueError].} =
+  let count = parseInt(input)
+  if count != 0 and count < 2:
+    warn "Invalid number of threads", input = input
+    quit QuitFailure
+  ThreadCount(count)
+
 proc parseCmdArg*(T: type SignedPeerRecord, uri: string): T =
   var res: SignedPeerRecord
   try:
@@ -587,6 +599,15 @@ proc readValue*(
   val = NBytes(value)
 
 proc readValue*(
+    r: var TomlReader, val: var ThreadCount
+) {.upraises: [SerializationError, IOError].} =
+  var str = r.readValue(string)
+  try:
+    val = parseCmdArg(ThreadCount, str)
+  except CatchableError as err:
+    raise newException(SerializationError, err.msg)
+
+proc readValue*(
     r: var TomlReader, val: var Duration
 ) {.upraises: [SerializationError, IOError].} =
   var str = r.readValue(string)
@@ -614,6 +635,9 @@ proc completeCmdArg*(T: type NBytes, val: string): seq[string] =
   discard
 
 proc completeCmdArg*(T: type Duration, val: string): seq[string] =
+  discard
+
+proc completeCmdArg*(T: type ThreadCount, val: string): seq[string] =
   discard
 
 # silly chronicles, colors is a compile-time property

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -184,6 +184,13 @@ type
       name: "max-peers"
     .}: int
 
+    numThreads* {.
+      desc:
+        "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)",
+      defaultValue: 0,
+      name: "num-threads"
+    .}: int
+
     agentString* {.
       defaultValue: "Codex",
       desc: "Node agent string which is used as identifier in network",

--- a/codex/erasure/backend.nim
+++ b/codex/erasure/backend.nim
@@ -29,7 +29,9 @@ method release*(self: ErasureBackend) {.base, gcsafe.} =
   raiseAssert("not implemented!")
 
 method encode*(
-    self: EncoderBackend, buffers, parity: var openArray[seq[byte]]
+    self: EncoderBackend,
+    buffers, parity: ptr UncheckedArray[ptr UncheckedArray[byte]],
+    dataLen, parityLen: int,
 ): Result[void, cstring] {.base, gcsafe.} =
   ## encode buffers using a backend
   ##

--- a/codex/erasure/backend.nim
+++ b/codex/erasure/backend.nim
@@ -38,7 +38,9 @@ method encode*(
   raiseAssert("not implemented!")
 
 method decode*(
-    self: DecoderBackend, buffers, parity, recovered: var openArray[seq[byte]]
+    self: DecoderBackend,
+    buffers, parity, recovered: ptr UncheckedArray[ptr UncheckedArray[byte]],
+    dataLen, parityLen, recoveredLen: int,
 ): Result[void, cstring] {.base, gcsafe.} =
   ## decode buffers using a backend
   ##

--- a/codex/erasure/backends/leopard.nim
+++ b/codex/erasure/backends/leopard.nim
@@ -41,7 +41,9 @@ method encode*(
   encoder.encode(data, parity, dataLen, parityLen)
 
 method decode*(
-    self: LeoDecoderBackend, data, parity, recovered: var openArray[seq[byte]]
+    self: LeoDecoderBackend,
+    data, parity, recovered: ptr UncheckedArray[ptr UncheckedArray[byte]],
+    dataLen, parityLen, recoveredLen: int,
 ): Result[void, cstring] =
   ## Decode data using given Leopard backend
 
@@ -52,7 +54,7 @@ method decode*(
     else:
       self.decoder.get()
 
-  decoder.decode(data, parity, recovered)
+  decoder.decode(data, parity, recovered, dataLen, parityLen, recoveredLen)
 
 method release*(self: LeoEncoderBackend) =
   if self.encoder.isSome:

--- a/codex/erasure/backends/leopard.nim
+++ b/codex/erasure/backends/leopard.nim
@@ -22,11 +22,13 @@ type
     decoder*: Option[LeoDecoder]
 
 method encode*(
-    self: LeoEncoderBackend, data, parity: var openArray[seq[byte]]
+    self: LeoEncoderBackend,
+    data, parity: ptr UncheckedArray[ptr UncheckedArray[byte]],
+    dataLen, parityLen: int,
 ): Result[void, cstring] =
   ## Encode data using Leopard backend
 
-  if parity.len == 0:
+  if parityLen == 0:
     return ok()
 
   var encoder =
@@ -36,7 +38,7 @@ method encode*(
     else:
       self.encoder.get()
 
-  encoder.encode(data, parity)
+  encoder.encode(data, parity, dataLen, parityLen)
 
 method decode*(
     self: LeoDecoderBackend, data, parity, recovered: var openArray[seq[byte]]

--- a/codex/erasure/erasure.nim
+++ b/codex/erasure/erasure.nim
@@ -613,7 +613,6 @@ proc new*(
 ): Erasure =
   ## Create a new Erasure instance for encoding and decoding manifests
   ##
-
   Erasure(
     store: store,
     encoderProvider: encoderProvider,

--- a/codex/erasure/erasure.nim
+++ b/codex/erasure/erasure.nim
@@ -94,10 +94,9 @@ type
   EncodeTask = object
     success: Atomic[bool]
     erasure: ptr Erasure
-    blockSize: int
     blocks: ptr UncheckedArray[ptr UncheckedArray[byte]]
     parity: ptr UncheckedArray[ptr UncheckedArray[byte]]
-    blocksLen, parityLen: int
+    blockSize, blocksLen, parityLen: int
     signal: ThreadSignalPtr
 
   DecodeTask = object
@@ -106,8 +105,8 @@ type
     blocks: ptr UncheckedArray[ptr UncheckedArray[byte]]
     parity: ptr UncheckedArray[ptr UncheckedArray[byte]]
     recovered: ptr UncheckedArray[ptr UncheckedArray[byte]]
-    blockSize: int
-    blocksLen, parityLen, recoveredLen: int
+    blockSize, blocksLen: int
+    parityLen, recoveredLen: int
     signal: ThreadSignalPtr
 
 func indexToPos(steps, idx, step: int): int {.inline.} =

--- a/codex/erasure/erasure.nim
+++ b/codex/erasure/erasure.nim
@@ -320,6 +320,9 @@ proc encodeAsync*(
   without threadPtr =? ThreadSignalPtr.new():
     return failure("Unable to create thread signal")
 
+  defer:
+    threadPtr.close().expect("closing once works")
+
   var blockData = createDoubleArray(blocksLen, blockSize)
 
   for i in 0 ..< data[].len:
@@ -358,8 +361,6 @@ proc encodeAsync*(
         raise (ref CancelledError) exc
       else:
         return failure(exc.msg)
-  finally:
-    threadPtr.close().expect("closing once works")
 
   if not t.success.load():
     return failure("Leopard encoding failed")
@@ -373,7 +374,6 @@ proc encodeData(
   ##
   ## `manifest` - the manifest to encode
   ##
-
   logScope:
     steps = params.steps
     rounded_blocks = params.rounded
@@ -518,6 +518,9 @@ proc decodeAsync*(
   without threadPtr =? ThreadSignalPtr.new():
     return failure("Unable to create thread signal")
 
+  defer:
+    threadPtr.close().expect("closing once works")
+
   var
     blocksData = createDoubleArray(blocksLen, blockSize)
     parityData = createDoubleArray(parityLen, blockSize)
@@ -570,8 +573,6 @@ proc decodeAsync*(
         raise (ref CancelledError) exc
       else:
         return failure(exc.msg)
-  finally:
-    threadPtr.close().expect("closing once works")
 
   if not t.success.load():
     return failure("Leopard encoding failed")
@@ -585,7 +586,6 @@ proc decode*(self: Erasure, encoded: Manifest): Future[?!Manifest] {.async.} =
   ## `encoded` - the encoded (protected) manifest to
   ##             be recovered
   ##
-
   logScope:
     steps = encoded.steps
     rounded_blocks = encoded.rounded

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -728,6 +728,9 @@ proc stop*(self: CodexNodeRef) {.async.} =
   if not self.networkStore.isNil:
     await self.networkStore.close
 
+  if not self.taskpool.isNil:
+    self.taskpool.shutdown()
+
 proc new*(
     T: type CodexNodeRef,
     switch: Switch,

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -71,6 +71,7 @@ type
     contracts*: Contracts
     clock*: Clock
     storage*: Contracts
+    taskpool: Taskpool
 
   CodexNodeRef* = ref CodexNode
 
@@ -237,7 +238,7 @@ proc streamEntireDataset(
     proc erasureJob(): Future[?!void] {.async.} =
       # Spawn an erasure decoding job
       let erasure = Erasure.new(
-        self.networkStore, leoEncoderProvider, leoDecoderProvider, Taskpool.new()
+        self.networkStore, leoEncoderProvider, leoDecoderProvider, self.taskpool
       )
       without _ =? (await erasure.decode(manifest)), error:
         error "Unable to erasure decode manifest", manifestCid, exc = error.msg
@@ -406,7 +407,7 @@ proc setupRequest(
 
   # Erasure code the dataset according to provided parameters
   let erasure = Erasure.new(
-    self.networkStore.localStore, leoEncoderProvider, leoDecoderProvider, Taskpool.new()
+    self.networkStore.localStore, leoEncoderProvider, leoDecoderProvider, self.taskpool
   )
 
   without encoded =? (await erasure.encode(manifest, ecK, ecM)), error:
@@ -733,6 +734,7 @@ proc new*(
     networkStore: NetworkStore,
     engine: BlockExcEngine,
     discovery: Discovery,
+    taskpool: Taskpool,
     prover = Prover.none,
     contracts = Contracts.default,
 ): CodexNodeRef =
@@ -745,5 +747,6 @@ proc new*(
     engine: engine,
     prover: prover,
     discovery: discovery,
+    taskPool: taskpool,
     contracts: contracts,
   )

--- a/codex/utils/arrayutils.nim
+++ b/codex/utils/arrayutils.nim
@@ -1,0 +1,25 @@
+import std/sequtils
+
+proc createDoubleArray*(
+    outerLen, innerLen: int
+): ptr UncheckedArray[ptr UncheckedArray[byte]] =
+  # Allocate outer array
+  result = cast[ptr UncheckedArray[ptr UncheckedArray[byte]]](allocShared0(
+    sizeof(ptr UncheckedArray[byte]) * outerLen
+  ))
+
+  # Allocate each inner array
+  for i in 0 ..< outerLen:
+    result[i] = cast[ptr UncheckedArray[byte]](allocShared0(sizeof(byte) * innerLen))
+
+proc freeDoubleArray*(
+    arr: ptr UncheckedArray[ptr UncheckedArray[byte]], outerLen: int
+) =
+  # Free each inner array
+  for i in 0 ..< outerLen:
+    if not arr[i].isNil:
+      deallocShared(arr[i])
+
+  # Free outer array
+  if not arr.isNil:
+    deallocShared(arr)

--- a/tests/codex/node/helpers.nim
+++ b/tests/codex/node/helpers.nim
@@ -6,6 +6,7 @@ import pkg/chronos
 import pkg/codex/codextypes
 import pkg/codex/chunker
 import pkg/codex/stores
+import pkg/taskpools
 
 import ../../asynctest
 
@@ -118,6 +119,7 @@ template setupAndTearDown*() {.dirty.} =
       engine = engine,
       prover = Prover.none,
       discovery = blockDiscovery,
+      taskpool = Taskpool.new(),
     )
 
   teardown:

--- a/tests/codex/node/testcontracts.nim
+++ b/tests/codex/node/testcontracts.nim
@@ -75,7 +75,7 @@ asyncchecksuite "Test Node - Host contracts":
     let
       manifestBlock =
         bt.Block.new(manifest.encode().tryGet(), codec = ManifestCodec).tryGet()
-      erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider)
+      erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider, Taskpool.new)
 
     manifestCid = manifestBlock.cid
     manifestCidStr = $(manifestCid)

--- a/tests/codex/node/testnode.nim
+++ b/tests/codex/node/testnode.nim
@@ -12,6 +12,7 @@ import pkg/questionable/results
 import pkg/stint
 import pkg/poseidon2
 import pkg/poseidon2/io
+import pkg/taskpools
 
 import pkg/nitro
 import pkg/codexdht/discv5/protocol as discv5
@@ -137,7 +138,8 @@ asyncchecksuite "Test Node - Basic":
 
   test "Setup purchase request":
     let
-      erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider)
+      erasure =
+        Erasure.new(store, leoEncoderProvider, leoDecoderProvider, Taskpool.new())
       manifest = await storeDataGetManifest(localStore, chunker)
       manifestBlock =
         bt.Block.new(manifest.encode().tryGet(), codec = ManifestCodec).tryGet()

--- a/tests/codex/node/testnode.nim
+++ b/tests/codex/node/testnode.nim
@@ -67,7 +67,7 @@ asyncchecksuite "Test Node - Basic":
     # https://github.com/codex-storage/nim-codex/issues/699
     let
       cstore = CountingStore.new(engine, localStore)
-      node = CodexNodeRef.new(switch, cstore, engine, blockDiscovery)
+      node = CodexNodeRef.new(switch, cstore, engine, blockDiscovery, Taskpool.new())
       missingCid =
         Cid.init("zDvZRwzmCvtiyubW9AecnxgLnXK8GrBvpQJBDzToxmzDN6Nrc2CZ").get()
 

--- a/tests/codex/testerasure.nim
+++ b/tests/codex/testerasure.nim
@@ -248,17 +248,17 @@ suite "Erasure encode/decode":
       # encode the data concurrently
       encodeTasks.add(erasure.encode(manifest, ecK, ecM))
     # wait for all encoding tasks to finish
-    let encodeResults = await all(encodeTasks)
+    let encodeResults = await allFinished(encodeTasks)
     # decode the data concurrently
     for i in 0 ..< encodeResults.len:
-      decodeTasks.add(erasure.decode(encodeResults[i].tryGet()))
+      decodeTasks.add(erasure.decode(encodeResults[i].read().tryGet()))
     # wait for all decoding tasks to finish
-    let decodeResults = await all(decodeTasks)
+    let decodeResults = await allFinished(decodeTasks) # TODO: use allFutures 
 
     for j in 0 ..< decodeTasks.len:
       let
-        decoded = decodeResults[j].tryGet()
-        encoded = encodeResults[j].tryGet()
+        decoded = decodeResults[j].read().tryGet()
+        encoded = encodeResults[j].read().tryGet()
       check:
         decoded.treeCid == manifests[j].treeCid
         decoded.treeCid == encoded.originalTreeCid

--- a/tests/codex/testerasure.nim
+++ b/tests/codex/testerasure.nim
@@ -37,8 +37,7 @@ suite "Erasure encode/decode":
     rng = Rng.instance()
     chunker = RandomChunker.new(rng, size = dataSetSize, chunkSize = BlockSize)
     store = RepoStore.new(repoDs, metaDs)
-    var taskPool = Taskpool.new()
-    erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider, taskPool)
+    erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider, Taskpool.new())
     manifest = await storeDataGetManifest(store, chunker)
 
   teardown:
@@ -243,6 +242,7 @@ suite "Erasure encode/decode":
       decoded.treeCid == manifest.treeCid
       decoded.treeCid == verifiable.originalTreeCid
       decoded.blocksCount == verifiable.originalBlocksCount
+
   for i in 1 .. 5:
     test "Should encode/decode using various parameters " & $i & "/5":
       let

--- a/tests/codex/testerasure.nim
+++ b/tests/codex/testerasure.nim
@@ -218,7 +218,7 @@ suite "Erasure encode/decode":
       let present = await store.hasBlock(manifest.treeCid, d)
       check present.tryGet()
 
-  test "handles edge case of 0 parity blocks":
+  test "Handles edge case of 0 parity blocks":
     const
       buffers = 20
       parity = 0

--- a/tests/codex/testerasure.nim
+++ b/tests/codex/testerasure.nim
@@ -1,5 +1,6 @@
 import std/sequtils
 import std/sugar
+import std/times
 
 import pkg/chronos
 import pkg/questionable/results
@@ -11,6 +12,7 @@ import pkg/codex/blocktype as bt
 import pkg/codex/rng
 import pkg/codex/utils
 import pkg/codex/indexingstrategy
+import pkg/taskpools
 
 import ../asynctest
 import ./helpers
@@ -35,7 +37,8 @@ suite "Erasure encode/decode":
     rng = Rng.instance()
     chunker = RandomChunker.new(rng, size = dataSetSize, chunkSize = BlockSize)
     store = RepoStore.new(repoDs, metaDs)
-    erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider)
+    var taskPool = Taskpool.new()
+    erasure = Erasure.new(store, leoEncoderProvider, leoDecoderProvider, taskPool)
     manifest = await storeDataGetManifest(store, chunker)
 
   teardown:
@@ -240,7 +243,6 @@ suite "Erasure encode/decode":
       decoded.treeCid == manifest.treeCid
       decoded.treeCid == verifiable.originalTreeCid
       decoded.blocksCount == verifiable.originalBlocksCount
-
   for i in 1 .. 5:
     test "Should encode/decode using various parameters " & $i & "/5":
       let


### PR DESCRIPTION
This PR introduces the following changes:

- Utilizes `TaskPool` to spawn separate threads for the erasure encoding and decoding.
- Adds a new `num-threads` flag, enabling users to specify the number of CPU threads available for TaskPool workers.

**Docs [PR](https://github.com/codex-storage/codex-docs/pull/58)**
