### PR TITLE
chore(marketplace) - fix the http error codes when validating the availability requests

### DIFF
--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -430,7 +430,7 @@ proc initSalesApi(node: CodexNodeRef, router: var RestRouter) =
 
       if restAv.totalSize == 0:
         return RestApiResponse.error(
-          Http400, "Total size must be larger then zero", headers = headers
+          Http422, "Total size must be larger then zero", headers = headers
         )
 
       if not reservations.hasAvailable(restAv.totalSize.truncate(uint)):
@@ -503,16 +503,19 @@ proc initSalesApi(node: CodexNodeRef, router: var RestRouter) =
         return RestApiResponse.error(Http500, error.msg)
 
       if isSome restAv.freeSize:
-        return RestApiResponse.error(Http400, "Updating freeSize is not allowed")
+        return RestApiResponse.error(Http422, "Updating freeSize is not allowed")
 
       if size =? restAv.totalSize:
         # we don't allow lowering the totalSize bellow currently utilized size
         if size < (availability.totalSize - availability.freeSize):
           return RestApiResponse.error(
-            Http400,
+            Http422,
             "New totalSize must be larger then current totalSize - freeSize, which is currently: " &
               $(availability.totalSize - availability.freeSize),
           )
+
+        if not reservations.hasAvailable(size.truncate(uint)):
+          return RestApiResponse.error(Http422, "Not enough storage quota")
 
         availability.freeSize += size - availability.totalSize
         availability.totalSize = size

--- a/tests/integration/codexclient.nim
+++ b/tests/integration/codexclient.nim
@@ -172,10 +172,10 @@ proc getSlots*(client: CodexClient): ?!seq[Slot] =
   let body = client.http.getContent(url)
   seq[Slot].fromJson(body)
 
-proc postAvailability*(
+proc postAvailabilityRaw*(
     client: CodexClient,
     totalSize, duration, minPricePerBytePerSecond, totalCollateral: UInt256,
-): ?!Availability =
+): Response =
   ## Post sales availability endpoint
   ##
   let url = client.baseurl & "/sales/availability"
@@ -186,7 +186,15 @@ proc postAvailability*(
       "minPricePerBytePerSecond": minPricePerBytePerSecond,
       "totalCollateral": totalCollateral,
     }
-  let response = client.http.post(url, $json)
+  return client.http.post(url, $json)
+
+proc postAvailability*(
+    client: CodexClient,
+    totalSize, duration, minPricePerBytePerSecond, totalCollateral: UInt256,
+): ?!Availability =
+  let response = client.postAvailabilityRaw(
+    totalSize, duration, minPricePerBytePerSecond, totalCollateral
+  )
   doAssert response.status == "201 Created",
     "expected 201 Created, got " & response.status & ", body: " & response.body
   Availability.fromJson(response.body)

--- a/tests/integration/testsales.nim
+++ b/tests/integration/testsales.nim
@@ -1,5 +1,6 @@
 import std/httpclient
 import pkg/codex/contracts
+from pkg/codex/stores/repostore/types import DefaultQuotaBytes
 import ./twonodes
 import ../codex/examples
 import ../contracts/time
@@ -93,7 +94,7 @@ multinodesuite "Sales":
     ).get
     let freeSizeResponse =
       host.patchAvailabilityRaw(availability.id, freeSize = 110000.u256.some)
-    check freeSizeResponse.status == "400 Bad Request"
+    check freeSizeResponse.status == "422 Unprocessable Entity"
     check "not allowed" in freeSizeResponse.body
 
   test "updating availability - updating totalSize", salesConfig:
@@ -143,7 +144,7 @@ multinodesuite "Sales":
     let totalSizeResponse = host.patchAvailabilityRaw(
       availability.id, totalSize = (utilizedSize - 1.u256).some
     )
-    check totalSizeResponse.status == "400 Bad Request"
+    check totalSizeResponse.status == "422 Unprocessable Entity"
     check "totalSize must be larger then current totalSize" in totalSizeResponse.body
 
     host.patchAvailability(availability.id, totalSize = (originalSize + 20000).some)
@@ -151,3 +152,27 @@ multinodesuite "Sales":
       (host.getAvailabilities().get).findItem(availability).get
     check newUpdatedAvailability.totalSize == originalSize + 20000
     check newUpdatedAvailability.freeSize - updatedAvailability.freeSize == 20000
+
+  test "creating availability above the node quota returns 422", salesConfig:
+    let response = host.postAvailabilityRaw(
+      totalSize = 14000000000.u256,
+      duration = 200.u256,
+      minPricePerBytePerSecond = 3.u256,
+      totalCollateral = 300.u256,
+    )
+
+    check response.status == "422 Unprocessable Entity"
+    check response.body == "Not enough storage quota"
+
+  test "updating availability above the node quota returns 422", salesConfig:
+    let availability = host.postAvailability(
+      totalSize = 140000.u256,
+      duration = 200.u256,
+      minPricePerBytePerSecond = 3.u256,
+      totalCollateral = 300.u256,
+    ).get
+    let response =
+      host.patchAvailabilityRaw(availability.id, totalSize = 14000000000.u256.some)
+
+    check response.status == "422 Unprocessable Entity"
+    check response.body == "Not enough storage quota"


### PR DESCRIPTION
This PR fixes #884 and fixes the semantics regarding the validation error codes. 

400 should be returned when the request cannot be processed (malformatted for example) [rfc](https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request). 
422 should be returned when the request has semantic errors (validation error for example) [rfc](https://www.rfc-editor.org/rfc/rfc4918.html#section-11.2).