### PR TITLE
chore(deps): bump ethers to propagate cancellations

### DIFF
--- a/codex/contracts/provider.nim
+++ b/codex/contracts/provider.nim
@@ -14,7 +14,7 @@ proc raiseProviderError(message: string) {.raises: [ProviderError].} =
 
 proc blockNumberAndTimestamp*(
     provider: Provider, blockTag: BlockTag
-): Future[(UInt256, UInt256)] {.async: (raises: [ProviderError]).} =
+): Future[(UInt256, UInt256)] {.async: (raises: [ProviderError, CancelledError]).} =
   without latestBlock =? await provider.getBlock(blockTag):
     raiseProviderError("Could not get latest block")
 
@@ -25,7 +25,7 @@ proc blockNumberAndTimestamp*(
 
 proc binarySearchFindClosestBlock(
     provider: Provider, epochTime: int, low: UInt256, high: UInt256
-): Future[UInt256] {.async: (raises: [ProviderError]).} =
+): Future[UInt256] {.async: (raises: [ProviderError, CancelledError]).} =
   let (_, lowTimestamp) = await provider.blockNumberAndTimestamp(BlockTag.init(low))
   let (_, highTimestamp) = await provider.blockNumberAndTimestamp(BlockTag.init(high))
   if abs(lowTimestamp.truncate(int) - epochTime) <
@@ -39,7 +39,7 @@ proc binarySearchBlockNumberForEpoch(
     epochTime: UInt256,
     latestBlockNumber: UInt256,
     earliestBlockNumber: UInt256,
-): Future[UInt256] {.async: (raises: [ProviderError]).} =
+): Future[UInt256] {.async: (raises: [ProviderError, CancelledError]).} =
   var low = earliestBlockNumber
   var high = latestBlockNumber
 
@@ -65,7 +65,7 @@ proc binarySearchBlockNumberForEpoch(
 
 proc blockNumberForEpoch*(
     provider: Provider, epochTime: SecondsSince1970
-): Future[UInt256] {.async: (raises: [ProviderError]).} =
+): Future[UInt256] {.async: (raises: [ProviderError, CancelledError]).} =
   let epochTimeUInt256 = epochTime.u256
   let (latestBlockNumber, latestBlockTimestamp) =
     await provider.blockNumberAndTimestamp(BlockTag.latest)
@@ -118,6 +118,6 @@ proc blockNumberForEpoch*(
 
 proc pastBlockTag*(
     provider: Provider, blocksAgo: int
-): Future[BlockTag] {.async: (raises: [ProviderError]).} =
+): Future[BlockTag] {.async: (raises: [ProviderError, CancelledError]).} =
   let head = await provider.getBlockNumber()
   return BlockTag.init(head - blocksAgo.abs.u256)

--- a/tests/contracts/helpers/mockprovider.nim
+++ b/tests/contracts/helpers/mockprovider.nim
@@ -13,7 +13,7 @@ type MockProvider* = ref object of Provider
 
 method getBlock*(
     provider: MockProvider, tag: BlockTag
-): Future[?Block] {.async: (raises: [ProviderError]).} =
+): Future[?Block] {.async: (raises: [ProviderError, CancelledError]).} =
   try:
     if tag == BlockTag.latest:
       if latestBlock =? provider.latest:

--- a/tests/contracts/testDeployment.nim
+++ b/tests/contracts/testDeployment.nim
@@ -12,7 +12,7 @@ type MockProvider = ref object of Provider
 
 method getChainId*(
     provider: MockProvider
-): Future[UInt256] {.async: (raises: [ProviderError]).} =
+): Future[UInt256] {.async: (raises: [ProviderError, CancelledError]).} =
   return provider.chainId
 
 proc configFactory(): CodexConf =


### PR DESCRIPTION
Ethers was swallowing canellations and turning them into EthersErrors, which was causing the sales statemachine to error when it should have been simply cancelling the current state's run. Hopefully fixes the intermittently failing marketplace integration test.

Note: this PR is based off of https://github.com/codex-storage/nim-ethers/pull/105, let's get that merged first so we can move our Ethers dependency off a branch.