### PR TITLE
fix dataset and slot size calculations in integration tests

### DIFF
--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -86,8 +86,7 @@ proc example(_: type G2Point): G2Point =
 proc example*(_: type Groth16Proof): Groth16Proof =
   Groth16Proof(a: G1Point.example, b: G2Point.example, c: G1Point.example)
 
-proc example*(_: type RandomChunker, blocks: int): Future[string] {.async.} =
-  # doAssert blocks >= 3, "must be more than 3 blocks"
+proc example*(_: type RandomChunker, blocks: int): Future[seq[byte]] {.async.} =
   let rng = Rng.instance()
   let chunker = RandomChunker.new(
     rng, size = DefaultBlockSize * blocks.NBytes, chunkSize = DefaultBlockSize
@@ -95,20 +94,7 @@ proc example*(_: type RandomChunker, blocks: int): Future[string] {.async.} =
   var data: seq[byte]
   while (let moar = await chunker.getBytes(); moar != []):
     data.add moar
-  return byteutils.toHex(data)
-
-proc exampleBytes*(_: type RandomChunker, blocks: int): Future[string] {.async.} =
-  let rng = Rng.instance()
-  let chunker = RandomChunker.new(
-    rng, size = DefaultBlockSize * blocks.NBytes, chunkSize = DefaultBlockSize
-  )
-  var data: seq[byte]
-  while (let moar = await chunker.getBytes(); moar != []):
-    data.add moar
-  let hex = byteutils.toHex(data)
-  let truncated = hex[0 .. DefaultBlockSize.int * blocks - 1]
-  echo "Generated random data with length: ", truncated.len
-  return truncated
+  return data
 
 proc example*(_: type RandomChunker): Future[string] {.async.} =
   await RandomChunker.example(3)

--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -97,5 +97,18 @@ proc example*(_: type RandomChunker, blocks: int): Future[string] {.async.} =
     data.add moar
   return byteutils.toHex(data)
 
+proc exampleBytes*(_: type RandomChunker, blocks: int): Future[string] {.async.} =
+  let rng = Rng.instance()
+  let chunker = RandomChunker.new(
+    rng, size = DefaultBlockSize * blocks.NBytes, chunkSize = DefaultBlockSize
+  )
+  var data: seq[byte]
+  while (let moar = await chunker.getBytes(); moar != []):
+    data.add moar
+  let hex = byteutils.toHex(data)
+  let truncated = hex[0 .. DefaultBlockSize.int * blocks - 1]
+  echo "Generated random data with length: ", truncated.len
+  return truncated
+
 proc example*(_: type RandomChunker): Future[string] {.async.} =
   await RandomChunker.example(3)

--- a/tests/integration/codexclient.nim
+++ b/tests/integration/codexclient.nim
@@ -45,11 +45,7 @@ proc upload*(client: CodexClient, contents: string): ?!Cid =
   Cid.init(response.body).mapFailure
 
 proc upload*(client: CodexClient, bytes: seq[byte]): ?!Cid =
-  proc toString(bytes: seq[byte]): string =
-    result = newString(bytes.len)
-    copyMem(result[0].addr, bytes[0].unsafeAddr, bytes.len)
-
-  client.upload(bytes.toString)
+  client.upload(string.fromBytes(bytes))
 
 proc download*(client: CodexClient, cid: Cid, local = false): ?!string =
   let response = client.http.get(

--- a/tests/integration/codexclient.nim
+++ b/tests/integration/codexclient.nim
@@ -44,6 +44,13 @@ proc upload*(client: CodexClient, contents: string): ?!Cid =
   assert response.status == "200 OK"
   Cid.init(response.body).mapFailure
 
+proc upload*(client: CodexClient, bytes: seq[byte]): ?!Cid =
+  proc toString(bytes: seq[byte]): string =
+    result = newString(bytes.len)
+    copyMem(result[0].addr, bytes[0].unsafeAddr, bytes.len)
+
+  client.upload(bytes.toString)
+
 proc download*(client: CodexClient, cid: Cid, local = false): ?!string =
   let response = client.http.get(
     client.baseurl & "/data/" & $cid & (if local: "" else: "/network/stream")

--- a/tests/integration/marketplacesuite.nim
+++ b/tests/integration/marketplacesuite.nim
@@ -4,6 +4,7 @@ from pkg/libp2p import Cid
 import pkg/codex/contracts/marketplace as mp
 import pkg/codex/periods
 import pkg/codex/utils/json
+from pkg/codex/utils import roundUp, divUp
 import ./multinodes
 import ../contracts/time
 import ../contracts/deployment
@@ -45,11 +46,14 @@ template marketplacesuite*(name: string, body: untyped) =
     proc periods(p: int): uint64 =
       p.uint64 * period
 
-    proc slotSize(blocks: int): UInt256 =
-      (DefaultBlockSize * blocks.NBytes).Natural.u256
+    proc slotSize(blocks, nodes, tolerance: int): UInt256 =
+      let ecK = nodes - tolerance
+      let blocksRounded = roundUp(blocks, ecK)
+      let blocksPerSlot = divUp(blocksRounded, ecK)
+      (DefaultBlockSize * blocksPerSlot.NBytes).Natural.u256
 
     proc datasetSize(blocks, nodes, tolerance: int): UInt256 =
-      (nodes + tolerance).u256 * slotSize(blocks)
+      return nodes.u256 * slotSize(blocks, nodes, tolerance)
 
     proc createAvailabilities(
         datasetSize: UInt256,

--- a/tests/integration/testmarketplace.nim
+++ b/tests/integration/testmarketplace.nim
@@ -35,7 +35,7 @@ marketplacesuite "Marketplace":
 
   test "nodes negotiate contracts on the marketplace", marketplaceConfig:
     let size = 0xFFFFFF.u256
-    let data = await RandomChunker.exampleBytes(blocks = blocks)
+    let data = await RandomChunker.example(blocks = blocks)
     # host makes storage available
     let availability = host.postAvailability(
       totalSize = size,
@@ -72,7 +72,7 @@ marketplacesuite "Marketplace":
   test "node slots gets paid out and rest of tokens are returned to client",
     marketplaceConfig:
     let size = 0xFFFFFF.u256
-    let data = await RandomChunker.exampleBytes(blocks = blocks)
+    let data = await RandomChunker.example(blocks = blocks)
     let marketplace = Marketplace.new(Marketplace.address, ethProvider.getSigner())
     let tokenAddress = await marketplace.token()
     let token = Erc20Token.new(tokenAddress, ethProvider.getSigner())
@@ -147,7 +147,7 @@ marketplacesuite "Marketplace payouts":
     ):
     let duration = 20.periods
     let expiry = 10.periods
-    let data = await RandomChunker.exampleBytes(blocks = blocks)
+    let data = await RandomChunker.example(blocks = blocks)
     let client = clients()[0]
     let provider = providers()[0]
     let clientApi = client.client

--- a/tests/integration/testmarketplace.nim
+++ b/tests/integration/testmarketplace.nim
@@ -35,7 +35,7 @@ marketplacesuite "Marketplace":
 
   test "nodes negotiate contracts on the marketplace", marketplaceConfig:
     let size = 0xFFFFFF.u256
-    let data = await RandomChunker.example(blocks = blocks)
+    let data = await RandomChunker.exampleBytes(blocks = blocks)
     # host makes storage available
     let availability = host.postAvailability(
       totalSize = size,
@@ -72,7 +72,7 @@ marketplacesuite "Marketplace":
   test "node slots gets paid out and rest of tokens are returned to client",
     marketplaceConfig:
     let size = 0xFFFFFF.u256
-    let data = await RandomChunker.example(blocks = blocks)
+    let data = await RandomChunker.exampleBytes(blocks = blocks)
     let marketplace = Marketplace.new(Marketplace.address, ethProvider.getSigner())
     let tokenAddress = await marketplace.token()
     let token = Erc20Token.new(tokenAddress, ethProvider.getSigner())
@@ -112,7 +112,7 @@ marketplacesuite "Marketplace":
     await ethProvider.advanceTime(duration)
 
     # Checking that the hosting node received reward for at least the time between <expiry;end>
-    let slotSize = slotSize(blocks)
+    let slotSize = slotSize(blocks, ecNodes, ecTolerance)
     let pricePerSlotPerSecond = minPricePerBytePerSecond * slotSize
     check eventually (await token.balanceOf(hostAccount)) - startBalanceHost >=
       (duration - 5 * 60) * pricePerSlotPerSecond * ecNodes.u256
@@ -147,7 +147,7 @@ marketplacesuite "Marketplace payouts":
     ):
     let duration = 20.periods
     let expiry = 10.periods
-    let data = await RandomChunker.example(blocks = blocks)
+    let data = await RandomChunker.exampleBytes(blocks = blocks)
     let client = clients()[0]
     let provider = providers()[0]
     let clientApi = client.client
@@ -197,7 +197,7 @@ marketplacesuite "Marketplace payouts":
 
     await advanceToNextPeriod()
 
-    let slotSize = slotSize(blocks)
+    let slotSize = slotSize(blocks, ecNodes, ecTolerance)
     let pricePerSlotPerSecond = minPricePerBytePerSecond * slotSize
 
     check eventually (

--- a/tests/integration/testproofs.nim
+++ b/tests/integration/testproofs.nim
@@ -40,7 +40,7 @@ marketplacesuite "Hosts submit regular proofs":
     let expiry = 10.periods
     let duration = expiry + 5.periods
 
-    let data = await RandomChunker.example(blocks = blocks)
+    let data = await RandomChunker.exampleBytes(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(
@@ -60,8 +60,7 @@ marketplacesuite "Hosts submit regular proofs":
     let purchase = client0.getPurchase(purchaseId).get
     check purchase.error == none string
 
-    let request = purchase.request.get
-    let slotSize = request.ask.slotSize
+    let slotSize = slotSize(blocks, ecNodes, ecTolerance)
 
     check eventually(
       client0.purchaseStateIs(purchaseId, "started"), timeout = expiry.int * 1000
@@ -115,7 +114,7 @@ marketplacesuite "Simulate invalid proofs":
     let expiry = 10.periods
     let duration = expiry + 10.periods
 
-    let data = await RandomChunker.example(blocks = blocks)
+    let data = await RandomChunker.exampleBytes(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(
@@ -175,7 +174,7 @@ marketplacesuite "Simulate invalid proofs":
     let expiry = 10.periods
     let duration = expiry + 10.periods
 
-    let data = await RandomChunker.example(blocks = blocks)
+    let data = await RandomChunker.exampleBytes(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(
@@ -258,7 +257,7 @@ marketplacesuite "Simulate invalid proofs":
   #   let totalPeriods = 25
 
   #   let datasetSizeInBlocks = 3
-  #   let data = await RandomChunker.example(blocks=datasetSizeInBlocks)
+  #   let data = await RandomChunker.exampleBytes(blocks=datasetSizeInBlocks)
   #   # original data = 3 blocks so slot size will be 4 blocks
   #   let slotSize = (DefaultBlockSize * 4.NBytes).Natural.u256
 

--- a/tests/integration/testproofs.nim
+++ b/tests/integration/testproofs.nim
@@ -1,7 +1,6 @@
 from std/times import inMilliseconds
 import pkg/questionable
 import pkg/codex/logutils
-import pkg/stew/byteutils
 import ../contracts/time
 import ../contracts/deployment
 import ../codex/helpers
@@ -40,7 +39,7 @@ marketplacesuite "Hosts submit regular proofs":
     let expiry = 10.periods
     let duration = expiry + 5.periods
 
-    let data = await RandomChunker.exampleBytes(blocks = blocks)
+    let data = await RandomChunker.example(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(
@@ -114,7 +113,7 @@ marketplacesuite "Simulate invalid proofs":
     let expiry = 10.periods
     let duration = expiry + 10.periods
 
-    let data = await RandomChunker.exampleBytes(blocks = blocks)
+    let data = await RandomChunker.example(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(
@@ -174,7 +173,7 @@ marketplacesuite "Simulate invalid proofs":
     let expiry = 10.periods
     let duration = expiry + 10.periods
 
-    let data = await RandomChunker.exampleBytes(blocks = blocks)
+    let data = await RandomChunker.example(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(
@@ -257,7 +256,7 @@ marketplacesuite "Simulate invalid proofs":
   #   let totalPeriods = 25
 
   #   let datasetSizeInBlocks = 3
-  #   let data = await RandomChunker.exampleBytes(blocks=datasetSizeInBlocks)
+  #   let data = await RandomChunker.example(blocks=datasetSizeInBlocks)
   #   # original data = 3 blocks so slot size will be 4 blocks
   #   let slotSize = (DefaultBlockSize * 4.NBytes).Natural.u256
 

--- a/tests/integration/testrestapi.nim
+++ b/tests/integration/testrestapi.nim
@@ -1,5 +1,6 @@
 import std/httpclient
 import std/sequtils
+import std/strformat
 from pkg/libp2p import `==`
 import pkg/codex/units
 import ./twonodes
@@ -144,18 +145,19 @@ twonodessuite "REST API":
       check responseBefore.body ==
         "Invalid parameters: `tolerance` cannot be greater than `nodes`"
 
-  test "request storage succeeds if nodes and tolerance within range", twoNodesConfig:
-    let data = await RandomChunker.example(blocks = 2)
-    let cid = client1.upload(data).get
-    let duration = 100.u256
-    let pricePerBytePerSecond = 1.u256
-    let proofProbability = 3.u256
-    let expiry = 30.uint
-    let collateralPerByte = 1.u256
-    let ecParams = @[(3, 1), (5, 2)]
-
-    for ecParam in ecParams:
-      let (nodes, tolerance) = ecParam
+  for ecParams in @[
+    (minBlocks: 2, nodes: 3, tolerance: 1), (minBlocks: 3, nodes: 5, tolerance: 2)
+  ]:
+    let (minBlocks, nodes, tolerance) = ecParams
+    test "request storage succeeds if nodes and tolerance within range " &
+      fmt"({minBlocks=}, {nodes=}, {tolerance=})", twoNodesConfig:
+      let data = await RandomChunker.example(blocks = minBlocks)
+      let cid = client1.upload(data).get
+      let duration = 100.u256
+      let pricePerBytePerSecond = 1.u256
+      let proofProbability = 3.u256
+      let expiry = 30.uint
+      let collateralPerByte = 1.u256
 
       var responseBefore = client1.requestStorageRaw(
         cid, duration, pricePerBytePerSecond, proofProbability, collateralPerByte,

--- a/tests/integration/testupdownload.nim
+++ b/tests/integration/testupdownload.nim
@@ -88,7 +88,7 @@ twonodessuite "Uploads and downloads":
       let cid = a.upload(data).get
       let response = b.download(cid).get
       check:
-        response == data
+        @response.mapIt(it.byte) == data
 
     for run in 0 .. 10:
       await transferTest(client1, client2)

--- a/tests/integration/testvalidator.nim
+++ b/tests/integration/testvalidator.nim
@@ -96,7 +96,7 @@ marketplacesuite "Validation":
     var currentTime = await ethProvider.currentTime()
     let requestEndTime = currentTime.truncate(uint64) + duration
 
-    let data = await RandomChunker.example(blocks = blocks)
+    let data = await RandomChunker.exampleBytes(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(
@@ -163,7 +163,7 @@ marketplacesuite "Validation":
     var currentTime = await ethProvider.currentTime()
     let requestEndTime = currentTime.truncate(uint64) + duration
 
-    let data = await RandomChunker.example(blocks = blocks)
+    let data = await RandomChunker.exampleBytes(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(

--- a/tests/integration/testvalidator.nim
+++ b/tests/integration/testvalidator.nim
@@ -96,7 +96,7 @@ marketplacesuite "Validation":
     var currentTime = await ethProvider.currentTime()
     let requestEndTime = currentTime.truncate(uint64) + duration
 
-    let data = await RandomChunker.exampleBytes(blocks = blocks)
+    let data = await RandomChunker.example(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(
@@ -163,7 +163,7 @@ marketplacesuite "Validation":
     var currentTime = await ethProvider.currentTime()
     let requestEndTime = currentTime.truncate(uint64) + duration
 
-    let data = await RandomChunker.exampleBytes(blocks = blocks)
+    let data = await RandomChunker.example(blocks = blocks)
     let datasetSize =
       datasetSize(blocks = blocks, nodes = ecNodes, tolerance = ecTolerance)
     createAvailabilities(


### PR DESCRIPTION
When working on price-per-byte feature, I added two functions to `tests/integration/marketplacesuite.nim`:

```nim
proc slotSize(blocks: int): UInt256 =
  (DefaultBlockSize * blocks.NBytes).Natural.u256

proc datasetSize(blocks, nodes, tolerance: int): UInt256 =
  (nodes + tolerance).u256 * slotSize(blocks)
```

They are not correct, and should be defined as follows:

```nim
proc slotSize(blocks, nodes, tolerance: int): UInt256 =
  let ecK = nodes - tolerance
  let blocksRounded = roundUp(blocks, ecK)
  let blocksPerSlot = divUp(blocksRounded, ecK)
  (DefaultBlockSize * blocksPerSlot.NBytes).Natural.u256

proc datasetSize(blocks, nodes, tolerance: int): UInt256 =
  return nodes.u256 * slotSize(blocks, nodes, tolerance)
```

The functions are used in the following integration tests:

- `ntegration/testmarketplace`
- `integration/testproofs`
- `integration/testvalidator`

While working on this, I discovered that `proc example*(_: type RandomChunker, blocks: int): Future[string] {.async.}`, returning `string`, was doing `byteutils.toHex(data)` to convert the `seq[bytes]` into a `string`, which means it was returning double of the requested size (so e.g. `16` blocks where `8` were requested). This was causing subtle errors in some integration tests, once the computation of the dataset size and the slot size has been corrected as indicated above.

To fix this, the `example` proc listed above has been changed so that it now returns `seq[byte]` with the correct size:

```nim
proc example*(_: type RandomChunker, blocks: int): Future[seq[byte]] {.async.} =
  let rng = Rng.instance()
  let chunker = RandomChunker.new(
    rng, size = DefaultBlockSize * blocks.NBytes, chunkSize = DefaultBlockSize
  )
  var data: seq[byte]
  while (let moar = await chunker.getBytes(); moar != []):
    data.add moar
  return data
```

This change, however, was causing a problem with `CodexClient.upload`, which expects passed `contents` to have type `string`. Because there are still a number of tests where we do actually use strings, in order to support both content types, I added the following overload for the `CodexClient.upload` proc:

```nim
proc upload*(client: CodexClient, bytes: seq[byte]): ?!Cid =
  proc toString(bytes: seq[byte]): string =
    result = newString(bytes.len)
    copyMem(result[0].addr, bytes[0].unsafeAddr, bytes.len)

  client.upload(bytes.toString)
```

The relevant tests has been reviewed and fixed.