### PR TITLE
feat(marketplace) - add command line arg for maxPriorityFeePerGas

### DIFF
--- a/codex/codex.nim
+++ b/codex/codex.nim
@@ -83,7 +83,9 @@ proc bootstrapInteractions(s: CodexServer): Future[void] {.async.} =
       error "Persistence enabled, but no Ethereum account was set"
       quit QuitFailure
 
-    let provider = JsonRpcProvider.new(config.ethProvider)
+    let provider = JsonRpcProvider.new(
+      config.ethProvider, maxPriorityFeePerGas = config.maxPriorityFeePerGas.u256
+    )
     await waitForSync(provider)
     var signer: Signer
     if account =? config.ethAccount:

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -44,7 +44,7 @@ import ./utils
 import ./nat
 import ./utils/natutils
 
-from ./contracts/config import DefaultRequestCacheSize
+from ./contracts/config import DefaultRequestCacheSize, DefaultMaxPriorityFeePerGas
 from ./validationconfig import MaxSlots, ValidationGroups
 
 export units, net, codextypes, logutils, completeCmdArg, parseCmdArg, NatConfig
@@ -52,7 +52,7 @@ export ValidationGroups, MaxSlots
 
 export
   DefaultQuotaBytes, DefaultBlockTtl, DefaultBlockInterval, DefaultNumBlocksPerInterval,
-  DefaultRequestCacheSize
+  DefaultRequestCacheSize, DefaultMaxPriorityFeePerGas
 
 type ThreadCount* = distinct Natural
 
@@ -369,6 +369,15 @@ type
         name: "request-cache-size",
         hidden
       .}: uint16
+
+      maxPriorityFeePerGas* {.
+        desc:
+          "Sets the maximum priority fee per gas for Ethereum EIP-1559 transactions in wei.",
+        defaultValue: DefaultMaxPriorityFeePerGas,
+        defaultValueDesc: $DefaultMaxPriorityFeePerGas,
+        name: "max-priority-fee-per-gas",
+        hidden
+      .}: uint64
 
       case persistenceCmd* {.defaultValue: noCmd, command.}: PersistenceCmd
       of PersistenceCmd.prover:

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -372,7 +372,7 @@ type
 
       maxPriorityFeePerGas* {.
         desc:
-          "Sets the maximum priority fee per gas for Ethereum EIP-1559 transactions in wei.",
+          "Sets the default maximum priority fee per gas for Ethereum EIP-1559 transactions, in wei, when not provided by the network.",
         defaultValue: DefaultMaxPriorityFeePerGas,
         defaultValueDesc: $DefaultMaxPriorityFeePerGas,
         name: "max-priority-fee-per-gas",

--- a/codex/contracts/config.nim
+++ b/codex/contracts/config.nim
@@ -5,6 +5,7 @@ import pkg/questionable/results
 export contractabi
 
 const DefaultRequestCacheSize* = 128.uint16
+const DefaultMaxPriorityFeePerGas* = 1_000_000_000.uint64
 
 type
   MarketplaceConfig* = object


### PR DESCRIPTION
This PR adds a new command line argument to configure the maxPriorityFeePerGas available now with [EIP-1559 implementation] (https://github.com/codex-storage/nim-ethers/pull/113)