### PR TITLE
ci: add compatible contracts image for nim-codex docker image

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -124,6 +124,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Docker - Variables
+        run: |
+          # Create contract label for compatible contract image if specified
+          if [[ -n "${{ env.CONTRACT_IMAGE }}" ]]; then
+            echo "CONTRACT_LABEL=storage.codex.nim-codex.blockchain-image=${{ env.CONTRACT_IMAGE }}" >>$GITHUB_ENV
+          fi
+
       - name: Docker - Meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -112,6 +112,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Docker - Meta
         id: meta

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -129,6 +129,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_REPO }}
+          labels: ${{ env.CONTRACT_LABEL }}
 
       - name: Docker - Set up Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -85,8 +85,19 @@ env:
 
 
 jobs:
+  compute:
+      name: Compute build ID
+      runs-on: ubuntu-latest
+      outputs:
+        build_id: ${{ steps.build_id.outputs.build_id }}
+      steps:
+        - name: Generate unique build id
+          id: build_id
+          run: echo "build_id=$(openssl rand -hex 5)" >> $GITHUB_OUTPUT
+
   # Build platform specific image
   build:
+    needs: compute
     strategy:
       fail-fast: true
       matrix:
@@ -152,7 +163,7 @@ jobs:
       - name: Docker - Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.target.arch }}
+          name: digests-${{ needs.compute.outputs.build_id }}-${{ matrix.target.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -164,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.meta.outputs.version }}
-    needs: build
+    needs: [build, compute]
     steps:
       - name: Docker - Variables
         run: |
@@ -197,7 +208,7 @@ jobs:
       - name: Docker - Download digests
         uses: actions/download-artifact@v4
         with:
-          pattern: digests-*
+          pattern: digests-${{ needs.compute.outputs.build_id }}-*
           merge-multiple: true
           path: /tmp/digests
 

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -59,6 +59,10 @@ on:
         required: false
         type: string
         default: false
+      contract_image:
+        description: Specifies compatible smart contract image
+        required: false
+        type: string
 
 
 env:
@@ -71,6 +75,7 @@ env:
   TAG_LATEST: ${{ inputs.tag_latest }}
   TAG_SHA: ${{ inputs.tag_sha }}
   TAG_SUFFIX: ${{ inputs.tag_suffix }}
+  CONTRACT_IMAGE: ${{ inputs.contract_image }}
   # Tests
   TESTS_SOURCE: codex-storage/cs-codex-dist-tests
   TESTS_BRANCH: master
@@ -183,6 +188,11 @@ jobs:
           else
             echo "TAG_RAW=false" >>$GITHUB_ENV
           fi
+          
+          # Create contract label for compatible contract image if specified
+          if [[ -n "${{ env.CONTRACT_IMAGE }}" ]]; then
+            echo "CONTRACT_LABEL=storage.codex.nim-codex.blockchain-image=${{ env.CONTRACT_IMAGE }}" >>$GITHUB_ENV
+          fi
 
       - name: Docker - Download digests
         uses: actions/download-artifact@v4
@@ -199,6 +209,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_REPO }}
+          labels: ${{ env.CONTRACT_LABEL }}
           flavor: |
             latest=${{ env.TAG_LATEST }}
             suffix=${{ env.TAG_SUFFIX }},onlatest=true

--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -112,8 +112,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Docker - Meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,7 @@ jobs:
       dockerhub_repo: codexstorage/codex-contracts-eth
       tag_suffix: -codex-factory
       tag_sha_long: true
+      checkout-submodules: true
     secrets: inherit
 
   build-and-push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Get submodule short hash
         id: get-hash
         run: |
-          hash=$(git submodule status | awk '$2 == "vendor/codex-contracts-eth" {print substr($1,1,7)}')
+          hash=$(git rev-parse --short HEAD:vendor/codex-contracts-eth)
           echo "hash=$hash" >> $GITHUB_OUTPUT
   build-and-push:
     name: Build and Push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,5 +37,5 @@ jobs:
     uses: ./.github/workflows/docker-reusable.yml
     with:
       tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
-      contract_image: "codexstorage/codex-contracts-eth:${{ github.sha }}-codex-factory"
+      contract_image: "codexstorage/codex-contracts-eth:sha-${{ github.sha }}-codex-factory"
     secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
       docker_build_context: vendor/codex-contracts-eth
       docker_file: vendor/codex-contracts-eth/docker/Dockerfile
       dockerhub_repo: codexstorage/codex-contracts-eth
-      tag_suffix: -codex-factory
+      tag_suffix: codex-factory
       tag_sha_long: true
       checkout-submodules: true
     secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,22 +20,25 @@ on:
 
 
 jobs:
-  build-contracts-and-push:
-    name: Build and Push Codex Contracts
-    uses: codex-storage/github-actions/.github/workflows/docker-reusable.yml@master
-    with:
-      docker_build_context: vendor/codex-contracts-eth
-      docker_file: vendor/codex-contracts-eth/docker/Dockerfile
-      dockerhub_repo: codexstorage/codex-contracts-eth
-      tag_suffix: codex-factory
-      tag_sha_long: true
-      checkout-submodules: true
-    secrets: inherit
+  get-contracts-hash:
+    runs-on: ubuntu-latest
+    outputs:
+      hash: ${{ steps.get-hash.outputs.hash }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
+      - name: Get submodule short hash
+        id: get-hash
+        run: |
+          hash=$(git submodule status | awk '$2 == "vendor/codex-contracts-eth" {print substr($1,1,7)}')
+          echo "hash=$hash" >> $GITHUB_OUTPUT
   build-and-push:
     name: Build and Push
     uses: ./.github/workflows/docker-reusable.yml
+    needs: get-contracts-hash
     with:
       tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
-      contract_image: "codexstorage/codex-contracts-eth:sha-${{ github.sha }}-codex-factory"
+      contract_image: "codexstorage/codex-contracts-eth:sha-${{ needs.get-contracts-hash.outputs.hash }}"
     secrets: inherit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,9 +20,21 @@ on:
 
 
 jobs:
+  build-contracts-and-push:
+    name: Build and Push Codex Contracts
+    uses: codex-storage/github-actions/.github/workflows/docker-reusable.yml@master
+    with:
+      docker_build_context: vendor/codex-contracts-eth
+      docker_file: vendor/codex-contracts-eth/docker/Dockerfile
+      dockerhub_repo: codexstorage/codex-contracts-eth
+      tag_suffix: -codex-factory
+      tag_sha_long: true
+    secrets: inherit
+
   build-and-push:
     name: Build and Push
     uses: ./.github/workflows/docker-reusable.yml
     with:
       tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
+      contract_image: "codexstorage/codex-contracts-eth:${{ github.sha }}-codex-factory"
     secrets: inherit


### PR DESCRIPTION
Adds another job to Docker building, that creates Contract's image that is compatible with the image being built, then this image is linked using Docker image labels. This is in order to support https://github.com/codex-storage/codex-factory