### PR TITLE
chore: use results instead of stew/results

### DIFF
--- a/codex/erasure/backends/leopard.nim
+++ b/codex/erasure/backends/leopard.nim
@@ -10,7 +10,7 @@
 import std/options
 
 import pkg/leopard
-import pkg/stew/results
+import pkg/results
 
 import ../backend
 

--- a/codex/errors.nim
+++ b/codex/errors.nim
@@ -9,7 +9,7 @@
 
 import std/options
 
-import pkg/stew/results
+import pkg/results
 import pkg/chronos
 import pkg/questionable/results
 

--- a/codex/rest/coders.nim
+++ b/codex/rest/coders.nim
@@ -14,7 +14,7 @@ import pkg/chronos
 import pkg/libp2p
 import pkg/stew/base10
 import pkg/stew/byteutils
-import pkg/stew/results
+import pkg/results
 import pkg/stint
 
 import ../sales

--- a/codex/utils/asyncheapqueue.nim
+++ b/codex/utils/asyncheapqueue.nim
@@ -9,7 +9,7 @@
 
 import std/sequtils
 import pkg/chronos
-import pkg/stew/results
+import pkg/results
 
 # Based on chronos AsyncHeapQueue and std/heapqueue
 

--- a/codex/utils/natutils.nim
+++ b/codex/utils/natutils.nim
@@ -1,7 +1,6 @@
 {.push raises: [].}
 
-import
-  std/[tables, hashes], stew/results, stew/shims/net as stewNet, chronos, chronicles
+import std/[tables, hashes], pkg/results, stew/shims/net as stewNet, chronos, chronicles
 
 import pkg/libp2p
 

--- a/tests/codex/stores/testqueryiterhelper.nim
+++ b/tests/codex/stores/testqueryiterhelper.nim
@@ -1,6 +1,6 @@
 import std/sugar
 
-import pkg/stew/results
+import pkg/results
 import pkg/questionable
 import pkg/chronos
 import pkg/datastore/typedds

--- a/tests/codex/testasyncheapqueue.nim
+++ b/tests/codex/testasyncheapqueue.nim
@@ -1,5 +1,5 @@
 import pkg/chronos
-import pkg/stew/results
+import pkg/results
 
 import pkg/codex/utils/asyncheapqueue
 import pkg/codex/rng

--- a/tests/codex/testnat.nim
+++ b/tests/codex/testnat.nim
@@ -1,7 +1,7 @@
 import std/[unittest, options, net], stew/shims/net as stewNet
 import pkg/chronos
 import pkg/libp2p/[multiaddress, multihash, multicodec]
-import pkg/stew/results
+import pkg/results
 
 import ../../codex/nat
 import ../../codex/utils/natutils


### PR DESCRIPTION
This PR update the imports of `results` to remove the deprecation warning.