### PR TITLE
checked exceptions in stores

### DIFF
--- a/codex/blockexchange/engine/advertiser.nim
+++ b/codex/blockexchange/engine/advertiser.nim
@@ -126,8 +126,11 @@ proc start*(b: Advertiser) {.async: (raises: []).} =
 
   trace "Advertiser start"
 
-  proc onBlock(cid: Cid) {.async.} =
-    await b.advertiseBlock(cid)
+  proc onBlock(cid: Cid) {.async: (raises: []).} =
+    try:
+      await b.advertiseBlock(cid)
+    except CancelledError:
+      trace "Cancelled advertise block", cid
 
   doAssert(b.localStore.onBlockStored.isNone())
   b.localStore.onBlockStored = onBlock.some

--- a/codex/blockexchange/engine/advertiser.nim
+++ b/codex/blockexchange/engine/advertiser.nim
@@ -86,7 +86,7 @@ proc advertiseLocalStoreLoop(b: Advertiser) {.async: (raises: []).} =
       if cidsIter =? await b.localStore.listBlocks(blockType = BlockType.Manifest):
         trace "Advertiser begins iterating blocks..."
         for c in cidsIter:
-          if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
+          if cid =? await c:
             await b.advertiseBlock(cid)
         trace "Advertiser iterating blocks finished."
 

--- a/codex/blockexchange/engine/advertiser.nim
+++ b/codex/blockexchange/engine/advertiser.nim
@@ -7,6 +7,8 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
+{.push raises: [].}
+
 import pkg/chronos
 import pkg/libp2p/cid
 import pkg/libp2p/multicodec
@@ -81,16 +83,12 @@ proc advertiseBlock(b: Advertiser, cid: Cid) {.async: (raises: [CancelledError])
 proc advertiseLocalStoreLoop(b: Advertiser) {.async: (raises: []).} =
   try:
     while b.advertiserRunning:
-      try:
-        if cids =? await b.localStore.listBlocks(blockType = BlockType.Manifest):
-          trace "Advertiser begins iterating blocks..."
-          for c in cids:
-            if cid =? await c:
-              await b.advertiseBlock(cid)
-          trace "Advertiser iterating blocks finished."
-      except CatchableError as e:
-        error "Error in advertise local store loop", error = e.msgDetail
-        raiseAssert("Unexpected exception in advertiseLocalStoreLoop")
+      if cidsIter =? await b.localStore.listBlocks(blockType = BlockType.Manifest):
+        trace "Advertiser begins iterating blocks..."
+        for c in cidsIter:
+          if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
+            await b.advertiseBlock(cid)
+        trace "Advertiser iterating blocks finished."
 
       await sleepAsync(b.advertiseLocalStoreLoopSleep)
   except CancelledError:

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -309,7 +309,7 @@ proc cancelBlocks(
     return peerCtx
 
   try:
-    let (succeededFuts, failedFuts) = await allFinishedFailed(
+    let (succeededFuts, failedFuts) = await allFinishedFailed[BlockExcPeerCtx](
       toSeq(self.peers.peers.values).filterIt(it.peerHave.anyIt(it in addrs)).map(
         processPeer
       )

--- a/codex/blockexchange/engine/engine.nim
+++ b/codex/blockexchange/engine/engine.nim
@@ -202,8 +202,8 @@ proc downloadInternal(
     trace "Block download cancelled"
     if not handle.finished:
       await handle.cancelAndWait()
-  except CatchableError as exc:
-    warn "Error downloadloading block", exc = exc.msg
+  except RetriesExhaustedError as exc:
+    warn "Retries exhausted for block", address, exc = exc.msg
     if not handle.finished:
       handle.fail(exc)
   finally:

--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -177,7 +177,7 @@ proc start*(s: CodexServer) {.async.} =
 proc stop*(s: CodexServer) {.async.} =
   notice "Stopping codex node"
 
-  let res = await noCancel allFinishedFailed(
+  let res = await noCancel allFinishedFailed[void](
     @[
       s.restServer.stop(),
       s.codexNode.switch.stop(),

--- a/codex/errors.nim
+++ b/codex/errors.nim
@@ -7,6 +7,8 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
+{.push raises: [].}
+
 import std/options
 import std/sugar
 import std/sequtils

--- a/codex/errors.nim
+++ b/codex/errors.nim
@@ -65,7 +65,7 @@ proc allFinishedFailed*[T](
   return res
 
 proc allFinishedValues*[T](
-    futs: seq[Future[T]]
+    futs: auto
 ): Future[?!seq[T]] {.async: (raises: [CancelledError]).} =
   ## If all futures have finished, return corresponding values,
   ## otherwise return failure

--- a/codex/errors.nim
+++ b/codex/errors.nim
@@ -47,7 +47,7 @@ func toFailure*[T](exp: Option[T]): Result[T, ref CatchableError] {.inline.} =
     T.failure("Option is None")
 
 proc allFinishedFailed*[T](
-    futs: seq[Future[T]]
+    futs: auto
 ): Future[FinishedFailed[T]] {.async: (raises: [CancelledError]).} =
   ## Check if all futures have finished or failed
   ##

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -485,7 +485,7 @@ proc iterateManifests*(self: CodexNodeRef, onManifest: OnManifest) {.async.} =
     return
 
   for c in cidsIter:
-    if cid =? await c:
+    if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
       without blk =? await self.networkStore.getBlock(cid):
         warn "Failed to get manifest block by cid", cid
         return

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -187,7 +187,7 @@ proc fetchBatched*(
   #   )
 
   while not iter.finished:
-    let blockFutures: seq[Future[?!blocktype.Block].Raising([CancelledError])] = collect:
+    let blockFutures = collect:
       for i in 0 ..< batchSize:
         if not iter.finished:
           let address = BlockAddress.init(cid, iter.next())
@@ -197,8 +197,7 @@ proc fetchBatched*(
     if blockFutures.len == 0:
       continue
 
-    without blockResults =?
-      await allFinishedValues(cast[seq[Future[?!blocktype.Block]]](blockFutures)), err:
+    without blockResults =? await allFinishedValues[?!bt.Block](blockFutures), err:
       trace "Some blocks failed to fetch", err = err.msg
       return failure(err)
 
@@ -485,7 +484,7 @@ proc iterateManifests*(self: CodexNodeRef, onManifest: OnManifest) {.async.} =
     return
 
   for c in cidsIter:
-    if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
+    if cid =? await c:
       without blk =? await self.networkStore.getBlock(cid):
         warn "Failed to get manifest block by cid", cid
         return

--- a/codex/node.nim
+++ b/codex/node.nim
@@ -158,7 +158,7 @@ proc updateExpiry*(
         self.networkStore.localStore.ensureExpiry(manifest.treeCid, it, expiry)
       )
 
-    let res = await allFinishedFailed(cast[seq[Future[?!void]]](ensuringFutures))
+    let res = await allFinishedFailed[?!void](ensuringFutures)
     if res.failure.len > 0:
       trace "Some blocks failed to update expiry", len = res.failure.len
       return failure("Some blocks failed to update expiry (" & $res.failure.len & " )")
@@ -665,7 +665,7 @@ proc onStore(
     let ensureExpiryFutures =
       blocks.mapIt(self.networkStore.ensureExpiry(it.cid, expiry.toSecondsSince1970))
 
-    let res = await allFinishedFailed(cast[seq[Future[?!void]]](ensureExpiryFutures))
+    let res = await allFinishedFailed[?!void](ensureExpiryFutures)
     if res.failure.len > 0:
       trace "Some blocks failed to update expiry", len = res.failure.len
       return failure("Some blocks failed to update expiry (" & $res.failure.len & " )")

--- a/codex/sales/salescontext.nim
+++ b/codex/sales/salescontext.nim
@@ -24,15 +24,17 @@ type
     slotQueue*: SlotQueue
     simulateProofFailures*: int
 
-  BlocksCb* = proc(blocks: seq[bt.Block]): Future[?!void] {.gcsafe, raises: [].}
+  BlocksCb* = proc(blocks: seq[bt.Block]): Future[?!void] {.
+    gcsafe, async: (raises: [CancelledError])
+  .}
   OnStore* = proc(
     request: StorageRequest, slot: uint64, blocksCb: BlocksCb, isRepairing: bool
-  ): Future[?!void] {.gcsafe, upraises: [].}
+  ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).}
   OnProve* = proc(slot: Slot, challenge: ProofChallenge): Future[?!Groth16Proof] {.
-    gcsafe, upraises: []
+    gcsafe, async: (raises: [CancelledError])
   .}
   OnExpiryUpdate* = proc(rootCid: Cid, expiry: SecondsSince1970): Future[?!void] {.
-    gcsafe, upraises: []
+    gcsafe, async: (raises: [CancelledError])
   .}
-  OnClear* = proc(request: StorageRequest, slotIndex: uint64) {.gcsafe, upraises: [].}
-  OnSale* = proc(request: StorageRequest, slotIndex: uint64) {.gcsafe, upraises: [].}
+  OnClear* = proc(request: StorageRequest, slotIndex: uint64) {.gcsafe, raises: [].}
+  OnSale* = proc(request: StorageRequest, slotIndex: uint64) {.gcsafe, raises: [].}

--- a/codex/sales/states/downloading.nim
+++ b/codex/sales/states/downloading.nim
@@ -55,7 +55,9 @@ method run*(
     reservationId = reservation.id
     availabilityId = reservation.availabilityId
 
-  proc onBlocks(blocks: seq[bt.Block]): Future[?!void] {.async.} =
+  proc onBlocks(
+      blocks: seq[bt.Block]
+  ): Future[?!void] {.async: (raises: [CancelledError]).} =
     # release batches of blocks as they are written to disk and
     # update availability size
     var bytes: uint = 0

--- a/codex/slots/proofs/prover.nim
+++ b/codex/slots/proofs/prover.nim
@@ -50,7 +50,7 @@ type
 
 proc prove*(
     self: Prover, slotIdx: int, manifest: Manifest, challenge: ProofChallenge
-): Future[?!(AnyProofInputs, AnyProof)] {.async.} =
+): Future[?!(AnyProofInputs, AnyProof)] {.async: (raises: [CancelledError]).} =
   ## Prove a statement using backend.
   ## Returns a future that resolves to a proof.
 

--- a/codex/slots/sampler/sampler.nim
+++ b/codex/slots/sampler/sampler.nim
@@ -48,7 +48,7 @@ func getCell*[T, H](
 
 proc getSample*[T, H](
     self: DataSampler[T, H], cellIdx: int, slotTreeCid: Cid, slotRoot: H
-): Future[?!Sample[H]] {.async.} =
+): Future[?!Sample[H]] {.async: (raises: [CancelledError]).} =
   let
     cellsPerBlock = self.builder.numBlockCells
     blkCellIdx = cellIdx.toCellInBlk(cellsPerBlock) # block cell index
@@ -81,7 +81,7 @@ proc getSample*[T, H](
 
 proc getProofInput*[T, H](
     self: DataSampler[T, H], entropy: ProofChallenge, nSamples: Natural
-): Future[?!ProofInputs[H]] {.async.} =
+): Future[?!ProofInputs[H]] {.async: (raises: [CancelledError]).} =
   ## Generate proofs as input to the proving circuit.
   ##
 

--- a/codex/stores/blockstore.nim
+++ b/codex/stores/blockstore.nim
@@ -7,10 +7,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import pkg/upraises
-
-push:
-  {.upraises: [].}
+{.push raises: [].}
 
 import pkg/chronos
 import pkg/libp2p
@@ -152,7 +149,7 @@ method hasBlock*(
 
 method listBlocks*(
     self: BlockStore, blockType = BlockType.Manifest
-): Future[?!AsyncIter[?Cid]] {.base, async: (raises: [CancelledError]), gcsafe.} =
+): Future[?!SafeAsyncIter[Cid]] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Get the list of blocks in the BlockStore. This is an intensive operation
   ##
 

--- a/codex/stores/blockstore.nim
+++ b/codex/stores/blockstore.nim
@@ -32,11 +32,13 @@ type
     Block
     Both
 
-  CidCallback* = proc(cid: Cid): Future[void] {.gcsafe, raises: [].}
+  CidCallback* = proc(cid: Cid): Future[void] {.gcsafe, async: (raises: []).}
   BlockStore* = ref object of RootObj
     onBlockStored*: ?CidCallback
 
-method getBlock*(self: BlockStore, cid: Cid): Future[?!Block] {.base, gcsafe.} =
+method getBlock*(
+    self: BlockStore, cid: Cid
+): Future[?!Block] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Get a block from the blockstore
   ##
 
@@ -44,20 +46,23 @@ method getBlock*(self: BlockStore, cid: Cid): Future[?!Block] {.base, gcsafe.} =
 
 method getBlock*(
     self: BlockStore, treeCid: Cid, index: Natural
-): Future[?!Block] {.base, gcsafe.} =
+): Future[?!Block] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Get a block from the blockstore
   ##
 
   raiseAssert("getBlock by treecid not implemented!")
 
-method getCid*(self: BlockStore, treeCid: Cid, index: Natural): Future[?!Cid] {.base.} =
+method getCid*(
+    self: BlockStore, treeCid: Cid, index: Natural
+): Future[?!Cid] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Get a cid given a tree and index
   ##
+
   raiseAssert("getCid by treecid not implemented!")
 
 method getBlock*(
     self: BlockStore, address: BlockAddress
-): Future[?!Block] {.base, gcsafe.} =
+): Future[?!Block] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Get a block from the blockstore
   ##
 
@@ -65,7 +70,7 @@ method getBlock*(
 
 method getBlockAndProof*(
     self: BlockStore, treeCid: Cid, index: Natural
-): Future[?!(Block, CodexProof)] {.base, gcsafe.} =
+): Future[?!(Block, CodexProof)] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Get a block and associated inclusion proof by Cid of a merkle tree and an index of a leaf in a tree
   ##
 
@@ -73,7 +78,7 @@ method getBlockAndProof*(
 
 method putBlock*(
     self: BlockStore, blk: Block, ttl = Duration.none
-): Future[?!void] {.base, gcsafe.} =
+): Future[?!void] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Put a block to the blockstore
   ##
 
@@ -81,7 +86,7 @@ method putBlock*(
 
 method putCidAndProof*(
     self: BlockStore, treeCid: Cid, index: Natural, blockCid: Cid, proof: CodexProof
-): Future[?!void] {.base, gcsafe.} =
+): Future[?!void] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Put a block proof to the blockstore
   ##
 
@@ -89,7 +94,7 @@ method putCidAndProof*(
 
 method getCidAndProof*(
     self: BlockStore, treeCid: Cid, index: Natural
-): Future[?!(Cid, CodexProof)] {.base, gcsafe.} =
+): Future[?!(Cid, CodexProof)] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Get a block proof from the blockstore
   ##
 
@@ -97,7 +102,7 @@ method getCidAndProof*(
 
 method ensureExpiry*(
     self: BlockStore, cid: Cid, expiry: SecondsSince1970
-): Future[?!void] {.base, gcsafe.} =
+): Future[?!void] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Ensure that block's assosicated expiry is at least given timestamp
   ## If the current expiry is lower then it is updated to the given one, otherwise it is left intact
   ##
@@ -106,14 +111,16 @@ method ensureExpiry*(
 
 method ensureExpiry*(
     self: BlockStore, treeCid: Cid, index: Natural, expiry: SecondsSince1970
-): Future[?!void] {.base, gcsafe.} =
+): Future[?!void] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Ensure that block's associated expiry is at least given timestamp
   ## If the current expiry is lower then it is updated to the given one, otherwise it is left intact
   ##
 
   raiseAssert("Not implemented!")
 
-method delBlock*(self: BlockStore, cid: Cid): Future[?!void] {.base, gcsafe.} =
+method delBlock*(
+    self: BlockStore, cid: Cid
+): Future[?!void] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Delete a block from the blockstore
   ##
 
@@ -121,13 +128,15 @@ method delBlock*(self: BlockStore, cid: Cid): Future[?!void] {.base, gcsafe.} =
 
 method delBlock*(
     self: BlockStore, treeCid: Cid, index: Natural
-): Future[?!void] {.base, gcsafe.} =
+): Future[?!void] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Delete a block from the blockstore
   ##
 
   raiseAssert("delBlock not implemented!")
 
-method hasBlock*(self: BlockStore, cid: Cid): Future[?!bool] {.base, gcsafe.} =
+method hasBlock*(
+    self: BlockStore, cid: Cid
+): Future[?!bool] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Check if the block exists in the blockstore
   ##
 
@@ -135,7 +144,7 @@ method hasBlock*(self: BlockStore, cid: Cid): Future[?!bool] {.base, gcsafe.} =
 
 method hasBlock*(
     self: BlockStore, tree: Cid, index: Natural
-): Future[?!bool] {.base, gcsafe.} =
+): Future[?!bool] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Check if the block exists in the blockstore
   ##
 
@@ -143,27 +152,31 @@ method hasBlock*(
 
 method listBlocks*(
     self: BlockStore, blockType = BlockType.Manifest
-): Future[?!AsyncIter[?Cid]] {.base, gcsafe.} =
+): Future[?!AsyncIter[?Cid]] {.base, async: (raises: [CancelledError]), gcsafe.} =
   ## Get the list of blocks in the BlockStore. This is an intensive operation
   ##
 
   raiseAssert("listBlocks not implemented!")
 
-method close*(self: BlockStore): Future[void] {.base, gcsafe.} =
+method close*(self: BlockStore): Future[void] {.base, async: (raises: []), gcsafe.} =
   ## Close the blockstore, cleaning up resources managed by it.
   ## For some implementations this may be a no-op
   ##
 
   raiseAssert("close not implemented!")
 
-proc contains*(self: BlockStore, blk: Cid): Future[bool] {.async.} =
+proc contains*(
+    self: BlockStore, blk: Cid
+): Future[bool] {.async: (raises: [CancelledError]), gcsafe.} =
   ## Check if the block exists in the blockstore.
   ## Return false if error encountered
   ##
 
   return (await self.hasBlock(blk)) |? false
 
-proc contains*(self: BlockStore, address: BlockAddress): Future[bool] {.async.} =
+proc contains*(
+    self: BlockStore, address: BlockAddress
+): Future[bool] {.async: (raises: [CancelledError]), gcsafe.} =
   return
     if address.leaf:
       (await self.hasBlock(address.treeCid, address.index)) |? false

--- a/codex/stores/cachestore.nim
+++ b/codex/stores/cachestore.nim
@@ -46,7 +46,9 @@ type
 
 const DefaultCacheSize*: NBytes = 5.MiBs
 
-method getBlock*(self: CacheStore, cid: Cid): Future[?!Block] {.async.} =
+method getBlock*(
+    self: CacheStore, cid: Cid
+): Future[?!Block] {.async: (raises: [CancelledError]).} =
   ## Get a block from the stores
   ##
 
@@ -69,7 +71,7 @@ method getBlock*(self: CacheStore, cid: Cid): Future[?!Block] {.async.} =
 
 method getCidAndProof*(
     self: CacheStore, treeCid: Cid, index: Natural
-): Future[?!(Cid, CodexProof)] {.async.} =
+): Future[?!(Cid, CodexProof)] {.async: (raises: [CancelledError]).} =
   if cidAndProof =? self.cidAndProofCache.getOption((treeCid, index)):
     success(cidAndProof)
   else:
@@ -81,7 +83,7 @@ method getCidAndProof*(
 
 method getBlock*(
     self: CacheStore, treeCid: Cid, index: Natural
-): Future[?!Block] {.async.} =
+): Future[?!Block] {.async: (raises: [CancelledError]).} =
   without cidAndProof =? (await self.getCidAndProof(treeCid, index)), err:
     return failure(err)
 
@@ -89,7 +91,7 @@ method getBlock*(
 
 method getBlockAndProof*(
     self: CacheStore, treeCid: Cid, index: Natural
-): Future[?!(Block, CodexProof)] {.async.} =
+): Future[?!(Block, CodexProof)] {.async: (raises: [CancelledError]).} =
   without cidAndProof =? (await self.getCidAndProof(treeCid, index)), err:
     return failure(err)
 
@@ -100,13 +102,17 @@ method getBlockAndProof*(
 
   success((blk, proof))
 
-method getBlock*(self: CacheStore, address: BlockAddress): Future[?!Block] =
+method getBlock*(
+    self: CacheStore, address: BlockAddress
+): Future[?!Block] {.async: (raw: true, raises: [CancelledError]).} =
   if address.leaf:
     self.getBlock(address.treeCid, address.index)
   else:
     self.getBlock(address.cid)
 
-method hasBlock*(self: CacheStore, cid: Cid): Future[?!bool] {.async.} =
+method hasBlock*(
+    self: CacheStore, cid: Cid
+): Future[?!bool] {.async: (raises: [CancelledError]).} =
   ## Check if the block exists in the blockstore
   ##
 
@@ -119,7 +125,7 @@ method hasBlock*(self: CacheStore, cid: Cid): Future[?!bool] {.async.} =
 
 method hasBlock*(
     self: CacheStore, treeCid: Cid, index: Natural
-): Future[?!bool] {.async.} =
+): Future[?!bool] {.async: (raises: [CancelledError]).} =
   without cidAndProof =? (await self.getCidAndProof(treeCid, index)), err:
     if err of BlockNotFoundError:
       return success(false)
@@ -136,7 +142,7 @@ func cids(self: CacheStore): (iterator (): Cid {.gcsafe.}) =
 
 method listBlocks*(
     self: CacheStore, blockType = BlockType.Manifest
-): Future[?!AsyncIter[?Cid]] {.async.} =
+): Future[?!AsyncIter[?Cid]] {.async: (raises: [CancelledError]).} =
   ## Get the list of blocks in the BlockStore. This is an intensive operation
   ##
 
@@ -148,30 +154,33 @@ method listBlocks*(
   proc genNext(): Future[Cid] {.async.} =
     cids()
 
-  let iter = await (
-    AsyncIter[Cid].new(genNext, isFinished).filter(
-      proc(cid: Cid): Future[bool] {.async.} =
-        without isManifest =? cid.isManifest, err:
-          trace "Error checking if cid is a manifest", err = err.msg
-          return false
+  try:
+    let iter = await (
+      AsyncIter[Cid].new(genNext, isFinished).filter(
+        proc(cid: Cid): Future[bool] {.async.} =
+          without isManifest =? cid.isManifest, err:
+            trace "Error checking if cid is a manifest", err = err.msg
+            return false
 
-        case blockType
-        of BlockType.Both:
-          return true
-        of BlockType.Manifest:
-          return isManifest
-        of BlockType.Block:
-          return not isManifest
+          case blockType
+          of BlockType.Both:
+            return true
+          of BlockType.Manifest:
+            return isManifest
+          of BlockType.Block:
+            return not isManifest
+      )
     )
-  )
 
-  return success(
-    map[Cid, ?Cid](
-      iter,
-      proc(cid: Cid): Future[?Cid] {.async.} =
-        some(cid),
+    return success(
+      map[Cid, ?Cid](
+        iter,
+        proc(cid: Cid): Future[?Cid] {.async.} =
+          some(cid),
+      )
     )
-  )
+  except CatchableError as err:
+    raiseAssert err.msg
 
 func putBlockSync(self: CacheStore, blk: Block): bool =
   let blkSize = blk.data.len.NBytes # in bytes
@@ -196,7 +205,7 @@ func putBlockSync(self: CacheStore, blk: Block): bool =
 
 method putBlock*(
     self: CacheStore, blk: Block, ttl = Duration.none
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Put a block to the blockstore
   ##
 
@@ -213,13 +222,13 @@ method putBlock*(
 
 method putCidAndProof*(
     self: CacheStore, treeCid: Cid, index: Natural, blockCid: Cid, proof: CodexProof
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   self.cidAndProofCache[(treeCid, index)] = (blockCid, proof)
   success()
 
 method ensureExpiry*(
     self: CacheStore, cid: Cid, expiry: SecondsSince1970
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Updates block's assosicated TTL in store - not applicable for CacheStore
   ##
 
@@ -227,13 +236,15 @@ method ensureExpiry*(
 
 method ensureExpiry*(
     self: CacheStore, treeCid: Cid, index: Natural, expiry: SecondsSince1970
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Updates block's associated TTL in store - not applicable for CacheStore
   ##
 
   discard # CacheStore does not have notion of TTL
 
-method delBlock*(self: CacheStore, cid: Cid): Future[?!void] {.async.} =
+method delBlock*(
+    self: CacheStore, cid: Cid
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Delete a block from the blockstore
   ##
 
@@ -250,7 +261,7 @@ method delBlock*(self: CacheStore, cid: Cid): Future[?!void] {.async.} =
 
 method delBlock*(
     self: CacheStore, treeCid: Cid, index: Natural
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   let maybeRemoved = self.cidAndProofCache.del((treeCid, index))
 
   if removed =? maybeRemoved:
@@ -258,7 +269,7 @@ method delBlock*(
 
   return success()
 
-method close*(self: CacheStore): Future[void] {.async.} =
+method close*(self: CacheStore): Future[void] {.async: (raises: []).} =
   ## Close the blockstore, a no-op for this implementation
   ##
 

--- a/codex/stores/cachestore.nim
+++ b/codex/stores/cachestore.nim
@@ -131,7 +131,7 @@ method hasBlock*(
 
   await self.hasBlock(cidAndProof[0])
 
-func cids(self: CacheStore): (iterator (): Cid {.gcsafe.}) =
+func cids(self: CacheStore): (iterator (): Cid {.gcsafe, raises: [].}) =
   return
     iterator (): Cid =
       for cid in self.cache.keys:
@@ -149,11 +149,7 @@ method listBlocks*(
     return finished(cids)
 
   proc genNext(): Future[?!Cid] {.async: (raises: [CancelledError]).} =
-    try:
-      let cid = cids()
-      success(cid)
-    except Exception as err:
-      failure(err.msg)
+    success(cids())
 
   let iter = await (
     SafeAsyncIter[Cid].new(genNext, isFinished).filter(

--- a/codex/stores/cachestore.nim
+++ b/codex/stores/cachestore.nim
@@ -7,10 +7,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import pkg/upraises
-
-push:
-  {.upraises: [].}
+{.push raises: [].}
 
 import std/options
 
@@ -142,7 +139,7 @@ func cids(self: CacheStore): (iterator (): Cid {.gcsafe.}) =
 
 method listBlocks*(
     self: CacheStore, blockType = BlockType.Manifest
-): Future[?!AsyncIter[?Cid]] {.async: (raises: [CancelledError]).} =
+): Future[?!SafeAsyncIter[Cid]] {.async: (raises: [CancelledError]).} =
   ## Get the list of blocks in the BlockStore. This is an intensive operation
   ##
 
@@ -151,36 +148,33 @@ method listBlocks*(
   proc isFinished(): bool =
     return finished(cids)
 
-  proc genNext(): Future[Cid] {.async.} =
-    cids()
+  proc genNext(): Future[?!Cid] {.async: (raises: [CancelledError]).} =
+    try:
+      let cid = cids()
+      success(cid)
+    except Exception as err:
+      failure(err.msg)
 
-  try:
-    let iter = await (
-      AsyncIter[Cid].new(genNext, isFinished).filter(
-        proc(cid: Cid): Future[bool] {.async.} =
-          without isManifest =? cid.isManifest, err:
-            trace "Error checking if cid is a manifest", err = err.msg
-            return false
+  let iter = await (
+    SafeAsyncIter[Cid].new(genNext, isFinished).filter(
+      proc(cid: ?!Cid): Future[bool] {.async: (raises: [CancelledError]).} =
+        without cid =? cid, err:
+          trace "Cannot get Cid from the iterator", err = err.msg
+          return false
+        without isManifest =? cid.isManifest, err:
+          trace "Error checking if cid is a manifest", err = err.msg
+          return false
 
-          case blockType
-          of BlockType.Both:
-            return true
-          of BlockType.Manifest:
-            return isManifest
-          of BlockType.Block:
-            return not isManifest
-      )
+        case blockType
+        of BlockType.Both:
+          return true
+        of BlockType.Manifest:
+          return isManifest
+        of BlockType.Block:
+          return not isManifest
     )
-
-    return success(
-      map[Cid, ?Cid](
-        iter,
-        proc(cid: Cid): Future[?Cid] {.async.} =
-          some(cid),
-      )
-    )
-  except CatchableError as err:
-    raiseAssert err.msg
+  )
+  success(iter)
 
 func putBlockSync(self: CacheStore, blk: Block): bool =
   let blkSize = blk.data.len.NBytes # in bytes

--- a/codex/stores/maintenance.nim
+++ b/codex/stores/maintenance.nim
@@ -83,8 +83,7 @@ proc runBlockCheck(
 
   var numberReceived = 0
   for beFut in iter:
-    let beRes = await cast[Future[?!BlockExpiration].Raising([CancelledError])](beFut)
-    without be =? beRes, err:
+    without be =? (await beFut), err:
       trace "Unable to obtain blockExpiration from iterator"
       continue
     inc numberReceived

--- a/codex/stores/networkstore.nim
+++ b/codex/stores/networkstore.nim
@@ -31,7 +31,9 @@ type NetworkStore* = ref object of BlockStore
   engine*: BlockExcEngine # blockexc decision engine
   localStore*: BlockStore # local block store
 
-method getBlock*(self: NetworkStore, address: BlockAddress): Future[?!Block] {.async.} =
+method getBlock*(
+    self: NetworkStore, address: BlockAddress
+): Future[?!Block] {.async: (raises: [CancelledError]).} =
   without blk =? (await self.localStore.getBlock(address)), err:
     if not (err of BlockNotFoundError):
       error "Error getting block from local store", address, err = err.msg
@@ -45,13 +47,17 @@ method getBlock*(self: NetworkStore, address: BlockAddress): Future[?!Block] {.a
 
   return success blk
 
-method getBlock*(self: NetworkStore, cid: Cid): Future[?!Block] =
+method getBlock*(
+    self: NetworkStore, cid: Cid
+): Future[?!Block] {.async: (raw: true, raises: [CancelledError]).} =
   ## Get a block from the blockstore
   ##
 
   self.getBlock(BlockAddress.init(cid))
 
-method getBlock*(self: NetworkStore, treeCid: Cid, index: Natural): Future[?!Block] =
+method getBlock*(
+    self: NetworkStore, treeCid: Cid, index: Natural
+): Future[?!Block] {.async: (raw: true, raises: [CancelledError]).} =
   ## Get a block from the blockstore
   ##
 
@@ -59,7 +65,7 @@ method getBlock*(self: NetworkStore, treeCid: Cid, index: Natural): Future[?!Blo
 
 method putBlock*(
     self: NetworkStore, blk: Block, ttl = Duration.none
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Store block locally and notify the network
   ##
   let res = await self.localStore.putBlock(blk, ttl)
@@ -71,12 +77,12 @@ method putBlock*(
 
 method putCidAndProof*(
     self: NetworkStore, treeCid: Cid, index: Natural, blockCid: Cid, proof: CodexProof
-): Future[?!void] =
+): Future[?!void] {.async: (raw: true, raises: [CancelledError]).} =
   self.localStore.putCidAndProof(treeCid, index, blockCid, proof)
 
 method getCidAndProof*(
     self: NetworkStore, treeCid: Cid, index: Natural
-): Future[?!(Cid, CodexProof)] =
+): Future[?!(Cid, CodexProof)] {.async: (raw: true, raises: [CancelledError]).} =
   ## Get a block proof from the blockstore
   ##
 
@@ -84,7 +90,7 @@ method getCidAndProof*(
 
 method ensureExpiry*(
     self: NetworkStore, cid: Cid, expiry: SecondsSince1970
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Ensure that block's assosicated expiry is at least given timestamp
   ## If the current expiry is lower then it is updated to the given one, otherwise it is left intact
   ##
@@ -101,7 +107,7 @@ method ensureExpiry*(
 
 method ensureExpiry*(
     self: NetworkStore, treeCid: Cid, index: Natural, expiry: SecondsSince1970
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Ensure that block's associated expiry is at least given timestamp
   ## If the current expiry is lower then it is updated to the given one, otherwise it is left intact
   ##
@@ -118,10 +124,12 @@ method ensureExpiry*(
 
 method listBlocks*(
     self: NetworkStore, blockType = BlockType.Manifest
-): Future[?!AsyncIter[?Cid]] =
+): Future[?!AsyncIter[?Cid]] {.async: (raw: true, raises: [CancelledError]).} =
   self.localStore.listBlocks(blockType)
 
-method delBlock*(self: NetworkStore, cid: Cid): Future[?!void] =
+method delBlock*(
+    self: NetworkStore, cid: Cid
+): Future[?!void] {.async: (raw: true, raises: [CancelledError]).} =
   ## Delete a block from the blockstore
   ##
 
@@ -130,7 +138,9 @@ method delBlock*(self: NetworkStore, cid: Cid): Future[?!void] =
 
 {.pop.}
 
-method hasBlock*(self: NetworkStore, cid: Cid): Future[?!bool] {.async.} =
+method hasBlock*(
+    self: NetworkStore, cid: Cid
+): Future[?!bool] {.async: (raises: [CancelledError]).} =
   ## Check if the block exists in the blockstore
   ##
 
@@ -139,13 +149,13 @@ method hasBlock*(self: NetworkStore, cid: Cid): Future[?!bool] {.async.} =
 
 method hasBlock*(
     self: NetworkStore, tree: Cid, index: Natural
-): Future[?!bool] {.async.} =
+): Future[?!bool] {.async: (raises: [CancelledError]).} =
   ## Check if the block exists in the blockstore
   ##
   trace "Checking network store for block existence", tree, index
   return await self.localStore.hasBlock(tree, index)
 
-method close*(self: NetworkStore): Future[void] {.async.} =
+method close*(self: NetworkStore): Future[void] {.async: (raises: []).} =
   ## Close the underlying local blockstore
   ##
 

--- a/codex/stores/networkstore.nim
+++ b/codex/stores/networkstore.nim
@@ -19,7 +19,7 @@ import ../blockexchange
 import ../logutils
 import ../merkletree
 import ../utils/asyncheapqueue
-import ../utils/asynciter
+import ../utils/safeasynciter
 import ./blockstore
 
 export blockstore, blockexchange, asyncheapqueue
@@ -124,7 +124,7 @@ method ensureExpiry*(
 
 method listBlocks*(
     self: NetworkStore, blockType = BlockType.Manifest
-): Future[?!AsyncIter[?Cid]] {.async: (raw: true, raises: [CancelledError]).} =
+): Future[?!SafeAsyncIter[Cid]] {.async: (raw: true, raises: [CancelledError]).} =
   self.localStore.listBlocks(blockType)
 
 method delBlock*(

--- a/codex/stores/queryiterhelper.nim
+++ b/codex/stores/queryiterhelper.nim
@@ -5,6 +5,9 @@ import pkg/chronicles
 import pkg/datastore/typedds
 
 import ../utils/asynciter
+import ../utils/safeasynciter
+
+{.push raises: [].}
 
 type KeyVal*[T] = tuple[key: Key, value: T]
 
@@ -42,6 +45,40 @@ proc toAsyncIter*[T](
 
   AsyncIter[?!QueryResponse[T]].new(genNext, isFinished).success
 
+proc toSafeAsyncIter*[T](
+    queryIter: QueryIter[T], finishOnErr: bool = true
+): Future[?!SafeAsyncIter[QueryResponse[T]]] {.async: (raises: [CancelledError]).} =
+  ## Converts `QueryIter[T]` to `SafeAsyncIter[QueryResponse[T]]` and automatically
+  ## runs dispose whenever `QueryIter` finishes or whenever an error occurs (only
+  ## if the flag finishOnErr is set to true)
+  ##
+
+  if queryIter.finished:
+    trace "Disposing iterator"
+    if error =? (await queryIter.dispose()).errorOption:
+      return failure(error)
+    return success(SafeAsyncIter[QueryResponse[T]].empty())
+
+  var errOccurred = false
+
+  proc genNext(): Future[?!QueryResponse[T]] {.async: (raises: [CancelledError]).} =
+    let queryResOrErr = await queryIter.next()
+
+    if queryResOrErr.isErr:
+      errOccurred = true
+
+    if queryIter.finished or (errOccurred and finishOnErr):
+      trace "Disposing iterator"
+      if error =? (await queryIter.dispose()).errorOption:
+        return failure(error)
+
+    return queryResOrErr
+
+  proc isFinished(): bool =
+    queryIter.finished
+
+  SafeAsyncIter[QueryResponse[T]].new(genNext, isFinished).success
+
 proc filterSuccess*[T](
     iter: AsyncIter[?!QueryResponse[T]]
 ): Future[AsyncIter[tuple[key: Key, value: T]]] {.async: (raises: [CancelledError]).} =
@@ -62,7 +99,30 @@ proc filterSuccess*[T](
 
     (key: key, value: value).some
 
-  try:
-    await mapFilter[?!QueryResponse[T], KeyVal[T]](iter, mapping)
-  except CatchableError as err:
-    raiseAssert err.msg
+  await mapFilter[?!QueryResponse[T], KeyVal[T]](iter, mapping)
+
+proc filterSuccess*[T](
+    iter: SafeAsyncIter[QueryResponse[T]]
+): Future[SafeAsyncIter[tuple[key: Key, value: T]]] {.
+    async: (raises: [CancelledError])
+.} =
+  ## Filters out any items that are not success
+
+  proc mapping(
+      resOrErr: ?!QueryResponse[T]
+  ): Future[Option[?!KeyVal[T]]] {.async: (raises: [CancelledError]).} =
+    without res =? resOrErr, error:
+      error "Error occurred when getting QueryResponse", msg = error.msg
+      return Result[KeyVal[T], ref CatchableError].none
+
+    without key =? res.key:
+      warn "No key for a QueryResponse"
+      return Result[KeyVal[T], ref CatchableError].none
+
+    without value =? res.value, error:
+      error "Error occurred when getting a value from QueryResponse", msg = error.msg
+      return Result[KeyVal[T], ref CatchableError].none
+
+    some(success((key: key, value: value)))
+
+  await mapFilter[QueryResponse[T], KeyVal[T]](iter, mapping)

--- a/codex/stores/repostore/operations.nim
+++ b/codex/stores/repostore/operations.nim
@@ -34,7 +34,7 @@ declareGauge(codex_repostore_bytes_reserved, "codex repostore bytes reserved")
 
 proc putLeafMetadata*(
     self: RepoStore, treeCid: Cid, index: Natural, blkCid: Cid, proof: CodexProof
-): Future[?!StoreResultKind] {.async.} =
+): Future[?!StoreResultKind] {.async: (raises: [CancelledError]).} =
   without key =? createBlockCidAndProofMetadataKey(treeCid, index), err:
     return failure(err)
 
@@ -59,7 +59,7 @@ proc putLeafMetadata*(
 
 proc delLeafMetadata*(
     self: RepoStore, treeCid: Cid, index: Natural
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   without key =? createBlockCidAndProofMetadataKey(treeCid, index), err:
     return failure(err)
 
@@ -70,7 +70,7 @@ proc delLeafMetadata*(
 
 proc getLeafMetadata*(
     self: RepoStore, treeCid: Cid, index: Natural
-): Future[?!LeafMetadata] {.async.} =
+): Future[?!LeafMetadata] {.async: (raises: [CancelledError]).} =
   without key =? createBlockCidAndProofMetadataKey(treeCid, index), err:
     return failure(err)
 
@@ -84,7 +84,7 @@ proc getLeafMetadata*(
 
 proc updateTotalBlocksCount*(
     self: RepoStore, plusCount: Natural = 0, minusCount: Natural = 0
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   await self.metaDs.modify(
     CodexTotalBlocksKey,
     proc(maybeCurrCount: ?Natural): Future[?Natural] {.async.} =
@@ -139,7 +139,7 @@ proc updateBlockMetadata*(
     plusRefCount: Natural = 0,
     minusRefCount: Natural = 0,
     minExpiry: SecondsSince1970 = 0,
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   if cid.isEmpty:
     return success()
 
@@ -163,7 +163,7 @@ proc updateBlockMetadata*(
 
 proc storeBlock*(
     self: RepoStore, blk: Block, minExpiry: SecondsSince1970
-): Future[?!StoreResult] {.async.} =
+): Future[?!StoreResult] {.async: (raises: [CancelledError]).} =
   if blk.isEmpty:
     return success(StoreResult(kind: AlreadyInStore))
 
@@ -189,7 +189,7 @@ proc storeBlock*(
           )
           res = StoreResult(kind: AlreadyInStore)
 
-          # making sure that the block acutally is stored in the repoDs
+          # making sure that the block actually is stored in the repoDs
           without hasBlock =? await self.repoDs.has(blkKey), err:
             raise err
 
@@ -215,7 +215,7 @@ proc storeBlock*(
 
 proc tryDeleteBlock*(
     self: RepoStore, cid: Cid, expiryLimit = SecondsSince1970.low
-): Future[?!DeleteResult] {.async.} =
+): Future[?!DeleteResult] {.async: (raises: [CancelledError]).} =
   without metaKey =? createBlockExpirationMetadataKey(cid), err:
     return failure(err)
 

--- a/codex/stores/repostore/store.nim
+++ b/codex/stores/repostore/store.nim
@@ -36,7 +36,9 @@ logScope:
 # BlockStore API
 ###########################################################
 
-method getBlock*(self: RepoStore, cid: Cid): Future[?!Block] {.async.} =
+method getBlock*(
+    self: RepoStore, cid: Cid
+): Future[?!Block] {.async: (raises: [CancelledError]).} =
   ## Get a block from the blockstore
   ##
 
@@ -63,7 +65,7 @@ method getBlock*(self: RepoStore, cid: Cid): Future[?!Block] {.async.} =
 
 method getBlockAndProof*(
     self: RepoStore, treeCid: Cid, index: Natural
-): Future[?!(Block, CodexProof)] {.async.} =
+): Future[?!(Block, CodexProof)] {.async: (raises: [CancelledError]).} =
   without leafMd =? await self.getLeafMetadata(treeCid, index), err:
     return failure(err)
 
@@ -74,13 +76,15 @@ method getBlockAndProof*(
 
 method getBlock*(
     self: RepoStore, treeCid: Cid, index: Natural
-): Future[?!Block] {.async.} =
+): Future[?!Block] {.async: (raises: [CancelledError]).} =
   without leafMd =? await self.getLeafMetadata(treeCid, index), err:
     return failure(err)
 
   await self.getBlock(leafMd.blkCid)
 
-method getBlock*(self: RepoStore, address: BlockAddress): Future[?!Block] =
+method getBlock*(
+    self: RepoStore, address: BlockAddress
+): Future[?!Block] {.async: (raw: true, raises: [CancelledError]).} =
   ## Get a block from the blockstore
   ##
 
@@ -91,7 +95,7 @@ method getBlock*(self: RepoStore, address: BlockAddress): Future[?!Block] =
 
 method ensureExpiry*(
     self: RepoStore, cid: Cid, expiry: SecondsSince1970
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Ensure that block's associated expiry is at least given timestamp
   ## If the current expiry is lower then it is updated to the given one, otherwise it is left intact
   ##
@@ -104,7 +108,7 @@ method ensureExpiry*(
 
 method ensureExpiry*(
     self: RepoStore, treeCid: Cid, index: Natural, expiry: SecondsSince1970
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Ensure that block's associated expiry is at least given timestamp
   ## If the current expiry is lower then it is updated to the given one, otherwise it is left intact
   ##
@@ -116,7 +120,7 @@ method ensureExpiry*(
 
 method putCidAndProof*(
     self: RepoStore, treeCid: Cid, index: Natural, blkCid: Cid, proof: CodexProof
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Put a block to the blockstore
   ##
 
@@ -142,13 +146,15 @@ method putCidAndProof*(
 
 method getCidAndProof*(
     self: RepoStore, treeCid: Cid, index: Natural
-): Future[?!(Cid, CodexProof)] {.async.} =
+): Future[?!(Cid, CodexProof)] {.async: (raises: [CancelledError]).} =
   without leafMd =? await self.getLeafMetadata(treeCid, index), err:
     return failure(err)
 
   success((leafMd.blkCid, leafMd.proof))
 
-method getCid*(self: RepoStore, treeCid: Cid, index: Natural): Future[?!Cid] {.async.} =
+method getCid*(
+    self: RepoStore, treeCid: Cid, index: Natural
+): Future[?!Cid] {.async: (raises: [CancelledError]).} =
   without leafMd =? await self.getLeafMetadata(treeCid, index), err:
     return failure(err)
 
@@ -156,7 +162,7 @@ method getCid*(self: RepoStore, treeCid: Cid, index: Natural): Future[?!Cid] {.a
 
 method putBlock*(
     self: RepoStore, blk: Block, ttl = Duration.none
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Put a block to the blockstore
   ##
 
@@ -186,7 +192,9 @@ method putBlock*(
 
   return success()
 
-proc delBlockInternal(self: RepoStore, cid: Cid): Future[?!DeleteResultKind] {.async.} =
+proc delBlockInternal(
+    self: RepoStore, cid: Cid
+): Future[?!DeleteResultKind] {.async: (raises: [CancelledError]).} =
   logScope:
     cid = cid
 
@@ -208,7 +216,9 @@ proc delBlockInternal(self: RepoStore, cid: Cid): Future[?!DeleteResultKind] {.a
 
   success(res.kind)
 
-method delBlock*(self: RepoStore, cid: Cid): Future[?!void] {.async.} =
+method delBlock*(
+    self: RepoStore, cid: Cid
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   ## Delete a block from the blockstore when block refCount is 0 or block is expired
   ##
 
@@ -230,7 +240,7 @@ method delBlock*(self: RepoStore, cid: Cid): Future[?!void] {.async.} =
 
 method delBlock*(
     self: RepoStore, treeCid: Cid, index: Natural
-): Future[?!void] {.async.} =
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   without leafMd =? await self.getLeafMetadata(treeCid, index), err:
     if err of BlockNotFoundError:
       return success()
@@ -251,7 +261,9 @@ method delBlock*(
 
   success()
 
-method hasBlock*(self: RepoStore, cid: Cid): Future[?!bool] {.async.} =
+method hasBlock*(
+    self: RepoStore, cid: Cid
+): Future[?!bool] {.async: (raises: [CancelledError]).} =
   ## Check if the block exists in the blockstore
   ##
 
@@ -270,7 +282,7 @@ method hasBlock*(self: RepoStore, cid: Cid): Future[?!bool] {.async.} =
 
 method hasBlock*(
     self: RepoStore, treeCid: Cid, index: Natural
-): Future[?!bool] {.async.} =
+): Future[?!bool] {.async: (raises: [CancelledError]).} =
   without leafMd =? await self.getLeafMetadata(treeCid, index), err:
     if err of BlockNotFoundError:
       return success(false)
@@ -281,7 +293,7 @@ method hasBlock*(
 
 method listBlocks*(
     self: RepoStore, blockType = BlockType.Manifest
-): Future[?!AsyncIter[?Cid]] {.async.} =
+): Future[?!AsyncIter[?Cid]] {.async: (raises: [CancelledError]).} =
   ## Get the list of blocks in the RepoStore.
   ## This is an intensive operation
   ##
@@ -332,7 +344,9 @@ proc blockRefCount*(self: RepoStore, cid: Cid): Future[?!Natural] {.async.} =
 
 method getBlockExpirations*(
     self: RepoStore, maxNumber: int, offset: int
-): Future[?!AsyncIter[BlockExpiration]] {.async, base.} =
+): Future[?!AsyncIter[BlockExpiration]] {.
+    async: (raises: [CancelledError]), base, gcsafe
+.} =
   ## Get iterator with block expirations
   ##
 
@@ -358,12 +372,14 @@ method getBlockExpirations*(
 
     BlockExpiration(cid: cid, expiry: kv.value.expiry).some
 
-  let blockExpIter =
-    await mapFilter[KeyVal[BlockMetadata], BlockExpiration](filteredIter, mapping)
+  try:
+    let blockExpIter =
+      await mapFilter[KeyVal[BlockMetadata], BlockExpiration](filteredIter, mapping)
+    success(blockExpIter)
+  except CatchableError as err:
+    raiseAssert err.msg
 
-  success(blockExpIter)
-
-method close*(self: RepoStore): Future[void] {.async.} =
+method close*(self: RepoStore): Future[void] {.async: (raises: []).} =
   ## Close the blockstore, cleaning up resources managed by it.
   ## For some implementations this may be a no-op
   ##
@@ -371,10 +387,13 @@ method close*(self: RepoStore): Future[void] {.async.} =
   trace "Closing repostore"
 
   if not self.metaDs.isNil:
-    (await self.metaDs.close()).expect("Should meta datastore")
+    try:
+      (await noCancel self.metaDs.close()).expect("Should meta datastore")
+    except CatchableError as err:
+      error "Failed to close meta datastore", err = err.msg
 
   if not self.repoDs.isNil:
-    (await self.repoDs.close()).expect("Should repo datastore")
+    (await noCancel self.repoDs.close()).expect("Should repo datastore")
 
 ###########################################################
 # RepoStore procs
@@ -400,7 +419,9 @@ proc release*(
 
   await self.updateQuotaUsage(minusReserved = bytes)
 
-proc start*(self: RepoStore): Future[void] {.async.} =
+proc start*(
+    self: RepoStore
+): Future[void] {.async: (raises: [CancelledError, CodexError]).} =
   ## Start repo
   ##
 
@@ -417,7 +438,7 @@ proc start*(self: RepoStore): Future[void] {.async.} =
 
   self.started = true
 
-proc stop*(self: RepoStore): Future[void] {.async.} =
+proc stop*(self: RepoStore): Future[void] {.async: (raises: []).} =
   ## Stop repo
   ##
   if not self.started:

--- a/codex/stores/repostore/store.nim
+++ b/codex/stores/repostore/store.nim
@@ -7,6 +7,8 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
+{.push raises: [].}
+
 import pkg/chronos
 import pkg/chronos/futures
 import pkg/datastore
@@ -293,12 +295,12 @@ method hasBlock*(
 
 method listBlocks*(
     self: RepoStore, blockType = BlockType.Manifest
-): Future[?!AsyncIter[?Cid]] {.async: (raises: [CancelledError]).} =
+): Future[?!SafeAsyncIter[Cid]] {.async: (raises: [CancelledError]).} =
   ## Get the list of blocks in the RepoStore.
   ## This is an intensive operation
   ##
 
-  var iter = AsyncIter[?Cid]()
+  var iter = SafeAsyncIter[Cid]()
 
   let key =
     case blockType
@@ -311,7 +313,7 @@ method listBlocks*(
     trace "Error querying cids in repo", blockType, err = err.msg
     return failure(err)
 
-  proc next(): Future[?Cid] {.async.} =
+  proc next(): Future[?!Cid] {.async: (raises: [CancelledError]).} =
     await idleAsync()
     if queryIter.finished:
       iter.finish
@@ -319,9 +321,9 @@ method listBlocks*(
       if pair =? (await queryIter.next()) and cid =? pair.key:
         doAssert pair.data.len == 0
         trace "Retrieved record from repo", cid
-        return Cid.init(cid.value).option
+        return Cid.init(cid.value).mapFailure
       else:
-        return Cid.none
+        return Cid.failure("No or invalid Cid")
 
   iter.next = next
   return success iter
@@ -344,7 +346,7 @@ proc blockRefCount*(self: RepoStore, cid: Cid): Future[?!Natural] {.async.} =
 
 method getBlockExpirations*(
     self: RepoStore, maxNumber: int, offset: int
-): Future[?!AsyncIter[BlockExpiration]] {.
+): Future[?!SafeAsyncIter[BlockExpiration]] {.
     async: (raises: [CancelledError]), base, gcsafe
 .} =
   ## Get iterator with block expirations
@@ -358,26 +360,28 @@ method getBlockExpirations*(
     error "Unable to execute block expirations query", err = err.msg
     return failure(err)
 
-  without asyncQueryIter =? await queryIter.toAsyncIter(), err:
+  without asyncQueryIter =? (await queryIter.toSafeAsyncIter()), err:
     error "Unable to convert QueryIter to AsyncIter", err = err.msg
     return failure(err)
 
-  let filteredIter: AsyncIter[KeyVal[BlockMetadata]] =
+  let filteredIter: SafeAsyncIter[KeyVal[BlockMetadata]] =
     await asyncQueryIter.filterSuccess()
 
-  proc mapping(kv: KeyVal[BlockMetadata]): Future[?BlockExpiration] {.async.} =
+  proc mapping(
+      kvRes: ?!KeyVal[BlockMetadata]
+  ): Future[Option[?!BlockExpiration]] {.async: (raises: [CancelledError]).} =
+    without kv =? kvRes, err:
+      error "Error occurred when getting KeyVal", err = err.msg
+      return Result[BlockExpiration, ref CatchableError].none
     without cid =? Cid.init(kv.key.value).mapFailure, err:
       error "Failed decoding cid", err = err.msg
-      return BlockExpiration.none
+      return Result[BlockExpiration, ref CatchableError].none
 
-    BlockExpiration(cid: cid, expiry: kv.value.expiry).some
+    some(success(BlockExpiration(cid: cid, expiry: kv.value.expiry)))
 
-  try:
-    let blockExpIter =
-      await mapFilter[KeyVal[BlockMetadata], BlockExpiration](filteredIter, mapping)
-    success(blockExpIter)
-  except CatchableError as err:
-    raiseAssert err.msg
+  let blockExpIter =
+    await mapFilter[KeyVal[BlockMetadata], BlockExpiration](filteredIter, mapping)
+  success(blockExpIter)
 
 method close*(self: RepoStore): Future[void] {.async: (raises: []).} =
   ## Close the blockstore, cleaning up resources managed by it.

--- a/codex/streams/storestream.nim
+++ b/codex/streams/storestream.nim
@@ -125,7 +125,7 @@ method readOnce*(
 
   return read
 
-method closeImpl*(self: StoreStream) {.async.} =
+method closeImpl*(self: StoreStream) {.async: (raises: []).} =
   trace "Closing StoreStream"
   self.offset = self.size # set Eof
   await procCall LPStream(self).closeImpl()

--- a/codex/utils.nim
+++ b/codex/utils.nim
@@ -8,6 +8,8 @@
 ## those terms.
 ##
 
+{.push raises: [].}
+
 import std/enumerate
 import std/parseutils
 import std/options
@@ -17,8 +19,9 @@ import pkg/chronos
 import ./utils/asyncheapqueue
 import ./utils/fileutils
 import ./utils/asynciter
+import ./utils/safeasynciter
 
-export asyncheapqueue, fileutils, asynciter, chronos
+export asyncheapqueue, fileutils, asynciter, safeasynciter, chronos
 
 when defined(posix):
   import os, posix

--- a/codex/utils/asynciter.nim
+++ b/codex/utils/asynciter.nim
@@ -123,7 +123,7 @@ proc map*[T, U](iter: AsyncIter[T], fn: Function[T, Future[U]]): AsyncIter[U] =
 
 proc mapFilter*[T, U](
     iter: AsyncIter[T], mapPredicate: Function[T, Future[Option[U]]]
-): Future[AsyncIter[U]] {.async.} =
+): Future[AsyncIter[U]] {.async: (raises: [CancelledError]).} =
   var nextFutU: Option[Future[U]]
 
   proc tryFetch(): Future[void] {.async: (raises: [CancelledError]).} =
@@ -157,7 +157,7 @@ proc mapFilter*[T, U](
 
 proc filter*[T](
     iter: AsyncIter[T], predicate: Function[T, Future[bool]]
-): Future[AsyncIter[T]] {.async.} =
+): Future[AsyncIter[T]] {.async: (raises: [CancelledError]).} =
   proc wrappedPredicate(t: T): Future[Option[T]] {.async.} =
     if await predicate(t):
       some(t)

--- a/codex/utils/asynciter.nim
+++ b/codex/utils/asynciter.nim
@@ -126,7 +126,7 @@ proc mapFilter*[T, U](
 ): Future[AsyncIter[U]] {.async.} =
   var nextFutU: Option[Future[U]]
 
-  proc tryFetch(): Future[void] {.async.} =
+  proc tryFetch(): Future[void] {.async: (raises: [CancelledError]).} =
     nextFutU = Future[U].none
     while not iter.finished:
       let futT = iter.next()

--- a/codex/utils/safeasynciter.nim
+++ b/codex/utils/safeasynciter.nim
@@ -1,0 +1,239 @@
+## Nim-Codex
+## Copyright (c) 2025 Status Research & Development GmbH
+## Licensed under either of
+##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+## at your option.
+## This file may not be copied, modified, or distributed except according to
+## those terms.
+
+{.push raises: [].}
+
+import std/sugar
+
+import pkg/questionable
+import pkg/questionable/results
+import pkg/chronos
+
+import ./iter
+
+## SafeAsyncIter[T] is similar to `AsyncIter[Future[T]]`
+## but does not throw exceptions others than CancelledError.
+## It is thus way easier to use with checked exceptions
+##
+##
+## Public interface:
+##
+## Attributes
+## - next - allows to set a custom function to be called when the next item is requested
+##
+## Operations:
+## - new - to create a new async iterator (SafeAsyncIter)
+## - finish - to finish the async iterator
+## - finished - to check if the async iterator is finished
+## - next - to get the next item from the async iterator
+## - items - to iterate over the async iterator
+## - pairs - to iterate over the async iterator and return the index of each item
+## - mapAsync - to convert a regular sync iterator (Iter) to an async iter (SafeAsyncIter)
+## - map - to convert one async iterator (SafeAsyncIter) to another async iter (SafeAsyncIter)
+## - mapFilter - to convert one async iterator (SafeAsyncIter) to another async iter (SafeAsyncIter) and apply filtering at the same time
+## - filter - to filter an async iterator (SafeAsyncIter) returning another async iterator (SafeAsyncIter)
+## - delayBy - to delay each item returned by async iter by a given duration
+## - empty - to create an empty async iterator (SafeAsyncIter)
+
+type
+  SafeFunction[T, U] =
+    proc(fut: T): Future[U] {.async: (raises: [CancelledError]), gcsafe, closure.}
+  SafeIsFinished = proc(): bool {.raises: [], gcsafe, closure.}
+  SafeGenNext[T] = proc(): Future[T] {.async: (raises: [CancelledError]), gcsafe.}
+
+  SafeAsyncIter*[T] = ref object
+    finished: bool
+    next*: SafeGenNext[?!T]
+
+proc flatMap[T, U](
+    fut: Future[?!T], fn: SafeFunction[?!T, ?!U]
+): Future[?!U] {.async: (raises: [CancelledError]).} =
+  let raisingFut = cast[Future[?!T].Raising([CancelledError])](fut)
+  let t = await raisingFut
+  await fn(t)
+
+proc flatMap[T, U](
+    fut: Future[?!T], fn: SafeFunction[?!T, Option[?!U]]
+): Future[Option[?!U]] {.async: (raises: [CancelledError]).} =
+  let raisingFut = cast[Future[?!T].Raising([CancelledError])](fut)
+  let t = await raisingFut
+  await fn(t)
+
+########################################################################
+## SafeAsyncIter public interface methods
+########################################################################
+
+proc new*[T](
+    _: type SafeAsyncIter[T],
+    genNext: SafeGenNext[?!T],
+    isFinished: IsFinished,
+    finishOnErr: bool = true,
+): SafeAsyncIter[T] =
+  ## Creates a new Iter using elements returned by supplier function `genNext`.
+  ## Iter is finished whenever `isFinished` returns true.
+  ##
+
+  var iter = SafeAsyncIter[T]()
+
+  proc next(): Future[?!T] {.async: (raises: [CancelledError]).} =
+    try:
+      if not iter.finished:
+        let item = await genNext()
+        if finishOnErr and err =? item.errorOption:
+          iter.finished = true
+          return failure(err)
+        if isFinished():
+          iter.finished = true
+        return item
+      else:
+        return failure("SafeAsyncIter is finished but next item was requested")
+    except CancelledError as err:
+      iter.finished = true
+      raise err
+
+  if isFinished():
+    iter.finished = true
+
+  iter.next = next
+  return iter
+
+# forward declaration
+proc mapAsync*[T, U](
+  iter: Iter[T], fn: SafeFunction[T, ?!U], finishOnErr: bool = true
+): SafeAsyncIter[U]
+
+proc new*[U, V: Ordinal](
+    _: type SafeAsyncIter[U], slice: HSlice[U, V], finishOnErr: bool = true
+): SafeAsyncIter[U] =
+  ## Creates new Iter from a slice
+  ##
+
+  let iter = Iter[U].new(slice)
+  mapAsync[U, U](
+    iter,
+    proc(i: U): Future[?!U] {.async: (raises: [CancelledError]).} =
+      success[U](i),
+  )
+
+proc new*[U, V, S: Ordinal](
+    _: type SafeAsyncIter[U], a: U, b: V, step: S = 1, finishOnErr: bool = true
+): SafeAsyncIter[U] =
+  ## Creates new Iter in range a..b with specified step (default 1)
+  ##
+
+  let iter = Iter[U].new(a, b, step)
+  mapAsync[U, U](
+    iter,
+    proc(i: U): Future[?!U] {.async: (raises: [CancelledError]).} =
+      U.success(i),
+    finishOnErr = finishOnErr,
+  )
+
+proc finish*[T](self: SafeAsyncIter[T]): void =
+  self.finished = true
+
+proc finished*[T](self: SafeAsyncIter[T]): bool =
+  self.finished
+
+iterator items*[T](self: SafeAsyncIter[T]): Future[?!T] =
+  while not self.finished:
+    yield self.next()
+
+iterator pairs*[T](
+    self: SafeAsyncIter[T]
+): tuple[key: int, val: Future[?!T]] {.inline.} =
+  var i = 0
+  while not self.finished:
+    yield (i, self.next())
+    inc(i)
+
+proc mapAsync*[T, U](
+    iter: Iter[T], fn: SafeFunction[T, ?!U], finishOnErr: bool = true
+): SafeAsyncIter[U] =
+  SafeAsyncIter[U].new(
+    genNext = () => fn(iter.next()),
+    isFinished = () => iter.finished(),
+    finishOnErr = finishOnErr,
+  )
+
+proc map*[T, U](
+    iter: SafeAsyncIter[T], fn: SafeFunction[?!T, ?!U], finishOnErr: bool = true
+): SafeAsyncIter[U] =
+  SafeAsyncIter[U].new(
+    genNext = () => iter.next().flatMap(fn),
+    isFinished = () => iter.finished,
+    finishOnErr = finishOnErr,
+  )
+
+proc mapFilter*[T, U](
+    iter: SafeAsyncIter[T],
+    mapPredicate: SafeFunction[?!T, Option[?!U]],
+    finishOnErr: bool = true,
+): Future[SafeAsyncIter[U]] {.async: (raises: [CancelledError]).} =
+  var nextFutU: Option[Future[?!U]]
+
+  proc filter(): Future[void] {.async: (raises: [CancelledError]).} =
+    nextFutU = Future[?!U].none
+    while not iter.finished:
+      let futT: Future[?!T] = iter.next()
+      if mappedValue =? await futT.flatMap(mapPredicate):
+        let fut: Future[?!U] = newFuture[?!U]("mapFilter.filter")
+        fut.complete(mappedValue)
+        nextFutU = fut.some
+        break
+
+  proc genNext(): Future[?!U] {.async: (raises: [CancelledError]).} =
+    let futU = cast[Future[?!U].Raising([CancelledError])](nextFutU.unsafeGet)
+    await filter()
+    await futU
+
+  proc isFinished(): bool =
+    nextFutU.isNone
+
+  await filter()
+  SafeAsyncIter[U].new(genNext, isFinished, finishOnErr = finishOnErr)
+
+proc filter*[T](
+    iter: SafeAsyncIter[T], predicate: SafeFunction[?!T, bool], finishOnErr: bool = true
+): Future[SafeAsyncIter[T]] {.async: (raises: [CancelledError]).} =
+  proc wrappedPredicate(
+      t: ?!T
+  ): Future[Option[?!T]] {.async: (raises: [CancelledError]).} =
+    if await predicate(t):
+      some(t)
+    else:
+      none(?!T)
+
+  await mapFilter[T, T](iter, wrappedPredicate, finishOnErr = finishOnErr)
+
+proc delayBy*[T](
+    iter: SafeAsyncIter[T], d: Duration, finishOnErr: bool = true
+): SafeAsyncIter[T] =
+  ## Delays emitting each item by given duration
+  ##
+
+  map[T, T](
+    iter,
+    proc(t: ?!T): Future[?!T] {.async: (raises: [CancelledError]).} =
+      await sleepAsync(d)
+      return t,
+    finishOnErr = finishOnErr,
+  )
+
+proc empty*[T](_: type SafeAsyncIter[T]): SafeAsyncIter[T] =
+  ## Creates an empty SafeAsyncIter
+  ##
+
+  proc genNext(): Future[?!T] {.async: (raises: [CancelledError]).} =
+    T.failure("Next item requested from an empty SafeAsyncIter")
+
+  proc isFinished(): bool =
+    true
+
+  SafeAsyncIter[T].new(genNext, isFinished)

--- a/codex/utils/safeasynciter.nim
+++ b/codex/utils/safeasynciter.nim
@@ -117,6 +117,7 @@ proc new*[U, V: Ordinal](
     iter,
     proc(i: U): Future[?!U] {.async: (raises: [CancelledError]).} =
       success[U](i),
+    finishOnErr = finishOnErr,
   )
 
 proc new*[U, V, S: Ordinal](

--- a/codex/utils/timer.nim
+++ b/codex/utils/timer.nim
@@ -20,7 +20,7 @@ import pkg/chronos
 import ../logutils
 
 type
-  TimerCallback* = proc(): Future[void] {.gcsafe, upraises: [].}
+  TimerCallback* = proc(): Future[void] {.gcsafe, raises: [].}
   Timer* = ref object of RootObj
     callback: TimerCallback
     interval: Duration

--- a/tests/codex/helpers/mockrepostore.nim
+++ b/tests/codex/helpers/mockrepostore.nim
@@ -22,19 +22,17 @@ type MockRepoStore* = ref object of RepoStore
   getBeOffset*: int
 
   testBlockExpirations*: seq[BlockExpiration]
-  getBlockExpirationsThrows*: bool
 
-method delBlock*(self: MockRepoStore, cid: Cid): Future[?!void] {.async.} =
+method delBlock*(
+    self: MockRepoStore, cid: Cid
+): Future[?!void] {.async: (raises: [CancelledError]).} =
   self.delBlockCids.add(cid)
   self.testBlockExpirations = self.testBlockExpirations.filterIt(it.cid != cid)
   return success()
 
 method getBlockExpirations*(
     self: MockRepoStore, maxNumber: int, offset: int
-): Future[?!AsyncIter[BlockExpiration]] {.async.} =
-  if self.getBlockExpirationsThrows:
-    raise new CatchableError
-
+): Future[?!AsyncIter[BlockExpiration]] {.async: (raises: [CancelledError]).} =
   self.getBeMaxNumber = maxNumber
   self.getBeOffset = offset
 

--- a/tests/codex/helpers/mocktimer.nim
+++ b/tests/codex/helpers/mocktimer.nim
@@ -26,7 +26,7 @@ method start*(mockTimer: MockTimer, callback: timer.TimerCallback, interval: Dur
   mockTimer.mockInterval = interval
   inc mockTimer.startCalled
 
-method stop*(mockTimer: MockTimer) {.async.} =
+method stop*(mockTimer: MockTimer) {.async: (raises: []).} =
   inc mockTimer.stopCalled
 
 method invokeCallback*(mockTimer: MockTimer) {.async, base.} =

--- a/tests/codex/node/testcontracts.nim
+++ b/tests/codex/node/testcontracts.nim
@@ -120,7 +120,9 @@ asyncchecksuite "Test Node - Host contracts":
       (getTime() + DefaultBlockTtl.toTimesDuration + 1.hours).toUnix.uint64
     var fetchedBytes: uint = 0
 
-    let onBlocks = proc(blocks: seq[bt.Block]): Future[?!void] {.async.} =
+    let onBlocks = proc(
+        blocks: seq[bt.Block]
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       for blk in blocks:
         fetchedBytes += blk.data.len.uint
       return success()

--- a/tests/codex/node/testnode.nim
+++ b/tests/codex/node/testnode.nim
@@ -73,7 +73,9 @@ asyncchecksuite "Test Node - Basic":
         await node.fetchBatched(
           manifest,
           batchSize = batchSize,
-          proc(blocks: seq[bt.Block]): Future[?!void] {.gcsafe, async.} =
+          proc(
+              blocks: seq[bt.Block]
+          ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
             check blocks.len > 0 and blocks.len <= batchSize
             return success(),
         )
@@ -96,7 +98,9 @@ asyncchecksuite "Test Node - Basic":
       await node.fetchBatched(
         manifest,
         batchSize = batchSize,
-        proc(blocks: seq[bt.Block]): Future[?!void] {.gcsafe, async.} =
+        proc(
+            blocks: seq[bt.Block]
+        ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
           return failure("Should not be called"),
       )
     )

--- a/tests/codex/sales/states/testfilled.nim
+++ b/tests/codex/sales/states/testfilled.nim
@@ -37,7 +37,7 @@ suite "sales state 'filled'":
     onExpiryUpdatePassedExpiry = -1
     let onExpiryUpdate = proc(
         rootCid: Cid, expiry: SecondsSince1970
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       onExpiryUpdatePassedExpiry = expiry
       return success()
     let context = SalesContext(market: market, onExpiryUpdate: some onExpiryUpdate)

--- a/tests/codex/sales/states/testinitialproving.nim
+++ b/tests/codex/sales/states/testinitialproving.nim
@@ -31,7 +31,7 @@ asyncchecksuite "sales state 'initialproving'":
   setup:
     let onProve = proc(
         slot: Slot, challenge: ProofChallenge
-    ): Future[?!Groth16Proof] {.async.} =
+    ): Future[?!Groth16Proof] {.async: (raises: [CancelledError]).} =
       receivedChallenge = challenge
       return success(proof)
     let context = SalesContext(onProve: onProve.some, market: market, clock: clock)
@@ -88,7 +88,7 @@ asyncchecksuite "sales state 'initialproving'":
   test "switches to errored state when onProve callback fails":
     let onProveFailed: OnProve = proc(
         slot: Slot, challenge: ProofChallenge
-    ): Future[?!Groth16Proof] {.async.} =
+    ): Future[?!Groth16Proof] {.async: (raises: [CancelledError]).} =
       return failure("oh no!")
 
     let proofFailedContext =

--- a/tests/codex/sales/states/testproving.nim
+++ b/tests/codex/sales/states/testproving.nim
@@ -31,7 +31,7 @@ asyncchecksuite "sales state 'proving'":
     market = MockMarket.new()
     let onProve = proc(
         slot: Slot, challenge: ProofChallenge
-    ): Future[?!Groth16Proof] {.async.} =
+    ): Future[?!Groth16Proof] {.async: (raises: [CancelledError]).} =
       receivedChallenge = challenge
       return success(proof)
     let context = SalesContext(market: market, clock: clock, onProve: onProve.some)

--- a/tests/codex/sales/states/testsimulatedproving.nim
+++ b/tests/codex/sales/states/testsimulatedproving.nim
@@ -44,7 +44,7 @@ asyncchecksuite "sales state 'simulated-proving'":
 
     let onProve = proc(
         slot: Slot, challenge: ProofChallenge
-    ): Future[?!Groth16Proof] {.async.} =
+    ): Future[?!Groth16Proof] {.async: (raises: [CancelledError]).} =
       return success(proof)
     let context = SalesContext(market: market, clock: clock, onProve: onProve.some)
     agent = newSalesAgent(context, request.id, slot.slotIndex, request.some)

--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -64,18 +64,18 @@ asyncchecksuite "Sales - start":
     reservations = sales.context.reservations
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       return success()
 
     sales.onExpiryUpdate = proc(
         rootCid: Cid, expiry: SecondsSince1970
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       return success()
 
     queue = sales.context.slotQueue
     sales.onProve = proc(
         slot: Slot, challenge: ProofChallenge
-    ): Future[?!Groth16Proof] {.async.} =
+    ): Future[?!Groth16Proof] {.async: (raises: [CancelledError]).} =
       return success(proof)
     itemsProcessed = @[]
     expiry = (clock.now() + 42)
@@ -185,18 +185,18 @@ asyncchecksuite "Sales":
     reservations = sales.context.reservations
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       return success()
 
     sales.onExpiryUpdate = proc(
         rootCid: Cid, expiry: SecondsSince1970
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       return success()
 
     queue = sales.context.slotQueue
     sales.onProve = proc(
         slot: Slot, challenge: ProofChallenge
-    ): Future[?!Groth16Proof] {.async.} =
+    ): Future[?!Groth16Proof] {.async: (raises: [CancelledError]).} =
       return success(proof)
     await sales.start()
     itemsProcessed = @[]
@@ -375,7 +375,7 @@ asyncchecksuite "Sales":
   test "availability size is reduced by request slot size when fully downloaded":
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       let blk = bt.Block.new(@[1.byte]).get
       await onBatch(blk.repeat(request.ask.slotSize.int))
 
@@ -388,7 +388,7 @@ asyncchecksuite "Sales":
     var slotIndex = 0.uint64
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       slotIndex = slot
       let blk = bt.Block.new(@[1.byte]).get
       await onBatch(blk.repeat(request.ask.slotSize))
@@ -463,7 +463,7 @@ asyncchecksuite "Sales":
     var storingRequest: StorageRequest
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       storingRequest = request
       return success()
 
@@ -476,7 +476,7 @@ asyncchecksuite "Sales":
     var storingSlot: uint64
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       storingRequest = request
       storingSlot = slot
       return success()
@@ -489,7 +489,7 @@ asyncchecksuite "Sales":
     let error = newException(IOError, "data retrieval failed")
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       return failure(error)
     createAvailability()
     await market.requestStorage(request)
@@ -500,7 +500,7 @@ asyncchecksuite "Sales":
     var provingSlot: uint64
     sales.onProve = proc(
         slot: Slot, challenge: ProofChallenge
-    ): Future[?!Groth16Proof] {.async.} =
+    ): Future[?!Groth16Proof] {.async: (raises: [CancelledError]).} =
       provingRequest = slot.request
       provingSlot = slot.slotIndex
       return success(Groth16Proof.example)
@@ -540,8 +540,8 @@ asyncchecksuite "Sales":
     # which then calls the onClear callback
     sales.onProve = proc(
         slot: Slot, challenge: ProofChallenge
-    ): Future[?!Groth16Proof] {.async.} =
-      raise newException(IOError, "proof failed")
+    ): Future[?!Groth16Proof] {.async: (raises: [CancelledError]).} =
+      return failure("proof failed")
     var clearedRequest: StorageRequest
     var clearedSlotIndex: uint64
     sales.onClear = proc(request: StorageRequest, slotIndex: uint64) =
@@ -558,7 +558,7 @@ asyncchecksuite "Sales":
     let otherHost = Address.example
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       await sleepAsync(chronos.hours(1))
       return success()
     createAvailability()
@@ -574,7 +574,7 @@ asyncchecksuite "Sales":
     let origSize = availability.freeSize
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       await sleepAsync(chronos.hours(1))
       return success()
     createAvailability()
@@ -601,7 +601,7 @@ asyncchecksuite "Sales":
     let origSize = availability.freeSize
     sales.onStore = proc(
         request: StorageRequest, slot: uint64, onBatch: BatchProc, isRepairing = false
-    ): Future[?!void] {.async.} =
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
       await sleepAsync(chronos.hours(1))
       return success()
     createAvailability()

--- a/tests/codex/stores/commonstoretests.nim
+++ b/tests/codex/stores/commonstoretests.nim
@@ -106,11 +106,11 @@ proc commonBlockStoreTests*(
         check not handle.failed
         check handle.read.isOk
 
-      let cids = (await store.listBlocks(blockType = BlockType.Block)).tryGet()
+      let cidsIter = (await store.listBlocks(blockType = BlockType.Block)).tryGet()
 
       var count = 0
-      for c in cids:
-        if cid =? await c:
+      for c in cidsIter:
+        if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
           check (await store.hasBlock(cid)).tryGet()
           count.inc
 
@@ -130,11 +130,11 @@ proc commonBlockStoreTests*(
         check not handle.failed
         check handle.read.isOk
 
-      let cids = (await store.listBlocks(blockType = BlockType.Manifest)).tryGet()
+      let cidsIter = (await store.listBlocks(blockType = BlockType.Manifest)).tryGet()
 
       var count = 0
-      for c in cids:
-        if cid =? (await c):
+      for c in cidsIter:
+        if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
           check manifestBlock.cid == cid
           check (await store.hasBlock(cid)).tryGet()
           count.inc
@@ -155,11 +155,11 @@ proc commonBlockStoreTests*(
         check not handle.failed
         check handle.read.isOk
 
-      let cids = (await store.listBlocks(blockType = BlockType.Both)).tryGet()
+      let cidsIter = (await store.listBlocks(blockType = BlockType.Both)).tryGet()
 
       var count = 0
-      for c in cids:
-        if cid =? (await c):
+      for c in cidsIter:
+        if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
           check (await store.hasBlock(cid)).tryGet()
           count.inc
 

--- a/tests/codex/stores/commonstoretests.nim
+++ b/tests/codex/stores/commonstoretests.nim
@@ -110,7 +110,7 @@ proc commonBlockStoreTests*(
 
       var count = 0
       for c in cidsIter:
-        if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
+        if cid =? await c:
           check (await store.hasBlock(cid)).tryGet()
           count.inc
 
@@ -134,7 +134,7 @@ proc commonBlockStoreTests*(
 
       var count = 0
       for c in cidsIter:
-        if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
+        if cid =? await c:
           check manifestBlock.cid == cid
           check (await store.hasBlock(cid)).tryGet()
           count.inc
@@ -159,7 +159,7 @@ proc commonBlockStoreTests*(
 
       var count = 0
       for c in cidsIter:
-        if cid =? (await cast[Future[?!Cid].Raising([CancelledError])](c)):
+        if cid =? await c:
           check (await store.hasBlock(cid)).tryGet()
           count.inc
 

--- a/tests/codex/stores/commonstoretests.nim
+++ b/tests/codex/stores/commonstoretests.nim
@@ -58,7 +58,7 @@ proc commonBlockStoreTests*(
 
     test "putBlock raises onBlockStored":
       var storedCid = Cid.example
-      proc onStored(cid: Cid) {.async.} =
+      proc onStored(cid: Cid) {.async: (raises: []).} =
         storedCid = cid
 
       store.onBlockStored = onStored.some()

--- a/tests/codex/stores/testmaintenance.nim
+++ b/tests/codex/stores/testmaintenance.nim
@@ -73,11 +73,6 @@ suite "BlockMaintainer":
       mockRepoStore.getBeMaxNumber == 2
       mockRepoStore.getBeOffset == 0
 
-  test "Timer callback should handle Catachable errors":
-    mockRepoStore.getBlockExpirationsThrows = true
-    blockMaintainer.start()
-    await mockTimer.invokeCallback()
-
   test "Subsequent timer callback should call getBlockExpirations on RepoStore with offset":
     blockMaintainer.start()
     await mockTimer.invokeCallback()

--- a/tests/codex/stores/testrepostore.nim
+++ b/tests/codex/stores/testrepostore.nim
@@ -293,16 +293,13 @@ asyncchecksuite "RepoStore":
 
   test "Should retrieve block expiration information":
     proc unpack(
-        beIter: Future[?!SafeAsyncIter[BlockExpiration]]
+        beIter: auto
     ): Future[seq[BlockExpiration]] {.async: (raises: [CancelledError]).} =
       var expirations = newSeq[BlockExpiration](0)
-      without iter =? (
-        await cast[Future[?!SafeAsyncIter[BlockExpiration]].Raising([CancelledError])](beIter)
-      ), err:
+      without iter =? (await beIter), err:
         return expirations
       for beFut in toSeq(iter):
-        if value =?
-            (await cast[Future[?!BlockExpiration].Raising([CancelledError])](beFut)):
+        if value =? (await beFut):
           expirations.add(value)
       return expirations
 

--- a/tests/codex/testutils.nim
+++ b/tests/codex/testutils.nim
@@ -2,6 +2,7 @@ import ./utils/testoptions
 import ./utils/testkeyutils
 import ./utils/testasyncstatemachine
 import ./utils/testasynciter
+import ./utils/testsafeasynciter
 import ./utils/testtimer
 import ./utils/testtrackedfutures
 

--- a/tests/codex/utils/testsafeasynciter.nim
+++ b/tests/codex/utils/testsafeasynciter.nim
@@ -1,0 +1,388 @@
+import std/sugar
+import pkg/questionable
+import pkg/chronos
+import pkg/codex/utils/iter
+import pkg/codex/utils/safeasynciter
+
+import ../../asynctest
+import ../helpers
+
+asyncchecksuite "Test SafeAsyncIter":
+  test "Should be finished":
+    let iter = SafeAsyncIter[int].empty()
+
+    check:
+      iter.finished == true
+
+  test "using with async generator":
+    let value = 1
+    var intIter = Iter.new(0 ..< 5)
+    let expectedSeq = newSeqWith(5, intIter.next())
+    intIter = Iter.new(0 ..< 5)
+    proc asyncGen(): Future[?!int] {.async: (raw: true, raises: [CancelledError]).} =
+      let fut = newFuture[?!int]()
+      fut.complete(success(intIter.next()))
+      return fut
+
+    let iter = SafeAsyncIter[int].new(asyncGen, () => intIter.finished)
+
+    var collected: seq[int]
+    for iFut in iter:
+      let iRes = await iFut
+      if i =? iRes:
+        collected.add(i)
+      else:
+        fail()
+
+    check collected == expectedSeq
+    let nextRes = await iter.next()
+    assert nextRes.isFailure
+    check nextRes.error.msg == "SafeAsyncIter is finished but next item was requested"
+
+  test "getting async iter for simple sync range iterator":
+    let iter1 = SafeAsyncIter[int].new(0 ..< 5)
+
+    var collected: seq[int]
+    for iFut in iter1:
+      let iRes = await iFut
+      if i =? iRes:
+        collected.add(i)
+      else:
+        fail()
+    check:
+      collected == @[0, 1, 2, 3, 4]
+
+  test "Should map each item using `map`":
+    let iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
+
+    let iter2 = map[int, string](
+      iter1,
+      proc(iRes: ?!int): Future[?!string] {.async: (raises: [CancelledError]).} =
+        if i =? iRes:
+          return success($i)
+        else:
+          return failure("Some error"),
+    )
+
+    var collected: seq[string]
+
+    for fut in iter2:
+      if i =? (await fut):
+        collected.add(i)
+      else:
+        fail()
+
+    check:
+      collected == @["0", "1", "2", "3", "4"]
+
+  test "Should leave only odd items using `filter`":
+    let
+      iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
+      iter2 = await filter[int](
+        iter1,
+        proc(i: ?!int): Future[bool] {.async: (raises: [CancelledError]).} =
+          if i =? i:
+            return (i mod 2) == 1
+          else:
+            return false,
+      )
+
+    var collected: seq[int]
+
+    for fut in iter2:
+      if i =? (await fut):
+        collected.add(i)
+      else:
+        fail()
+
+    check:
+      collected == @[1, 3]
+
+  test "Should leave only odd items using `mapFilter`":
+    let
+      iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
+      iter2 = await mapFilter[int, string](
+        iter1,
+        proc(i: ?!int): Future[Option[?!string]] {.async: (raises: [CancelledError]).} =
+          if i =? i:
+            if (i mod 2) == 1:
+              return some(success($i))
+          Result[system.string, ref CatchableError].none,
+      )
+
+    var collected: seq[string]
+
+    for fut in iter2:
+      if i =? (await fut):
+        collected.add(i)
+      else:
+        fail()
+
+    check:
+      collected == @["1", "3"]
+
+  test "Collecting errors on `map` when finish on error is true":
+    let
+      iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
+      iter2 = map[int, string](
+        iter1,
+        proc(i: ?!int): Future[?!string] {.async: (raises: [CancelledError]).} =
+          if i =? i:
+            if i < 3:
+              return success($i)
+            else:
+              return failure("Error on item: " & $i)
+          return failure("Unexpected error"),
+      )
+
+    var collectedSuccess: seq[string]
+    var collectedFailure: seq[string]
+
+    for fut in iter2:
+      without i =? (await fut), err:
+        collectedFailure.add(err.msg)
+        continue
+      collectedSuccess.add(i)
+
+    check:
+      collectedSuccess == @["0", "1", "2"]
+      collectedFailure == @["Error on item: 3"]
+      iter2.finished
+
+  test "Collecting errors on `map` when finish on error is false":
+    let
+      iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
+      iter2 = map[int, string](
+        iter1,
+        proc(i: ?!int): Future[?!string] {.async: (raises: [CancelledError]).} =
+          if i =? i:
+            if i < 3:
+              return success($i)
+            else:
+              return failure("Error on item: " & $i)
+          return failure("Unexpected error"),
+        finishOnErr = false,
+      )
+
+    var collectedSuccess: seq[string]
+    var collectedFailure: seq[string]
+
+    for fut in iter2:
+      without i =? (await fut), err:
+        collectedFailure.add(err.msg)
+        continue
+      collectedSuccess.add(i)
+
+    check:
+      collectedSuccess == @["0", "1", "2"]
+      collectedFailure == @["Error on item: 3", "Error on item: 4"]
+      iter2.finished
+
+  test "Collecting errors on `map` when errors are mixed with successes":
+    let
+      iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
+      iter2 = map[int, string](
+        iter1,
+        proc(i: ?!int): Future[?!string] {.async: (raises: [CancelledError]).} =
+          if i =? i:
+            if i == 1 or i == 3:
+              return success($i)
+            else:
+              return failure("Error on item: " & $i)
+          return failure("Unexpected error"),
+        finishOnErr = false,
+      )
+
+    var collectedSuccess: seq[string]
+    var collectedFailure: seq[string]
+
+    for fut in iter2:
+      without i =? (await fut), err:
+        collectedFailure.add(err.msg)
+        continue
+      collectedSuccess.add(i)
+
+    check:
+      collectedSuccess == @["1", "3"]
+      collectedFailure == @["Error on item: 0", "Error on item: 2", "Error on item: 4"]
+      iter2.finished
+
+  test "Collecting errors on `mapFilter` when finish on error is true":
+    let
+      iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
+      iter2 = await mapFilter[int, string](
+        iter1,
+        proc(i: ?!int): Future[Option[?!string]] {.async: (raises: [CancelledError]).} =
+          if i =? i:
+            if i == 1:
+              return some(string.failure("Error on item: " & $i))
+            elif i < 3:
+              return some(success($i))
+            else:
+              return Result[system.string, ref CatchableError].none
+          return some(string.failure("Unexpected error")),
+      )
+
+    var collectedSuccess: seq[string]
+    var collectedFailure: seq[string]
+
+    for fut in iter2:
+      without i =? (await fut), err:
+        collectedFailure.add(err.msg)
+        continue
+      collectedSuccess.add(i)
+
+    check:
+      collectedSuccess == @["0"]
+      collectedFailure == @["Error on item: 1"]
+      iter2.finished
+
+  test "Collecting errors on `mapFilter` when finish on error is false":
+    let
+      iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
+      iter2 = await mapFilter[int, string](
+        iter1,
+        proc(i: ?!int): Future[Option[?!string]] {.async: (raises: [CancelledError]).} =
+          if i =? i:
+            if i == 1:
+              return some(string.failure("Error on item: " & $i))
+            elif i < 3:
+              return some(success($i))
+            else:
+              return Result[system.string, ref CatchableError].none
+          return some(string.failure("Unexpected error")),
+        finishOnErr = false,
+      )
+
+    var collectedSuccess: seq[string]
+    var collectedFailure: seq[string]
+
+    for fut in iter2:
+      without i =? (await fut), err:
+        collectedFailure.add(err.msg)
+        continue
+      collectedSuccess.add(i)
+
+    check:
+      collectedSuccess == @["0", "2"]
+      collectedFailure == @["Error on item: 1"]
+      iter2.finished
+
+  test "Collecting errors on `filter` when finish on error is false":
+    let
+      iter1 = SafeAsyncIter[int].new(0 ..< 5)
+      iter2 = map[int, string](
+        iter1,
+        proc(i: ?!int): Future[?!string] {.async: (raises: [CancelledError]).} =
+          if i =? i:
+            if i == 1 or i == 2:
+              return failure("Error on item: " & $i)
+            elif i < 4:
+              return success($i)
+          return failure("Unexpected error"),
+        finishOnErr = false,
+      )
+      iter3 = await filter[string](
+        iter2,
+        proc(i: ?!string): Future[bool] {.async: (raises: [CancelledError]).} =
+          without i =? i, err:
+            if err.msg == "Error on item: 1":
+              return false
+            else:
+              return true
+          if i == "0":
+            return false
+          else:
+            return true,
+        finishOnErr = false,
+      )
+
+    var collectedSuccess: seq[string]
+    var collectedFailure: seq[string]
+
+    for fut in iter3:
+      without i =? (await fut), err:
+        collectedFailure.add(err.msg)
+        continue
+      collectedSuccess.add(i)
+
+    check:
+      collectedSuccess == @["3"]
+      collectedFailure == @["Error on item: 2", "Unexpected error"]
+      iter3.finished
+
+  test "Collecting errors on `filter` when finish on error is true":
+    let
+      iter1 = SafeAsyncIter[int].new(0 ..< 5)
+      iter2 = map[int, string](
+        iter1,
+        proc(i: ?!int): Future[?!string] {.async: (raises: [CancelledError]).} =
+          if i =? i:
+            if i == 3:
+              return failure("Error on item: " & $i)
+            elif i < 3:
+              return success($i)
+          return failure("Unexpected error"),
+        finishOnErr = false,
+      )
+      iter3 = await filter[string](
+        iter2,
+        proc(i: ?!string): Future[bool] {.async: (raises: [CancelledError]).} =
+          without i =? i, err:
+            if err.msg == "Unexpected error":
+              return false
+            else:
+              return true
+          if i == "0":
+            return false
+          else:
+            return true,
+      )
+
+    var collectedSuccess: seq[string]
+    var collectedFailure: seq[string]
+
+    for fut in iter3:
+      without i =? (await fut), err:
+        collectedFailure.add(err.msg)
+        continue
+      collectedSuccess.add(i)
+
+    check:
+      collectedSuccess == @["1", "2"]
+      # On error iterator finishes and returns the error of the item
+      # that caused the error = that's why we see it here
+      collectedFailure == @["Error on item: 3"]
+      iter3.finished
+
+  test "Should propagate cancellation error immediately":
+    let fut = newFuture[Option[?!string]]("testsafeasynciter")
+
+    let iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
+    let iter2 = await mapFilter[int, string](
+      iter1,
+      proc(i: ?!int): Future[Option[?!string]] {.async: (raises: [CancelledError]).} =
+        if i =? i:
+          if (i < 3):
+            return some(success($i))
+        return await cast[Future[Option[?!string]].Raising([CancelledError])](fut),
+    )
+
+    proc cancelFut(): Future[void] {.async.} =
+      await sleepAsync(100.millis)
+      await fut.cancelAndWait()
+
+    asyncSpawn(cancelFut())
+
+    var collected: seq[string]
+
+    expect CancelledError:
+      for fut in iter2:
+        if i =? (await fut):
+          collected.add(i)
+        else:
+          fail()
+
+    check:
+      collected == @["0", "1"]
+      iter2.finished

--- a/tests/codex/utils/testsafeasynciter.nim
+++ b/tests/codex/utils/testsafeasynciter.nim
@@ -356,14 +356,8 @@ asyncchecksuite "Test SafeAsyncIter":
       iter3.finished
 
   test "Should propagate cancellation error immediately":
-    proc newRaisingFuture[T](
-        fromProc: static[string] = ""
-    ): Future[T] {.async: (raw: true, raises: [CancelledError]).} =
-      let fut = newFuture[T](fromProc)
-      return fut
-
     let fut: Future[Option[?!string]].Raising([CancelledError]) =
-      newRaisingFuture[Option[?!string]]("testsafeasynciter")
+      Future[Option[?!string]].Raising([CancelledError]).init("testsafeasynciter")
 
     let iter1 = SafeAsyncIter[int].new(0 ..< 5).delayBy(10.millis)
     let iter2 = await mapFilter[int, string](

--- a/tests/codex/utils/testtimer.nim
+++ b/tests/codex/utils/testtimer.nim
@@ -21,16 +21,13 @@ asyncchecksuite "Timer":
   var numbersState = 0
   var lettersState = 'a'
 
-  proc numbersCallback(): Future[void] {.async.} =
+  proc numbersCallback(): Future[void] {.async: (raises: []).} =
     output &= $numbersState
     inc numbersState
 
-  proc lettersCallback(): Future[void] {.async.} =
+  proc lettersCallback(): Future[void] {.async: (raises: []).} =
     output &= $lettersState
     inc lettersState
-
-  proc exceptionCallback(): Future[void] {.async.} =
-    raise newException(CatchableError, "Test Exception")
 
   proc startNumbersTimer() =
     timer1.start(numbersCallback, 10.milliseconds)
@@ -72,11 +69,6 @@ asyncchecksuite "Timer":
     let stoppedOutput = output
     await sleepAsync(30.milliseconds)
     check output == stoppedOutput
-
-  test "Exceptions raised in timer callback are handled":
-    timer1.start(exceptionCallback, 10.milliseconds)
-    await sleepAsync(30.milliseconds)
-    await timer1.stop()
 
   test "Starting both timers should execute callbacks sequentially":
     startNumbersTimer()


### PR DESCRIPTION
While working on BitTorrent stuff and trying to keep exceptions checked, I continuously hit the wall of set of "stores" which mostly do not use anything but `.async.`.

This PR adds checked exceptions to all stores and dependent abstractions.

To keep the PR still maintainable it focuses on the "stores", thus it has pretty much a minimal set of changes to get them compile.

Most of the changes are easy and syntactical, but there were a few exceptions where it was a big pain to move forward.
It all boils down to `AsynIter`, most probably created before `async: (raises: [CancelledError])` era, that makes checking exceptions much harder where it is used.

The only way to get it clean was for me to create a version of AsyncIter (called `SafeAsyncIter`) that uses `Results` and only ever allows for `async: (raises: [CancelledError])`. I applied it to `listBlocks` and `getBlockExpirations` and doing this I could remove problematic situations (especially in block maintenance). `SafeAsynIter` has the same API as `AsynIter` and requires very little work (pretty much syntactical) to use it in place of `AsyncIter`, which is still used in some other places, which can be dealt with in a separate PR to keep this one small.

To get some insights about challenges that you may encounter when working with checked (raising) exception, you may like to check the following note: https://publish.obsidian.md/bittorrent/10+Notes/Async+checked+(raising)+exceptions.