### PR TITLE
fix(availabilities): use totalRemainingCollateral instead of totalCollateral for comparaison 

### DIFF
--- a/codex/sales/reservations.nim
+++ b/codex/sales/reservations.nim
@@ -351,7 +351,8 @@ proc updateAvailability(
 
   if oldAvailability.freeSize < obj.freeSize or oldAvailability.duration < obj.duration or
       oldAvailability.minPricePerBytePerSecond < obj.minPricePerBytePerSecond or
-      oldAvailability.totalCollateral < obj.totalCollateral: # availability updated
+      oldAvailability.totalRemainingCollateral < obj.totalRemainingCollateral:
+    # availability updated
     # inform subscribers that Availability has been modified (with increased
     # size)
     if OnAvailabilitySaved =? self.OnAvailabilitySaved:

--- a/tests/codex/sales/testreservations.nim
+++ b/tests/codex/sales/testreservations.nim
@@ -427,22 +427,24 @@ asyncchecksuite "Reservations module":
 
     check not called
 
-  test "OnAvailabilitySaved called when availability totalCollateral is increased":
+  test "OnAvailabilitySaved called when availability totalRemainingCollateral is increased":
     var availability = createAvailability()
     var added: Availability
     reservations.OnAvailabilitySaved = proc(a: Availability) {.async: (raises: []).} =
       added = a
-    availability.totalCollateral = availability.totalCollateral + 1.u256
+    availability.totalRemainingCollateral =
+      availability.totalRemainingCollateral + 1.u256
     discard await reservations.update(availability)
 
     check added == availability
 
-  test "OnAvailabilitySaved is not called when availability totalCollateral is decreased":
+  test "OnAvailabilitySaved is not called when availability totalRemainingCollateral is decreased":
     var availability = createAvailability()
     var called = false
     reservations.OnAvailabilitySaved = proc(a: Availability) {.async: (raises: []).} =
       called = true
-    availability.totalCollateral = availability.totalCollateral - 1.u256
+    availability.totalRemainingCollateral =
+      availability.totalRemainingCollateral - 1.u256
     discard await reservations.update(availability)
 
     check not called

--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -575,7 +575,7 @@ ethersuite "On-Chain Market":
     switchAccount(host)
     await market.reserveSlot(request.id, 0.uint64)
     await market.fillSlot(request.id, 0.uint64, proof, request.ask.collateralPerSlot)
-    let filledAt = (await ethProvider.currentTime())
+    let filledAt = await ethProvider.blockTime(BlockTag.latest)
 
     for slotIndex in 1 ..< request.ask.slots:
       await market.reserveSlot(request.id, slotIndex.uint64)

--- a/tests/integration/testmarketplace.nim
+++ b/tests/integration/testmarketplace.nim
@@ -290,8 +290,7 @@ marketplacesuite "Marketplace payouts":
     await ethProvider.advanceTime(expiry.u256)
 
     check eventually(
-      await providerApi.saleStateIs(slotId, "SaleCancelled"),
-      pollInterval = 100,
+      await providerApi.saleStateIs(slotId, "SaleCancelled"), pollInterval = 100
     )
 
     await advanceToNextPeriod()

--- a/tests/integration/testmarketplace.nim
+++ b/tests/integration/testmarketplace.nim
@@ -291,8 +291,7 @@ marketplacesuite "Marketplace payouts":
 
     check eventually(
       await providerApi.saleStateIs(slotId, "SaleCancelled"),
-      timeout = 5 * 1000,
-      pollInterval = 200,
+      pollInterval = 100,
     )
 
     await advanceToNextPeriod()


### PR DESCRIPTION
This PR uses `totalRemainingCollateral` instead of `totalCollateral` when trying to detect availability changes for notifying the sales module during the availability update. 

 The  `totalRemainingCollateral`  has to be used because this is the value updated when a reservation is created or deleted. 
The `totalCollateral` is the initial value used when creating / updating the availability from the JSON api.