### PR TITLE
fix: use ubuntu-24.04 runners for docker workflows

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -94,11 +94,11 @@ jobs:
           - target:
               os: linux
               arch: amd64
-            builder: ubuntu-22.04
+            builder: ubuntu-24.04
           - target:
               os: linux
               arch: arm64
-            builder: ubuntu-22.04-arm
+            builder: ubuntu-24.04-arm
 
     name: Build ${{ matrix.target.os }}/${{ matrix.target.arch }}
     runs-on: ${{ matrix.builder }}


### PR DESCRIPTION
We recently observed that `amd64` Docker builds, which uses `ubuntu-22.04` runner, started to fail because they are running on the self-hosted runners.

And there two issues with that
- Self hosted runners are not configured properly to run Docker
- We have clashed labels - `ubuntu-22.04` is used by self-hosted runners and GitHub ones as well

PR contains a quick workaround to switch to the GutHub hosted runners with the labels `ubuntu-24.04` and `ubuntu-24.04-arm`.