### PR TITLE
fix(sales): handle cancellation of slot cleanup

### DIFF
--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -26,10 +26,10 @@ type
     onCleanUp*: OnCleanUp
     onFilled*: ?OnFilled
 
-  OnCleanUp* = proc(
-    reprocessSlot = false, returnedCollateral = UInt256.none
-  ): Future[void] {.gcsafe, upraises: [].}
-  OnFilled* = proc(request: StorageRequest, slotIndex: uint64) {.gcsafe, upraises: [].}
+  OnCleanUp* = proc(reprocessSlot = false, returnedCollateral = UInt256.none) {.
+    async: (raises: [])
+  .}
+  OnFilled* = proc(request: StorageRequest, slotIndex: uint64) {.gcsafe, raises: [].}
 
   SalesAgentError = object of CodexError
   AllSlotsFilledError* = object of SalesAgentError
@@ -132,7 +132,7 @@ proc subscribe*(agent: SalesAgent) {.async.} =
   await agent.subscribeCancellation()
   agent.subscribed = true
 
-proc unsubscribe*(agent: SalesAgent) {.async.} =
+proc unsubscribe*(agent: SalesAgent) {.async: (raises: [CancelledError]).} =
   if not agent.subscribed:
     return
 
@@ -143,6 +143,6 @@ proc unsubscribe*(agent: SalesAgent) {.async.} =
 
   agent.subscribed = false
 
-proc stop*(agent: SalesAgent) {.async.} =
+proc stop*(agent: SalesAgent) {.async: (raises: [CancelledError]).} =
   await Machine(agent).stop()
   await agent.unsubscribe()

--- a/codex/utils/asyncstatemachine.nim
+++ b/codex/utils/asyncstatemachine.nim
@@ -2,7 +2,6 @@ import pkg/questionable
 import pkg/chronos
 import ../logutils
 import ./trackedfutures
-import ./exceptions
 
 {.push raises: [].}
 
@@ -89,7 +88,7 @@ proc start*(machine: Machine, initialState: State) =
   machine.trackedFutures.track(fut)
   machine.schedule(Event.transition(machine.state, initialState))
 
-proc stop*(machine: Machine) {.async.} =
+proc stop*(machine: Machine) {.async: (raises: []).} =
   if not machine.started:
     return
 

--- a/tests/codex/sales/states/testcancelled.nim
+++ b/tests/codex/sales/states/testcancelled.nim
@@ -31,7 +31,7 @@ asyncchecksuite "sales state 'cancelled'":
     market = MockMarket.new()
     let onCleanUp = proc(
         reprocessSlot = false, returnedCollateral = UInt256.none
-    ) {.async.} =
+    ) {.async: (raises: []).} =
       reprocessSlotWas = some reprocessSlot
       returnedCollateralValue = returnedCollateral
 

--- a/tests/codex/sales/states/testerrored.nim
+++ b/tests/codex/sales/states/testerrored.nim
@@ -25,7 +25,7 @@ asyncchecksuite "sales state 'errored'":
   setup:
     let onCleanUp = proc(
         reprocessSlot = false, returnedCollateral = UInt256.none
-    ) {.async.} =
+    ) {.async: (raises: []).} =
       reprocessSlotWas = reprocessSlot
 
     let context = SalesContext(market: market, clock: clock)

--- a/tests/codex/sales/states/testfinished.nim
+++ b/tests/codex/sales/states/testfinished.nim
@@ -31,7 +31,7 @@ asyncchecksuite "sales state 'finished'":
     market = MockMarket.new()
     let onCleanUp = proc(
         reprocessSlot = false, returnedCollateral = UInt256.none
-    ) {.async.} =
+    ) {.async: (raises: []).} =
       reprocessSlotWas = some reprocessSlot
       returnedCollateralValue = returnedCollateral
 

--- a/tests/codex/sales/states/testignored.nim
+++ b/tests/codex/sales/states/testignored.nim
@@ -25,7 +25,7 @@ asyncchecksuite "sales state 'ignored'":
   setup:
     let onCleanUp = proc(
         reprocessSlot = false, returnedCollateral = UInt256.none
-    ) {.async.} =
+    ) {.async: (raises: []).} =
       reprocessSlotWas = reprocessSlot
 
     let context = SalesContext(market: market, clock: clock)


### PR DESCRIPTION
Possible fix for #1210 as suggested by @emizzle: https://github.com/codex-storage/nim-codex/issues/1210#issuecomment-2894016920

Ensures that processing slots from the slot queue continues even when cleanup of a slot is cancelled.
Also adds `{.async: (raises:[]}.}` to `onCleanup` to make sure that we didn't miss any other surprises here.

