### PR TITLE
Prevent duplicate block transmission

### DIFF
--- a/codex/blockexchange/engine/pendingblocks.nim
+++ b/codex/blockexchange/engine/pendingblocks.nim
@@ -113,12 +113,23 @@ proc setInFlight*(p: PendingBlocksManager, address: BlockAddress, inFlight = tru
   p.blocks.withValue(address, pending):
     pending[].inFlight = inFlight
 
+proc setInFlight*(
+    p: PendingBlocksManager, addresses: seq[BlockAddress], inFlight = true
+) =
+  for addrs in addresses:
+    p.setInFlight(addrs, inFlight)
+
 proc isInFlight*(p: PendingBlocksManager, address: BlockAddress): bool =
   ## Check if a block is in flight
   ##
 
   p.blocks.withValue(address, pending):
     result = pending[].inFlight
+
+proc getNotInFlight*(
+    p: PendingBlocksManager, addresses: seq[BlockAddress]
+): seq[BlockAddress] =
+  addresses.filterIt(not p.isInFlight(it))
 
 proc contains*(p: PendingBlocksManager, cid: Cid): bool =
   BlockAddress.init(cid) in p.blocks

--- a/tests/codex/blockexchange/testpendingblocks.nim
+++ b/tests/codex/blockexchange/testpendingblocks.nim
@@ -91,7 +91,7 @@ checksuite "Pending Blocks - inFlight":
     blk = bt.Block.new("Hello".toBytes).tryGet
     addrs = BlockAddress.init(blk.cid)
     discard pendingBlocks.getWantHandle(addrs)
-  
+
   proc req(): BlockReq =
     pendingBlocks.blocks[addrs]
 
@@ -100,13 +100,13 @@ checksuite "Pending Blocks - inFlight":
 
     check:
       req().inFlight
-    
+
   test "Sets inFlight (multiple)":
     pendingBlocks.setInFlight(@[addrs])
 
     check:
       req().inFlight
-    
+
   test "IsInFlight":
     pendingBlocks.setInFlight(addrs)
 


### PR DESCRIPTION
During reliability testing (https://github.com/codex-storage/nim-codex/issues/974) block retransmission was found to cause significant delay and download failure in larger networks.

This PR prevents wantBlocks being sent for open requests for which a wantBlock has already been sent, reducing duplicates to zero.

Open issue (that already existed and hasn't been seen in testing) is that when a wantBlock is sent and the peer *doesn't* respond with the block, the inFlight flag is never cleared, forcing the full block-retrieval-timeout before the block can be retried.
