### PR TITLE
fixes RandomChunker not respecting padding

### DIFF
--- a/tests/codex/helpers/randomchunker.nim
+++ b/tests/codex/helpers/randomchunker.nim
@@ -33,10 +33,10 @@ proc new*(
       return 0
 
     var read = 0
-    while read < len:
+    while read < len and (pad or read < size - consumed):
       rng.shuffle(alpha)
       for a in alpha:
-        if read >= len:
+        if read >= len or (not pad and read >= size - consumed):
           break
 
         data[read] = a


### PR DESCRIPTION
In our tests we usually use the `RandomChunker` as follows:

```nim
proc makeRandomBlocks*(
    datasetSize: int, blockSize: NBytes
): Future[seq[Block]] {.async.} =
  var chunker =
    RandomChunker.new(Rng.instance(), size = datasetSize, chunkSize = blockSize)

  while true:
    let chunk = await chunker.getBytes()
    if chunk.len <= 0:
      break

    result.add(Block.new(chunk).tryGet())
```

Thus, we are effectively creating `RandomChunker` with `pad = false`.

But then, in `await chunker.getBytes()` we have the following:

```nim
proc getBytes*(c: Chunker): Future[seq[byte]] {.async.} =
  ## returns a chunk of bytes from
  ## the instantiated chunker
  ##

  var buff = newSeq[byte](c.chunkSize.int)
  let read = await c.reader(cast[ChunkBuffer](addr buff[0]), buff.len)

  if read <= 0:
    return @[]

  c.offset += read

  if not c.pad and buff.len > read:
    buff.setLen(read)

  return move buff
```

The padding part is:

```nim
if not c.pad and buff.len > read:
  buff.setLen(read)
```

It means that `reader` is responsible for returning the correct amount of data and only if the returned data is less than the size of the chunk, the padding part will set the length to the correct size.

But, our `RandomChunker` does not respect the requested `datasetSize` and always returns full chunks. Thus if you request say `datasetSize=40960` (40 KiB) with `blockSize=16384`, you will get three blocks of `16384` which is `49152` and not `40960`. The last block should be `8192` bytes long.

This tiny PR fixes the `RandomChunker`.