### PR TITLE
Increase gas estimates

### DIFF
--- a/codex/contracts/config.nim
+++ b/codex/contracts/config.nim
@@ -1,5 +1,5 @@
 import pkg/contractabi
-import pkg/ethers/fields
+import pkg/ethers/contracts/fields
 import pkg/questionable/results
 
 export contractabi

--- a/codex/contracts/proofs.nim
+++ b/codex/contracts/proofs.nim
@@ -1,6 +1,6 @@
 import pkg/stint
 import pkg/contractabi
-import pkg/ethers/fields
+import pkg/ethers/contracts/fields
 
 type
   Groth16Proof* = object

--- a/codex/contracts/requests.nim
+++ b/codex/contracts/requests.nim
@@ -3,13 +3,12 @@ import std/sequtils
 import std/typetraits
 import pkg/contractabi
 import pkg/nimcrypto
-import pkg/ethers/fields
+import pkg/ethers/contracts/fields
 import pkg/questionable/results
 import pkg/stew/byteutils
 import pkg/libp2p/[cid, multicodec]
 import ../logutils
 import ../utils/json
-import ../clock
 from ../errors import mapFailure
 
 export contractabi


### PR DESCRIPTION
Adds 10% to gas estimates for `reserveSlot`, `fillSlot`, `freeSlot` and `markProofAsMissing`.

These calls could otherwise run out of gas because the on-chain state may have changed
between the time of the estimate and the time of processing the transaction.

Depends on a change in nim-ethers: https://github.com/codex-storage/nim-ethers/pull/115

Fixes #1133 