### PR TITLE
ci: trigger python generator upon release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,3 +177,12 @@ jobs:
           files: |
             /tmp/release/*
           make_latest: true
+
+      - name: Generate Python SDK
+        uses: peter-evans/repository-dispatch@v3
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          token: ${{ secrets.DISPATCH_PAT }}
+          repository: codex-storage/py-codex-api-client
+          event-type: generate
+          client-payload: '{"openapi_url": "https://raw.githubusercontent.com/codex-storage/nim-codex/${{ github.ref }}/openapi.yaml"}'


### PR DESCRIPTION
This PR will add `repository_dispatch` trigger, that will generate PR with update of Python generated SDK with the latest OpenAPI changes, when new release is made.