### PR TITLE
chore(openapi): add required parameters

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27,10 +27,6 @@ components:
       maxLength: 66
       example: 0x...
 
-    BigInt:
-      type: string
-      description: Integer represented as decimal string
-
     Cid:
       type: string
       description: Content Identifier as specified at https://github.com/multiformats/cid
@@ -55,17 +51,18 @@ components:
       description: The amount of tokens paid per byte per second per slot to hosts the client is willing to pay
 
     Duration:
-      type: string
-      description: The duration of the request in seconds as decimal string
+      type: integer
+      format: int64
+      description: The duration of the request in seconds
 
     ProofProbability:
       type: string
       description: How often storage proofs are required as decimal string
 
     Expiry:
-      type: string
+      type: integer
+      format: int64
       description: A timestamp as seconds since unix epoch at which this request expires if the Request does not find requested amount of nodes to host the data.
-      default: 10 minutes
 
     SPR:
       type: string
@@ -177,8 +174,9 @@ components:
         - totalCollateral
       properties:
         totalSize:
-          type: string
-          description: Total size of availability's storage in bytes as decimal string
+          type: integer
+          format: int64
+          description: Total size of availability's storage in bytes
         duration:
           $ref: "#/components/schemas/Duration"
         minPricePerBytePerSecond:
@@ -208,7 +206,8 @@ components:
               $ref: "#/components/schemas/Id"
               readonly: true
             freeSize:
-              type: string
+              type: integer
+              format: int64
               description: Unused size of availability's storage in bytes as decimal string
               readOnly: true
             totalRemainingCollateral:
@@ -228,8 +227,9 @@ components:
         request:
           $ref: "#/components/schemas/StorageRequest"
         slotIndex:
-          type: string
-          description: Slot Index as decimal string
+          type: integer
+          format: int64
+          description: Slot Index number
 
     SlotAgent:
       type: object
@@ -239,8 +239,9 @@ components:
         - slotIndex
       properties:
         slotIndex:
-          type: string
-          description: Slot Index as decimal string
+          type: integer
+          format: int64
+          description: Slot Index number
         requestId:
           $ref: "#/components/schemas/Id"
         request:
@@ -280,12 +281,15 @@ components:
         availabilityId:
           $ref: "#/components/schemas/Id"
         size:
-          $ref: "#/components/schemas/BigInt"
+          type: integer
+          format: int64
+          description: Size of the slot in bytes
         requestId:
           $ref: "#/components/schemas/Id"
         slotIndex:
-          type: string
-          description: Slot Index as decimal string
+          type: integer
+          format: int64
+          description: Slot Index number
         validUntil:
           type: integer
           description: Timestamp after which the reservation will no longer be valid.
@@ -308,17 +312,20 @@ components:
         nodes:
           description: Minimal number of nodes the content should be stored on
           type: integer
-          default: 1
+          default: 3
+          minimum: 3
         tolerance:
           description: Additional number of nodes on top of the `nodes` property that can be lost before pronouncing the content lost
           type: integer
-          default: 0
+          default: 1
+          minimum: 1
         collateralPerByte:
           type: string
           description: Number as decimal string that represents how much collateral per byte is asked from hosts that wants to fill a slots
         expiry:
-          type: string
-          description: Number as decimal string that represents expiry threshold in seconds from when the Request is submitted. When the threshold is reached and the Request does not find requested amount of nodes to host the data, the Request is voided. The number of seconds can not be higher then the Request's duration itself.
+          type: integer
+          format: int64
+          description: Number that represents expiry threshold in seconds from when the Request is submitted. When the threshold is reached and the Request does not find requested amount of nodes to host the data, the Request is voided. The number of seconds can not be higher then the Request's duration itself.
     StorageAsk:
       type: object
       required:
@@ -333,9 +340,11 @@ components:
         slots:
           description: Number of slots (eq. hosts) that the Request want to have the content spread over
           type: integer
+          format: int64
         slotSize:
-          type: string
-          description: Amount of storage per slot (in bytes) as decimal string
+          type: integer
+          format: int64
+          description: Amount of storage per slot in bytes
         duration:
           $ref: "#/components/schemas/Duration"
         proofProbability:
@@ -344,6 +353,7 @@ components:
           $ref: "#/components/schemas/PricePerBytePerSecond"
         maxSlotLoss:
           type: integer
+          format: int64
           description: Max slots that can be lost without data considered to be lost
 
     StorageRequest:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -73,6 +73,8 @@ components:
 
     SPRRead:
       type: object
+      required:
+        - spr
       properties:
         spr:
           $ref: "#/components/schemas/SPR"
@@ -85,6 +87,8 @@ components:
 
     Content:
       type: object
+      required:
+       - cid
       description: Parameters specifying the content
       properties:
         cid:
@@ -92,6 +96,12 @@ components:
 
     Node:
       type: object
+      required:
+       - nodeId
+       - peerId
+       - record
+       - address
+       - seen
       properties:
         nodeId:
           type: string
@@ -116,6 +126,9 @@ components:
 
     PeersTable:
       type: object
+      required:
+       - localNode
+       - nodes
       properties:
         localNode:
           $ref: "#/components/schemas/Node"
@@ -126,6 +139,14 @@ components:
 
     DebugInfo:
       type: object
+      required:
+        - id
+        - addrs
+        - repo
+        - spr
+        - announceAddresses
+        - table
+        - codex
       properties:
         id:
           $ref: "#/components/schemas/PeerId"
@@ -149,9 +170,12 @@ components:
 
     SalesAvailability:
       type: object
+      required:
+        - totalSize
+        - duration
+        - minPricePerBytePerSecond
+        - totalCollateral
       properties:
-        id:
-          $ref: "#/components/schemas/Id"
         totalSize:
           type: string
           description: Total size of availability's storage in bytes as decimal string
@@ -173,25 +197,35 @@ components:
           default: 0
 
     SalesAvailabilityREAD:
+      required:
+        - id
+        - totalRemainingCollateral
       allOf:
         - $ref: "#/components/schemas/SalesAvailability"
         - type: object
           properties:
+            id:
+              $ref: "#/components/schemas/Id"
+              readonly: true
             freeSize:
               type: string
               description: Unused size of availability's storage in bytes as decimal string
+              readonly: true
+            totalRemainingCollateral:
+              type: string
+              description: Total collateral effective (in amount of tokens) that can be used for matching requests
+              readonly: true
 
     SalesAvailabilityCREATE:
       allOf:
         - $ref: "#/components/schemas/SalesAvailability"
-        - required:
-            - totalSize
-            - minPricePerBytePerSecond
-            - totalCollateral
-            - duration
 
     Slot:
       type: object
+      required:
+        - id
+        - request
+        - slotIndex
       properties:
         id:
           $ref: "#/components/schemas/SlotId"
@@ -203,9 +237,11 @@ components:
 
     SlotAgent:
       type: object
+      required:
+        - state
+        - requestId
+        - slotIndex
       properties:
-        id:
-          $ref: "#/components/schemas/SlotId"
         slotIndex:
           type: string
           description: Slot Index as decimal string
@@ -235,6 +271,13 @@ components:
 
     Reservation:
       type: object
+      required:
+        - id
+        - availabilityId
+        - size
+        - requestId
+        - slotIndex
+        - validUntil
       properties:
         id:
           $ref: "#/components/schemas/Id"
@@ -283,7 +326,12 @@ components:
     StorageAsk:
       type: object
       required:
+        - slots
+        - slotSize
+        - duration
+        - proofProbability
         - pricePerBytePerSecond
+        - maxSlotLoss
       properties:
         slots:
           description: Number of slots (eq. hosts) that the Request want to have the content spread over
@@ -303,6 +351,13 @@ components:
 
     StorageRequest:
       type: object
+      required:
+       - id
+       - client
+       - ask
+       - content
+       - expiry
+       - nonce
       properties:
         id:
           type: string
@@ -321,6 +376,9 @@ components:
 
     Purchase:
       type: object
+      required:
+        - state
+        - requestId
       properties:
         state:
           type: string
@@ -340,9 +398,13 @@ components:
           description: If Request failed, then here is presented the error message
         request:
           $ref: "#/components/schemas/StorageRequest"
+        requestId:
+          $ref: "#/components/schemas/Id"
 
     DataList:
       type: object
+      required:
+        - content
       properties:
         content:
           type: array
@@ -351,6 +413,9 @@ components:
 
     DataItem:
       type: object
+      required:
+        - cid
+        - manifest
       properties:
         cid:
           $ref: "#/components/schemas/Cid"
@@ -359,6 +424,11 @@ components:
 
     ManifestItem:
       type: object
+      required:
+        - treeCid
+        - datasetSize
+        - blockSize
+        - protected
       properties:
         treeCid:
           $ref: "#/components/schemas/Cid"
@@ -386,6 +456,11 @@ components:
 
     Space:
       type: object
+      required:
+        - totalBlocks
+        - quotaMaxBytes
+        - quotaUsedBytes
+        - quotaReservedBytes
       properties:
         totalBlocks:
           description: "Number of blocks stored by the node"
@@ -739,7 +814,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SalesAvailability"
+              $ref: "#/components/schemas/SalesAvailabilityCREATE"
       responses:
         "204":
           description: Availability successfully updated
@@ -870,7 +945,7 @@ paths:
         "200":
           description: Node's SPR
           content:
-            plain/text:
+            text/plain:
               schema:
                 $ref: "#/components/schemas/SPR"
             application/json:
@@ -888,7 +963,7 @@ paths:
         "200":
           description: Node's Peer ID
           content:
-            plain/text:
+            text/plain:
               schema:
                 $ref: "#/components/schemas/PeerId"
             application/json:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -811,7 +811,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SalesAvailabilityCREATE"
+              $ref: "#/components/schemas/SalesAvailability"
       responses:
         "204":
           description: Availability successfully updated

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -216,10 +216,6 @@ components:
               description: Total collateral effective (in amount of tokens) that can be used for matching requests
               readOnly: true
 
-    SalesAvailabilityCREATE:
-      allOf:
-        - $ref: "#/components/schemas/SalesAvailability"
-
     Slot:
       type: object
       required:
@@ -331,6 +327,7 @@ components:
         - duration
         - proofProbability
         - pricePerBytePerSecond
+        - collateralPerByte
         - maxSlotLoss
       properties:
         slots:
@@ -779,7 +776,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SalesAvailabilityCREATE"
+              $ref: "#/components/schemas/SalesAvailability"
       responses:
         "201":
           description: Created storage availability

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -210,11 +210,11 @@ components:
             freeSize:
               type: string
               description: Unused size of availability's storage in bytes as decimal string
-              readonly: true
+              readOnly: true
             totalRemainingCollateral:
               type: string
               description: Total collateral effective (in amount of tokens) that can be used for matching requests
-              readonly: true
+              readOnly: true
 
     SalesAvailabilityCREATE:
       allOf:


### PR DESCRIPTION
While working on [generating the typescript types from the openapi yaml file](https://github.com/codex-storage/codex-js/blob/4750e0b6fe9430cef3d85b15bbddd937f454cbb8/src/openapi.ts#L348), I noticed that the required parameter was missing for several definitions. 

This PR add those required parameters and fix few minor mistakes.   