### PR TITLE
Fix/repostore deletes for non-orphan blocks

### DIFF
--- a/codex/stores/repostore/operations.nim
+++ b/codex/stores/repostore/operations.nim
@@ -216,9 +216,6 @@ proc storeBlock*(
 proc tryDeleteBlock*(
     self: RepoStore, cid: Cid, expiryLimit = SecondsSince1970.low
 ): Future[?!DeleteResult] {.async.} =
-  if cid.isEmpty:
-    return success(DeleteResult(kind: InUse))
-
   without metaKey =? createBlockExpirationMetadataKey(cid), err:
     return failure(err)
 

--- a/codex/stores/repostore/operations.nim
+++ b/codex/stores/repostore/operations.nim
@@ -57,6 +57,17 @@ proc putLeafMetadata*(
       (md.some, res),
   )
 
+proc delLeafMetadata*(
+    self: RepoStore, treeCid: Cid, index: Natural
+): Future[?!void] {.async.} =
+  without key =? createBlockCidAndProofMetadataKey(treeCid, index), err:
+    return failure(err)
+
+  if err =? (await self.metaDs.delete(key)).errorOption:
+    return failure(err)
+
+  success()
+
 proc getLeafMetadata*(
     self: RepoStore, treeCid: Cid, index: Natural
 ): Future[?!LeafMetadata] {.async.} =

--- a/tests/codex/examples.nim
+++ b/tests/codex/examples.nim
@@ -36,8 +36,8 @@ proc example*(_: type SignedState): SignedState =
 proc example*(_: type Pricing): Pricing =
   Pricing(address: EthAddress.example, price: uint32.rand.u256)
 
-proc example*(_: type bt.Block): bt.Block =
-  let length = rand(4096)
+proc example*(_: type bt.Block, size: int = 4096): bt.Block =
+  let length = rand(size)
   let bytes = newSeqWith(length, rand(uint8))
   bt.Block.new(bytes).tryGet()
 

--- a/tests/codex/stores/testrepostore.nim
+++ b/tests/codex/stores/testrepostore.nim
@@ -374,8 +374,9 @@ asyncchecksuite "RepoStore":
     (await repo.putBlock(blk)).tryGet()
     (await repo.putCidAndProof(treeCid, 0, blk.cid, proof)).tryGet()
 
-    (await repo.delBlock(blk.cid)).tryGet()
-    check (await blk.cid in repo)
+    let err = (await repo.delBlock(blk.cid)).error()
+    check err.msg ==
+      "Directly deleting a block that is part of a dataset is not allowed."
 
   test "should allow non-orphan blocks to be deleted by dataset reference":
     let

--- a/tests/codex/stores/testrepostore.nim
+++ b/tests/codex/stores/testrepostore.nim
@@ -452,7 +452,7 @@ asyncchecksuite "RepoStore":
     let err = (await repo.getLeafMetadata(treeCid, 0.Natural)).error()
     check err of BlockNotFoundError
 
-  test "reinserting a previously deleted block should not fail (bug #1108)":
+  test "should not fail when reinserting and deleting a previously deleted block (bug #1108)":
     let
       repo = RepoStore.new(repoDs, metaDs, clock = mockClock, quotaMaxBytes =
           1000'nb)


### PR DESCRIPTION
Fixes #1108

This PR:
* fixes the broken deletes for non-orphan blocks (i.e., blocks that are part of a dataset);
* makes `deleteBlock` more strict by actually returning an error on illegal deletes instead of failing silently;
* adds additional tests to cover the peculiar aspects of deletes for non-orphan blocks.