### PR TITLE
chore: Remove deprecated cid function

### DIFF
--- a/codex/manifest/manifest.nim
+++ b/codex/manifest/manifest.nim
@@ -162,9 +162,6 @@ func verify*(self: Manifest): ?!void =
 
   return success()
 
-func cid*(self: Manifest): ?!Cid {.deprecated: "use treeCid instead".} =
-  self.treeCid.success
-
 func `==`*(a, b: Manifest): bool =
   (a.treeCid == b.treeCid) and (a.datasetSize == b.datasetSize) and
     (a.blockSize == b.blockSize) and (a.version == b.version) and (a.hcodec == b.hcodec) and

--- a/codex/streams/storestream.nim
+++ b/codex/streams/storestream.nim
@@ -110,7 +110,7 @@ method readOnce*(
       raise newLPStreamReadError(error)
 
     trace "Reading bytes from store stream",
-      manifestCid = self.manifest.cid.get(),
+      manifestCid = self.manifest.treeCid,
       numBlocks = self.manifest.blocksCount,
       blockNum,
       blkCid = blk.cid,

--- a/tests/codex/blockexchange/discovery/testdiscovery.nim
+++ b/tests/codex/blockexchange/discovery/testdiscovery.nim
@@ -96,9 +96,9 @@ asyncchecksuite "Block Advertising and Discovery":
 
     await engine.stop()
 
-  test "Should advertise both manifests and trees":
+  test "Should advertise trees":
     let
-      cids = @[manifest.cid.tryGet, manifest.treeCid]
+      cids = @[manifest.treeCid]
       advertised = initTable.collect:
         for cid in cids:
           {cid: newFuture[void]()}


### PR DESCRIPTION
This PR remove the warning `Warning: use treeCid instead; cid is deprecated` by removing the `cid` function from the manifest.