### PR TITLE
chore(marketplace): use canProofBeMarkedAsMissing

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -335,12 +335,10 @@ method markProofAsMissing*(
 
 method canProofBeMarkedAsMissing*(
     market: OnChainMarket, id: SlotId, period: Period
-): Future[bool] {.async.} =
-  let provider = market.contract.provider
-  let contractWithoutSigner = market.contract.connect(provider)
-  let overrides = CallOverrides(blockTag: some BlockTag.pending)
+): Future[bool] {.async: (raises: [CancelledError]).} =
   try:
-    discard await contractWithoutSigner.markProofAsMissing(id, period, overrides)
+    let overrides = CallOverrides(blockTag: some BlockTag.pending)
+    discard await market.contract.canProofBeMarkedAsMissing(id, period, overrides)
     return true
   except EthersError as e:
     trace "Proof cannot be marked as missing", msg = e.msg

--- a/codex/contracts/marketplace.nim
+++ b/codex/contracts/marketplace.nim
@@ -178,6 +178,17 @@ proc markProofAsMissing*(
   ]
 .}
 
+proc canProofBeMarkedAsMissing*(
+  marketplace: Marketplace, id: SlotId, period: uint64
+): Confirmable {.
+  contract,
+  errors: [
+    Marketplace_SlotNotAcceptingProofs, Proofs_PeriodNotEnded,
+    Proofs_ValidationTimedOut, Proofs_ProofNotMissing, Proofs_ProofNotRequired,
+    Proofs_ProofAlreadyMarkedMissing,
+  ]
+.}
+
 proc reserveSlot*(
   marketplace: Marketplace, requestId: RequestId, slotIndex: uint64
 ): Confirmable {.contract.}

--- a/codex/market.nim
+++ b/codex/market.nim
@@ -206,7 +206,7 @@ method markProofAsMissing*(
 
 method canProofBeMarkedAsMissing*(
     market: Market, id: SlotId, period: Period
-): Future[bool] {.base, async.} =
+): Future[bool] {.base, async: (raises: [CancelledError]).} =
   raiseAssert("not implemented")
 
 method reserveSlot*(

--- a/tests/codex/helpers/mockmarket.nim
+++ b/tests/codex/helpers/mockmarket.nim
@@ -389,7 +389,7 @@ proc setCanProofBeMarkedAsMissing*(mock: MockMarket, id: SlotId, required: bool)
 
 method canProofBeMarkedAsMissing*(
     market: MockMarket, id: SlotId, period: Period
-): Future[bool] {.async.} =
+): Future[bool] {.async: (raises: [CancelledError]).} =
   return market.canBeMarkedAsMissing.contains(id)
 
 method reserveSlot*(

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -548,7 +548,7 @@ ethersuite "On-Chain Market":
     switchAccount(host)
     await market.reserveSlot(request.id, 0.uint64)
     await market.fillSlot(request.id, 0.uint64, proof, request.ask.collateralPerSlot)
-    let filledAt = (await ethProvider.currentTime()) - 1.u256
+    let filledAt = (await ethProvider.currentTime())
 
     for slotIndex in 1 ..< request.ask.slots:
       await market.reserveSlot(request.id, slotIndex.uint64)
@@ -575,7 +575,7 @@ ethersuite "On-Chain Market":
     switchAccount(host)
     await market.reserveSlot(request.id, 0.uint64)
     await market.fillSlot(request.id, 0.uint64, proof, request.ask.collateralPerSlot)
-    let filledAt = (await ethProvider.currentTime()) - 1.u256
+    let filledAt = await ethProvider.currentTime()
 
     for slotIndex in 1 ..< request.ask.slots:
       await market.reserveSlot(request.id, slotIndex.uint64)


### PR DESCRIPTION
This PR fixes #1153 by using a new function in the contract, canProofBeMarkedAsMissing.

Since this function is a view and does not transfer reward funds to the validator, we should no longer encounter the ERC20: transfer to the zero address error.