### PR TITLE
chore(marketplace): notify sales when duration, minPricePerBytePerSecond or totalCollateral is updated

### DIFF
--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -285,7 +285,7 @@ proc load*(sales: Sales) {.async.} =
     agent.start(SaleUnknown())
     sales.agents.add agent
 
-proc onAvailabilityAdded(sales: Sales, availability: Availability) {.async.} =
+proc OnAvailabilitySaved(sales: Sales, availability: Availability) {.async.} =
   ## When availabilities are modified or added, the queue should be unpaused if
   ## it was paused and any slots in the queue should have their `seen` flag
   ## cleared.
@@ -528,10 +528,10 @@ proc startSlotQueue(sales: Sales) =
 
   slotQueue.start()
 
-  proc onAvailabilityAdded(availability: Availability) {.async.} =
-    await sales.onAvailabilityAdded(availability)
+  proc OnAvailabilitySaved(availability: Availability) {.async.} =
+    await sales.OnAvailabilitySaved(availability)
 
-  reservations.onAvailabilityAdded = onAvailabilityAdded
+  reservations.OnAvailabilitySaved = OnAvailabilitySaved
 
 proc subscribe(sales: Sales) {.async.} =
   await sales.subscribeRequested()

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -285,7 +285,7 @@ proc load*(sales: Sales) {.async.} =
     agent.start(SaleUnknown())
     sales.agents.add agent
 
-proc OnAvailabilitySaved(sales: Sales, availability: Availability) {.async.} =
+proc OnAvailabilityUpserted(sales: Sales, availability: Availability) {.async.} =
   ## When availabilities are modified or added, the queue should be unpaused if
   ## it was paused and any slots in the queue should have their `seen` flag
   ## cleared.
@@ -528,10 +528,10 @@ proc startSlotQueue(sales: Sales) =
 
   slotQueue.start()
 
-  proc OnAvailabilitySaved(availability: Availability) {.async.} =
-    await sales.OnAvailabilitySaved(availability)
+  proc OnAvailabilityUpserted(availability: Availability) {.async.} =
+    await sales.OnAvailabilityUpserted(availability)
 
-  reservations.OnAvailabilitySaved = OnAvailabilitySaved
+  reservations.OnAvailabilityUpserted = OnAvailabilityUpserted
 
 proc subscribe(sales: Sales) {.async.} =
   await sales.subscribeRequested()

--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -285,7 +285,7 @@ proc load*(sales: Sales) {.async.} =
     agent.start(SaleUnknown())
     sales.agents.add agent
 
-proc OnAvailabilityUpserted(sales: Sales, availability: Availability) {.async.} =
+proc OnAvailabilitySaved(sales: Sales, availability: Availability) {.async.} =
   ## When availabilities are modified or added, the queue should be unpaused if
   ## it was paused and any slots in the queue should have their `seen` flag
   ## cleared.
@@ -528,10 +528,10 @@ proc startSlotQueue(sales: Sales) =
 
   slotQueue.start()
 
-  proc OnAvailabilityUpserted(availability: Availability) {.async.} =
-    await sales.OnAvailabilityUpserted(availability)
+  proc OnAvailabilitySaved(availability: Availability) {.async.} =
+    await sales.OnAvailabilitySaved(availability)
 
-  reservations.OnAvailabilityUpserted = OnAvailabilityUpserted
+  reservations.OnAvailabilitySaved = OnAvailabilitySaved
 
 proc subscribe(sales: Sales) {.async.} =
   await sales.subscribeRequested()

--- a/codex/sales/reservations.nim
+++ b/codex/sales/reservations.nim
@@ -300,7 +300,9 @@ proc updateAvailability(
 
   let res = await self.updateImpl(obj)
 
-  if oldAvailability.freeSize < obj.freeSize: # availability added
+  if oldAvailability.freeSize < obj.freeSize or oldAvailability.duration < obj.duration or
+      oldAvailability.minPricePerBytePerSecond < obj.minPricePerBytePerSecond or
+      oldAvailability.totalCollateral < obj.totalCollateral: # availability updated
     # inform subscribers that Availability has been modified (with increased
     # size)
     if onAvailabilityAdded =? self.onAvailabilityAdded:

--- a/codex/sales/reservations.nim
+++ b/codex/sales/reservations.nim
@@ -82,11 +82,11 @@ type
     availabilityLock: AsyncLock
       # Lock for protecting assertions of availability's sizes when searching for matching availability
     repo: RepoStore
-    onAvailabilityAdded: ?OnAvailabilityAdded
+    OnAvailabilitySaved: ?OnAvailabilitySaved
 
   GetNext* = proc(): Future[?seq[byte]] {.upraises: [], gcsafe, closure.}
   IterDispose* = proc(): Future[?!void] {.gcsafe, closure.}
-  OnAvailabilityAdded* =
+  OnAvailabilitySaved* =
     proc(availability: Availability): Future[void] {.upraises: [], gcsafe.}
   StorableIter* = ref object
     finished*: bool
@@ -189,10 +189,10 @@ logutils.formatIt(LogFormat.textLines, SomeStorableId):
 logutils.formatIt(LogFormat.json, SomeStorableId):
   it.to0xHexLog
 
-proc `onAvailabilityAdded=`*(
-    self: Reservations, onAvailabilityAdded: OnAvailabilityAdded
+proc `OnAvailabilitySaved=`*(
+    self: Reservations, OnAvailabilitySaved: OnAvailabilitySaved
 ) =
-  self.onAvailabilityAdded = some onAvailabilityAdded
+  self.OnAvailabilitySaved = some OnAvailabilitySaved
 
 func key*(id: AvailabilityId): ?!Key =
   ## sales / reservations / <availabilityId>
@@ -268,18 +268,18 @@ proc updateAvailability(
       trace "Creating new Availability"
       let res = await self.updateImpl(obj)
       # inform subscribers that Availability has been added
-      if onAvailabilityAdded =? self.onAvailabilityAdded:
-        # when chronos v4 is implemented, and OnAvailabilityAdded is annotated
+      if OnAvailabilitySaved =? self.OnAvailabilitySaved:
+        # when chronos v4 is implemented, and OnAvailabilitySaved is annotated
         # with async:(raises:[]), we can remove this try/catch as we know, with
         # certainty, that nothing will be raised
         try:
-          await onAvailabilityAdded(obj)
+          await OnAvailabilitySaved(obj)
         except CancelledError as e:
           raise e
         except CatchableError as e:
           # we don't have any insight into types of exceptions that
-          # `onAvailabilityAdded` can raise because it is caller-defined
-          warn "Unknown error during 'onAvailabilityAdded' callback", error = e.msg
+          # `OnAvailabilitySaved` can raise because it is caller-defined
+          warn "Unknown error during 'OnAvailabilitySaved' callback", error = e.msg
       return res
     else:
       return failure(err)
@@ -305,18 +305,18 @@ proc updateAvailability(
       oldAvailability.totalCollateral < obj.totalCollateral: # availability updated
     # inform subscribers that Availability has been modified (with increased
     # size)
-    if onAvailabilityAdded =? self.onAvailabilityAdded:
-      # when chronos v4 is implemented, and OnAvailabilityAdded is annotated
+    if OnAvailabilitySaved =? self.OnAvailabilitySaved:
+      # when chronos v4 is implemented, and OnAvailabilitySaved is annotated
       # with async:(raises:[]), we can remove this try/catch as we know, with
       # certainty, that nothing will be raised
       try:
-        await onAvailabilityAdded(obj)
+        await OnAvailabilitySaved(obj)
       except CancelledError as e:
         raise e
       except CatchableError as e:
         # we don't have any insight into types of exceptions that
-        # `onAvailabilityAdded` can raise because it is caller-defined
-        warn "Unknown error during 'onAvailabilityAdded' callback", error = e.msg
+        # `OnAvailabilitySaved` can raise because it is caller-defined
+        warn "Unknown error during 'OnAvailabilitySaved' callback", error = e.msg
 
   return res
 

--- a/codex/sales/reservations.nim
+++ b/codex/sales/reservations.nim
@@ -82,11 +82,11 @@ type
     availabilityLock: AsyncLock
       # Lock for protecting assertions of availability's sizes when searching for matching availability
     repo: RepoStore
-    OnAvailabilityUpserted: ?OnAvailabilityUpserted
+    OnAvailabilitySaved: ?OnAvailabilitySaved
 
   GetNext* = proc(): Future[?seq[byte]] {.upraises: [], gcsafe, closure.}
   IterDispose* = proc(): Future[?!void] {.gcsafe, closure.}
-  OnAvailabilityUpserted* =
+  OnAvailabilitySaved* =
     proc(availability: Availability): Future[void] {.upraises: [], gcsafe.}
   StorableIter* = ref object
     finished*: bool
@@ -189,10 +189,10 @@ logutils.formatIt(LogFormat.textLines, SomeStorableId):
 logutils.formatIt(LogFormat.json, SomeStorableId):
   it.to0xHexLog
 
-proc `OnAvailabilityUpserted=`*(
-    self: Reservations, OnAvailabilityUpserted: OnAvailabilityUpserted
+proc `OnAvailabilitySaved=`*(
+    self: Reservations, OnAvailabilitySaved: OnAvailabilitySaved
 ) =
-  self.OnAvailabilityUpserted = some OnAvailabilityUpserted
+  self.OnAvailabilitySaved = some OnAvailabilitySaved
 
 func key*(id: AvailabilityId): ?!Key =
   ## sales / reservations / <availabilityId>
@@ -268,18 +268,18 @@ proc updateAvailability(
       trace "Creating new Availability"
       let res = await self.updateImpl(obj)
       # inform subscribers that Availability has been added
-      if OnAvailabilityUpserted =? self.OnAvailabilityUpserted:
-        # when chronos v4 is implemented, and OnAvailabilityUpserted is annotated
+      if OnAvailabilitySaved =? self.OnAvailabilitySaved:
+        # when chronos v4 is implemented, and OnAvailabilitySaved is annotated
         # with async:(raises:[]), we can remove this try/catch as we know, with
         # certainty, that nothing will be raised
         try:
-          await OnAvailabilityUpserted(obj)
+          await OnAvailabilitySaved(obj)
         except CancelledError as e:
           raise e
         except CatchableError as e:
           # we don't have any insight into types of exceptions that
-          # `OnAvailabilityUpserted` can raise because it is caller-defined
-          warn "Unknown error during 'OnAvailabilityUpserted' callback", error = e.msg
+          # `OnAvailabilitySaved` can raise because it is caller-defined
+          warn "Unknown error during 'OnAvailabilitySaved' callback", error = e.msg
       return res
     else:
       return failure(err)
@@ -305,18 +305,18 @@ proc updateAvailability(
       oldAvailability.totalCollateral < obj.totalCollateral: # availability updated
     # inform subscribers that Availability has been modified (with increased
     # size)
-    if OnAvailabilityUpserted =? self.OnAvailabilityUpserted:
-      # when chronos v4 is implemented, and OnAvailabilityUpserted is annotated
+    if OnAvailabilitySaved =? self.OnAvailabilitySaved:
+      # when chronos v4 is implemented, and OnAvailabilitySaved is annotated
       # with async:(raises:[]), we can remove this try/catch as we know, with
       # certainty, that nothing will be raised
       try:
-        await OnAvailabilityUpserted(obj)
+        await OnAvailabilitySaved(obj)
       except CancelledError as e:
         raise e
       except CatchableError as e:
         # we don't have any insight into types of exceptions that
-        # `OnAvailabilityUpserted` can raise because it is caller-defined
-        warn "Unknown error during 'OnAvailabilityUpserted' callback", error = e.msg
+        # `OnAvailabilitySaved` can raise because it is caller-defined
+        warn "Unknown error during 'OnAvailabilitySaved' callback", error = e.msg
 
   return res
 

--- a/tests/codex/sales/testreservations.nim
+++ b/tests/codex/sales/testreservations.nim
@@ -283,89 +283,89 @@ asyncchecksuite "Reservations module":
     check updated.isErr
     check updated.error of NotExistsError
 
-  test "OnAvailabilitySaved called when availability is created":
+  test "OnAvailabilityUpserted called when availability is created":
     var added: Availability
-    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
       added = a
 
     let availability = createAvailability()
 
     check added == availability
 
-  test "OnAvailabilitySaved called when availability size is increased":
+  test "OnAvailabilityUpserted called when availability size is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
       added = a
     availability.freeSize += 1
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "OnAvailabilitySaved is not called when availability size is decreased":
+  test "OnAvailabilityUpserted is not called when availability size is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
       called = true
     availability.freeSize -= 1
     discard await reservations.update(availability)
 
     check not called
 
-  test "OnAvailabilitySaved called when availability duration is increased":
+  test "OnAvailabilityUpserted called when availability duration is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
       added = a
     availability.duration += 1
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "OnAvailabilitySaved is not called when availability duration is decreased":
+  test "OnAvailabilityUpserted is not called when availability duration is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
       called = true
     availability.duration -= 1
     discard await reservations.update(availability)
 
     check not called
 
-  test "OnAvailabilitySaved called when availability minPricePerBytePerSecond is increased":
+  test "OnAvailabilityUpserted called when availability minPricePerBytePerSecond is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
       added = a
     availability.minPricePerBytePerSecond += 1.u256
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "OnAvailabilitySaved is not called when availability minPricePerBytePerSecond is decreased":
+  test "OnAvailabilityUpserted is not called when availability minPricePerBytePerSecond is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
       called = true
     availability.minPricePerBytePerSecond -= 1.u256
     discard await reservations.update(availability)
 
     check not called
 
-  test "OnAvailabilitySaved called when availability totalCollateral is increased":
+  test "OnAvailabilityUpserted called when availability totalCollateral is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
       added = a
     availability.totalCollateral = availability.totalCollateral + 1.u256
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "OnAvailabilitySaved is not called when availability totalCollateral is decreased":
+  test "OnAvailabilityUpserted is not called when availability totalCollateral is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
       called = true
     availability.totalCollateral = availability.totalCollateral - 1.u256
     discard await reservations.update(availability)

--- a/tests/codex/sales/testreservations.nim
+++ b/tests/codex/sales/testreservations.nim
@@ -283,89 +283,89 @@ asyncchecksuite "Reservations module":
     check updated.isErr
     check updated.error of NotExistsError
 
-  test "onAvailabilityAdded called when availability is created":
+  test "OnAvailabilitySaved called when availability is created":
     var added: Availability
-    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
 
     let availability = createAvailability()
 
     check added == availability
 
-  test "onAvailabilityAdded called when availability size is increased":
+  test "OnAvailabilitySaved called when availability size is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
     availability.freeSize += 1
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "onAvailabilityAdded is not called when availability size is decreased":
+  test "OnAvailabilitySaved is not called when availability size is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       called = true
     availability.freeSize -= 1
     discard await reservations.update(availability)
 
     check not called
 
-  test "onAvailabilityAdded called when availability duration is increased":
+  test "OnAvailabilitySaved called when availability duration is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
     availability.duration += 1
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "onAvailabilityAdded is not called when availability duration is decreased":
+  test "OnAvailabilitySaved is not called when availability duration is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       called = true
     availability.duration -= 1
     discard await reservations.update(availability)
 
     check not called
 
-  test "onAvailabilityAdded called when availability minPricePerBytePerSecond is increased":
+  test "OnAvailabilitySaved called when availability minPricePerBytePerSecond is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
     availability.minPricePerBytePerSecond += 1.u256
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "onAvailabilityAdded is not called when availability minPricePerBytePerSecond is decreased":
+  test "OnAvailabilitySaved is not called when availability minPricePerBytePerSecond is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       called = true
     availability.minPricePerBytePerSecond -= 1.u256
     discard await reservations.update(availability)
 
     check not called
 
-  test "onAvailabilityAdded called when availability totalCollateral is increased":
+  test "OnAvailabilitySaved called when availability totalCollateral is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
     availability.totalCollateral = availability.totalCollateral + 1.u256
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "onAvailabilityAdded is not called when availability totalCollateral is decreased":
+  test "OnAvailabilitySaved is not called when availability totalCollateral is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       called = true
     availability.totalCollateral = availability.totalCollateral - 1.u256
     discard await reservations.update(availability)

--- a/tests/codex/sales/testreservations.nim
+++ b/tests/codex/sales/testreservations.nim
@@ -312,6 +312,66 @@ asyncchecksuite "Reservations module":
 
     check not called
 
+  test "onAvailabilityAdded called when availability duration is increased":
+    var availability = createAvailability()
+    var added: Availability
+    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+      added = a
+    availability.duration += 1
+    discard await reservations.update(availability)
+
+    check added == availability
+
+  test "onAvailabilityAdded is not called when availability duration is decreased":
+    var availability = createAvailability()
+    var called = false
+    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+      called = true
+    availability.duration -= 1
+    discard await reservations.update(availability)
+
+    check not called
+
+  test "onAvailabilityAdded called when availability minPricePerBytePerSecond is increased":
+    var availability = createAvailability()
+    var added: Availability
+    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+      added = a
+    availability.minPricePerBytePerSecond += 1.u256
+    discard await reservations.update(availability)
+
+    check added == availability
+
+  test "onAvailabilityAdded is not called when availability minPricePerBytePerSecond is decreased":
+    var availability = createAvailability()
+    var called = false
+    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+      called = true
+    availability.minPricePerBytePerSecond -= 1.u256
+    discard await reservations.update(availability)
+
+    check not called
+
+  test "onAvailabilityAdded called when availability totalCollateral is increased":
+    var availability = createAvailability()
+    var added: Availability
+    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+      added = a
+    availability.totalCollateral = availability.totalCollateral + 1.u256
+    discard await reservations.update(availability)
+
+    check added == availability
+
+  test "onAvailabilityAdded is not called when availability totalCollateral is decreased":
+    var availability = createAvailability()
+    var called = false
+    reservations.onAvailabilityAdded = proc(a: Availability) {.async.} =
+      called = true
+    availability.totalCollateral = availability.totalCollateral - 1.u256
+    discard await reservations.update(availability)
+
+    check not called
+
   test "availabilities can be found":
     let availability = createAvailability()
 

--- a/tests/codex/sales/testreservations.nim
+++ b/tests/codex/sales/testreservations.nim
@@ -283,89 +283,89 @@ asyncchecksuite "Reservations module":
     check updated.isErr
     check updated.error of NotExistsError
 
-  test "OnAvailabilityUpserted called when availability is created":
+  test "OnAvailabilitySaved called when availability is created":
     var added: Availability
-    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
 
     let availability = createAvailability()
 
     check added == availability
 
-  test "OnAvailabilityUpserted called when availability size is increased":
+  test "OnAvailabilitySaved called when availability size is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
     availability.freeSize += 1
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "OnAvailabilityUpserted is not called when availability size is decreased":
+  test "OnAvailabilitySaved is not called when availability size is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       called = true
     availability.freeSize -= 1
     discard await reservations.update(availability)
 
     check not called
 
-  test "OnAvailabilityUpserted called when availability duration is increased":
+  test "OnAvailabilitySaved called when availability duration is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
     availability.duration += 1
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "OnAvailabilityUpserted is not called when availability duration is decreased":
+  test "OnAvailabilitySaved is not called when availability duration is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       called = true
     availability.duration -= 1
     discard await reservations.update(availability)
 
     check not called
 
-  test "OnAvailabilityUpserted called when availability minPricePerBytePerSecond is increased":
+  test "OnAvailabilitySaved called when availability minPricePerBytePerSecond is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
     availability.minPricePerBytePerSecond += 1.u256
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "OnAvailabilityUpserted is not called when availability minPricePerBytePerSecond is decreased":
+  test "OnAvailabilitySaved is not called when availability minPricePerBytePerSecond is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       called = true
     availability.minPricePerBytePerSecond -= 1.u256
     discard await reservations.update(availability)
 
     check not called
 
-  test "OnAvailabilityUpserted called when availability totalCollateral is increased":
+  test "OnAvailabilitySaved called when availability totalCollateral is increased":
     var availability = createAvailability()
     var added: Availability
-    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       added = a
     availability.totalCollateral = availability.totalCollateral + 1.u256
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "OnAvailabilityUpserted is not called when availability totalCollateral is decreased":
+  test "OnAvailabilitySaved is not called when availability totalCollateral is decreased":
     var availability = createAvailability()
     var called = false
-    reservations.OnAvailabilityUpserted = proc(a: Availability) {.async.} =
+    reservations.OnAvailabilitySaved = proc(a: Availability) {.async.} =
       called = true
     availability.totalCollateral = availability.totalCollateral - 1.u256
     discard await reservations.update(availability)


### PR DESCRIPTION
Currently, when an availability is updated, `sales` is notified only when the freeSize increases.

This PR changes this behavior to notify `sales` when freeSize, duration, minPricePerBytePerSecond, or totalCollateral is increased. All those parameters are taken into consideration when trying to find an availability matching the slot.