### PR TITLE
upload OpenAPI artifacts and publish docs only when tagged

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,17 +2,17 @@ name: OpenAPI
 
 on:
   push:
-    branches:
-      - 'master'
+    tags:
+      - "v*.*.*"
     paths:
-      - 'openapi.yaml'
-      - '.github/workflows/docs.yml'
+      - "openapi.yaml"
+      - ".github/workflows/docs.yml"
   pull_request:
     branches:
-      - '**'
+      - "**"
     paths:
-      - 'openapi.yaml'
-      - '.github/workflows/docs.yml'
+      - "openapi.yaml"
+      - ".github/workflows/docs.yml"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -40,7 +40,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently the API docs are being published on every PR and every push to the master. This results in out of sync API spec, which should only be updated when there is a release.

In this PR, I am deploying the OpenAPI spec only when tagged with a tag matching `v*.*.*`.

> There is a linting problem on master that will prevent this PR from being merged. It is addressed in #1107 to make it visible (I still do not get how it is even possible). Thus once #1107 is merged, I will rebase this one.