### PR TITLE
chore: add marketplace topic to reservations

### DIFF
--- a/codex/sales/reservations.nim
+++ b/codex/sales/reservations.nim
@@ -56,7 +56,7 @@ export requests
 export logutils
 
 logScope:
-  topics = "sales reservations"
+  topics = "marketplace sales reservations"
 
 type
   AvailabilityId* = distinct array[32, byte]


### PR DESCRIPTION
We use `marketplace` everywhere related to Marketplace, but it is missing in the `reservations` module.