### PR TITLE
fix linting in "codex/blockexchange/engine/engine.nim"

### DIFF
--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -398,7 +398,7 @@ proc wantListHandler*(b: BlockExcEngine, peer: PeerId, wantList: WantList) {.asy
         have = await e.address in b.localStore
         price = @(b.pricing.get(Pricing(price: 0.u256)).price.toBytesBE)
 
-      case e.wantType:
+      case e.wantType
       of WantType.WantHave:
         if have:
           presence.add(


### PR DESCRIPTION
While working on https://github.com/codex-storage/nim-codex/pull/1106 I was hit with a linting problem in `codex/blockexchange/engine/engine.nim` (#1106 fails with [linting error](https://github.com/codex-storage/nim-codex/actions/runs/13236294382/job/36941754410?pr=1106)).

Looks like the change was introduced by @dryajov, so maybe there is something going on with his npx configuration? Or maybe there is some point being made? I still do not understand how did it get through to the master - it is failing my builds how did it not fail before 🧐?

Because, others may be dealing with the same problem, this is a separate PR that just fixed this small linting error.