### PR TITLE
ci: add compatible contracts image for nim-codex dist-tests docker images

### DIFF
--- a/.github/workflows/docker-dist-tests.yml
+++ b/.github/workflows/docker-dist-tests.yml
@@ -26,13 +26,29 @@ on:
 
 
 jobs:
+  get-contracts-hash:
+    runs-on: ubuntu-latest
+    outputs:
+      hash: ${{ steps.get-hash.outputs.hash }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Get submodule short hash
+        id: get-hash
+        run: |
+          hash=$(git rev-parse --short HEAD:vendor/codex-contracts-eth)
+          echo "hash=$hash" >> $GITHUB_OUTPUT
   build-and-push:
     name: Build and Push
     uses: ./.github/workflows/docker-reusable.yml
+    needs: get-contracts-hash
     with:
       nimflags: '-d:disableMarchNative -d:codex_enable_api_debug_peers=true -d:codex_enable_proof_failures=true -d:codex_enable_log_counter=true -d:verify_circuit=true'
       nat_ip_auto: true
       tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
       tag_suffix: dist-tests
+      contract_image: "codexstorage/codex-contracts-eth:sha-${{ needs.get-contracts-hash.outputs.hash }}-dist-tests"
       run_release_tests: ${{ inputs.run_release_tests }}
     secrets: inherit


### PR DESCRIPTION
This is a #1186 followup and it adds compatible contracts image label for `dist-test` Docker images as well.

Result, based on the branch build
```shell
docker pull codexstorage/nim-codex:sha-c9a5ef8-dist-tests

docker inspect \
  --format '{{ index .Config.Labels "storage.codex.nim-codex.blockchain-image"}}' \
  codexstorage/nim-codex:sha-c9a5ef8-dist-tests
```
```
codexstorage/codex-contracts-eth:sha-0bf1385-dist-tests
```