### PR TITLE
Missing nullability causes json-serialize failure

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -325,6 +325,7 @@ components:
             - unknown
         error:
           type: string
+          nullable: true
           description: If Request failed, then here is presented the error message
         request:
           $ref: "#/components/schemas/StorageRequest"


### PR DESCRIPTION
Deser fails with "missing field 'error'" in the case of no error.
