### PR TITLE
chore: returns the collateral when a slot is reserved but not filled

### DIFF
--- a/codex/sales/states/cancelled.nim
+++ b/codex/sales/states/cancelled.nim
@@ -31,21 +31,23 @@ method run*(
     raiseAssert "no sale request"
 
   try:
-    var returnedCollateral = UInt256.none
+    debug "Collecting collateral and partial payout",
+      requestId = data.requestId, slotIndex = data.slotIndex
+
+    # The returnedCollateral is needed even if the slot is not filled by the host
+    # because a reservation could be created and the collateral assigned
+    # to that reservation. So if the slot is not filled by that host,
+    # the reservation will be deleted during cleanup and the collateral
+    # must be returned to the host.
+    let slot = Slot(request: request, slotIndex: data.slotIndex)
+    let currentCollateral = await market.currentCollateral(slot.id)
+    let returnedCollateral = currentCollateral.some
 
     if await slotIsFilledByMe(market, data.requestId, data.slotIndex):
-      debug "Collecting collateral and partial payout",
-        requestId = data.requestId, slotIndex = data.slotIndex
-
-      let slot = Slot(request: request, slotIndex: data.slotIndex)
-      let currentCollateral = await market.currentCollateral(slot.id)
-
       try:
         await market.freeSlot(slot.id)
       except SlotStateMismatchError as e:
         warn "Failed to free slot because slot is already free", error = e.msg
-
-      returnedCollateral = currentCollateral.some
 
     if onClear =? agent.context.onClear and request =? data.request:
       onClear(request, data.slotIndex)

--- a/tests/codex/sales/states/testcancelled.nim
+++ b/tests/codex/sales/states/testcancelled.nim
@@ -75,7 +75,8 @@ asyncchecksuite "sales state 'cancelled'":
     check eventually reprocessSlotWas == some false
     check eventually returnedCollateralValue == some currentCollateral
 
-  test "completes the cancelled state when free slot error is raised and the collateral is not returned when a host is not hosting a slot":
+  test "completes the cancelled state when free slot error is raised and the collateral is returned":
+    discard market.reserveSlot(requestId = request.id, slotIndex = slotIndex)
     market.fillSlot(
       requestId = request.id,
       slotIndex = slotIndex,
@@ -91,7 +92,7 @@ asyncchecksuite "sales state 'cancelled'":
     let next = await state.run(agent)
     check next == none State
     check eventually reprocessSlotWas == some false
-    check eventually returnedCollateralValue == UInt256.none
+    check eventually returnedCollateralValue == some currentCollateral
 
   test "calls onCleanUp and returns the collateral when an error is raised":
     market.fillSlot(

--- a/tests/codex/sales/testsales.nim
+++ b/tests/codex/sales/testsales.nim
@@ -403,6 +403,13 @@ asyncchecksuite "Sales":
     await allowRequestToStart()
     await sold
 
+    # Disable the availability; otherwise, it will pick up the
+    # reservation again and we will not be able to check
+    # if the bytes are returned
+    availability.enabled = false
+    let result = await reservations.update(availability)
+    check result.isOk
+
     # complete request
     market.slotState[request.slotId(slotIndex)] = SlotState.Finished
     clock.advance(request.ask.duration.int64)


### PR DESCRIPTION
This PR contains:

1. The [contract PR](https://github.com/codex-storage/codex-contracts-eth/pull/235) that allows reserving a slot when the slot is in a repair state and avoids corrupted data when deleting reservations.
2. Returns the collateral when the request is canceled, not only when the slot is filled by the host, but also when a host creates a reservation and assigns collateral.