### PR TITLE
ci: switch out from ubuntu 20.04

### DIFF
--- a/.github/actions/nimbus-build-system/action.yml
+++ b/.github/actions/nimbus-build-system/action.yml
@@ -92,10 +92,16 @@ runs:
       if : ${{ inputs.os == 'linux' && inputs.coverage != 'true' }}
       shell: ${{ inputs.shell }} {0}
       run: |
-        # Add GCC-14 to alternatives
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 14
-        # Set GCC-14 as the default
-        sudo update-alternatives --set gcc /usr/bin/gcc-14
+        # Skip for older Ubuntu versions
+        if [[ $(lsb_release -r | awk -F '[^0-9]+' '{print $2}') -ge 24 ]]; then
+          # Install GCC-14
+          sudo apt-get update -qq
+          sudo apt-get install -yq gcc-14
+          # Add GCC-14 to alternatives
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 14
+          # Set GCC-14 as the default
+          sudo update-alternatives --set gcc /usr/bin/gcc-14
+        fi
 
     - name: Install ccache on Linux/Mac
       if: inputs.os == 'linux' || inputs.os == 'macos'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,7 @@ jobs:
           suggest: true
 
   coverage:
-    # Force to stick to ubuntu 20.04 for coverage because
-    # lcov was updated to 2.x version in ubuntu-latest
-    # and cause a lot of issues.
-    # See https://github.com/linux-test-project/lcov/issues/238
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       uses: fabiocaccamo/create-matrix-action@v5
       with:
         matrix: |
-          os {linux},   cpu {amd64}, builder {ubuntu-20.04},     nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
+          os {linux},   cpu {amd64}, builder {ubuntu-22.04},     nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
           os {linux},   cpu {arm64}, builder {ubuntu-22.04-arm}, nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
           os {macos},   cpu {amd64}, builder {macos-13},         nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}
           os {macos},   cpu {arm64}, builder {macos-14},         nim_version {${{ env.nim_version }}}, rust_version {${{ env.rust_version }}}, shell {bash --noprofile --norc -e -o pipefail}

--- a/Makefile
+++ b/Makefile
@@ -179,11 +179,11 @@ coverage:
 	$(MAKE) NIMFLAGS="$(NIMFLAGS) --lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage" test
 	cd nimcache/release/testCodex && rm -f *.c
 	mkdir -p coverage
-	lcov --capture --directory nimcache/release/testCodex --output-file coverage/coverage.info
+	lcov --capture --keep-going --directory nimcache/release/testCodex --output-file coverage/coverage.info
 	shopt -s globstar && ls $$(pwd)/codex/{*,**/*}.nim
-	shopt -s globstar && lcov --extract coverage/coverage.info $$(pwd)/codex/{*,**/*}.nim --output-file coverage/coverage.f.info
+	shopt -s globstar && lcov --extract coverage/coverage.info --keep-going $$(pwd)/codex/{*,**/*}.nim --output-file coverage/coverage.f.info
 	echo -e $(BUILD_MSG) "coverage/report/index.html"
-	genhtml coverage/coverage.f.info --output-directory coverage/report
+	genhtml coverage/coverage.f.info --keep-going --output-directory coverage/report
 
 show-coverage:
 	if which open >/dev/null; then (echo -e "\e[92mOpening\e[39m HTML coverage report in browser..." && open coverage/report/index.html) || true; fi

--- a/build.nims
+++ b/build.nims
@@ -107,14 +107,14 @@ task coverage, "generates code coverage report":
   mkDir("coverage")
   echo " ======== Running LCOV ======== "
   exec(
-    "lcov --capture --directory nimcache/coverage --output-file coverage/coverage.info"
+    "lcov --capture --keep-going --directory nimcache/coverage --output-file coverage/coverage.info"
   )
   exec(
-    "lcov --extract coverage/coverage.info --output-file coverage/coverage.f.info " &
+    "lcov --extract coverage/coverage.info --keep-going --output-file coverage/coverage.f.info " &
       nimSrcs
   )
   echo " ======== Generating HTML coverage report ======== "
-  exec("genhtml coverage/coverage.f.info --output-directory coverage/report ")
+  exec("genhtml coverage/coverage.f.info --keep-going --output-directory coverage/report ")
   echo " ======== Coverage report Done ======== "
 
 task showCoverage, "open coverage html":


### PR DESCRIPTION
This PR closes #1141
- We've switched to `ubuntu-latest` (`24.04`) for coverage because 20.04 will be fully unsupported by 2025-04-15
- To fix the issue with the `lcov` v2 (which is a default on ubuntu-24.04) it was required to pass [`--keep-going`](https://man.archlinux.org/man/lcov.1.en) and use default GCC 13 (GCC 14 compatibility issue need to be solved, but let's do it later)
    > Do not stop if error occurs: attempt to generate a result, however flawed.
- Release workflow was switched to `ubuntu-22.04`
- GCC-14 is not easy available on Ubuntu < 24.04 - so, install and use it only on the new versions

And to fix CI, it was required to update submodule [nim-leveldbstatic to 0.2.1](https://github.com/codex-storage/nim-leveldb/pull/4).