### PR TITLE
chore(restapi): add headers to support on progress when downloading

### DIFF
--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -103,6 +103,8 @@ proc retrieveCid(
     else:
       resp.setHeader("Content-Disposition", "attachment")
 
+    resp.setHeader("Content-Length", $manifest.datasetSize.uint64)
+
     await resp.prepareChunked()
 
     while not stream.atEof:
@@ -328,6 +330,7 @@ proc initDataApi(node: CodexNodeRef, repoStore: RepoStore, router: var RestRoute
       resp.setCorsHeaders("GET", corsOrigin)
       resp.setHeader("Access-Control-Headers", "X-Requested-With")
 
+    resp.setHeader("Access-Control-Expose-Headers", "Content-Disposition")
     await node.retrieveCid(cid.get(), local = false, resp = resp)
 
   router.api(MethodGet, "/api/codex/v1/data/{cid}/network/manifest") do(


### PR DESCRIPTION
This PR adds 2 headers to support [download component with progress](https://github.com/codex-storage/codex-marketplace-ui/issues/98):

1. `Content-Length` to enable [lengthComputable](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/lengthComputable)  
2. `Access-Control-Expose-Headers` to expose the `Content-Disposition` to get the filename from JavaScript.