### PR TITLE
fix: bumps CI timeouts to 3h

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -26,7 +26,7 @@ jobs:
 
     name: ${{ matrix.os }}-${{ matrix.tests }}-${{ matrix.cpu }}-${{ matrix.nim_version }}
     runs-on: ${{ matrix.builder }}
-    timeout-minutes: 120
+    timeout-minutes: 180
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
We're often seeing cancelled jobs:

![image](https://github.com/user-attachments/assets/0c5aab5f-667a-4244-baf0-408feeda95b7)

I suspect those are due to timeouts. I'm bumping this to 3h to see if it fixes the problem.