### PR TITLE
Codex-contracts hash in version information.

### DIFF
--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -477,14 +477,9 @@ proc getCodexRevision(): string =
   var res = strip(staticExec("git rev-parse --short HEAD"))
   return res
 
-proc getCodexContractsRevision(): string =
-  let
-    res = strip(
-        staticExec("git ls-tree -z -d --abbrev=7 HEAD -- ../vendor/codex-contracts-eth")
-      )
-      .replace('\t', ' ')
-    tokens = res.split(' ')
-  return tokens[2]
+proc getCodexContractsRevision() : string =
+  let res = strip(staticExec("git rev-parse --short HEAD:vendor/codex-contracts-eth"))
+  return res
 
 proc getNimBanner(): string =
   staticExec("nim --version | grep Version")

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -477,7 +477,7 @@ proc getCodexRevision(): string =
   var res = strip(staticExec("git rev-parse --short HEAD"))
   return res
 
-proc getCodexContractsRevision() : string =
+proc getCodexContractsRevision(): string =
   let
     res = strip(staticExec("git ls-tree -z -d --abbrev=7 HEAD -- ../vendor/codex-contracts-eth")).replace('\t', ' ')
     tokens = res.split(' ')

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -477,17 +477,24 @@ proc getCodexRevision(): string =
   var res = strip(staticExec("git rev-parse --short HEAD"))
   return res
 
+proc getCodexContractsRevision() : string =
+  let
+    res = strip(staticExec("git ls-tree -z -d --abbrev=7 HEAD -- ../vendor/codex-contracts-eth")).replace('\t', ' ')
+    tokens = res.split(' ')
+  return tokens[2]
+
 proc getNimBanner(): string =
   staticExec("nim --version | grep Version")
 
 const
   codexVersion* = getCodexVersion()
   codexRevision* = getCodexRevision()
+  codexContractsRevision* = getCodexContractsRevision()
   nimBanner* = getNimBanner()
 
   codexFullVersion* =
     "Codex version:  " & codexVersion & "\p" & "Codex revision: " & codexRevision & "\p" &
-    nimBanner
+    "Codex contracts revision: " & codexContractsRevision & "\p" & nimBanner
 
 proc parseCmdArg*(
     T: typedesc[MultiAddress], input: string

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -479,7 +479,10 @@ proc getCodexRevision(): string =
 
 proc getCodexContractsRevision(): string =
   let
-    res = strip(staticExec("git ls-tree -z -d --abbrev=7 HEAD -- ../vendor/codex-contracts-eth")).replace('\t', ' ')
+    res = strip(
+        staticExec("git ls-tree -z -d --abbrev=7 HEAD -- ../vendor/codex-contracts-eth")
+      )
+      .replace('\t', ' ')
     tokens = res.split(' ')
   return tokens[2]
 

--- a/codex/conf.nim
+++ b/codex/conf.nim
@@ -477,7 +477,7 @@ proc getCodexRevision(): string =
   var res = strip(staticExec("git rev-parse --short HEAD"))
   return res
 
-proc getCodexContractsRevision() : string =
+proc getCodexContractsRevision(): string =
   let res = strip(staticExec("git rev-parse --short HEAD:vendor/codex-contracts-eth"))
   return res
 

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -914,7 +914,11 @@ proc initDebugApi(node: CodexNodeRef, conf: CodexConf, router: var RestRouter) =
               "",
           "announceAddresses": node.discovery.announceAddrs,
           "table": table,
-          "codex": {"version": $codexVersion, "revision": $codexRevision, "contracts": $codexContractsRevision},
+          "codex": {
+            "version": $codexVersion,
+            "revision": $codexRevision,
+            "contracts": $codexContractsRevision,
+          },
         }
 
       # return pretty json for human readability

--- a/codex/rest/api.nim
+++ b/codex/rest/api.nim
@@ -914,7 +914,7 @@ proc initDebugApi(node: CodexNodeRef, conf: CodexConf, router: var RestRouter) =
               "",
           "announceAddresses": node.discovery.announceAddrs,
           "table": table,
-          "codex": {"version": $codexVersion, "revision": $codexRevision},
+          "codex": {"version": $codexVersion, "revision": $codexRevision, "contracts": $codexContractsRevision},
         }
 
       # return pretty json for human readability

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -124,6 +124,9 @@ components:
         revision:
           type: string
           example: 0c647d8
+        contracts:
+          type: string
+          example: 0b537c7
 
     PeersTable:
       type: object


### PR DESCRIPTION
Following a discussion on how to track compatibility of codex-contracts with the main application.

This PR adds the contracts revision hash to both `--version` and the debug/info version object:
```
	"codex": {
		"version": "v0.2.0",
		"revision": "22f5150d",
		"contracts": "0bf1385"
	}
```

This enabled the automatic checking of compatibility in tests. (Including situations where docker commands are not available to check the docker-image labels added in an earlier PR.)
