### PR TITLE
fix: sales cleanup cancellation

### DIFF
--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -106,10 +106,7 @@ proc new*(
   )
 
 proc remove(sales: Sales, agent: SalesAgent) {.async: (raises: []).} =
-  try:
-    await agent.stop()
-  except CancelledError:
-    trace "Agent stop was cancelled"
+  await agent.stop()
 
   if sales.running:
     sales.agents.keepItIf(it != agent)

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -26,10 +26,10 @@ type
     onCleanUp*: OnCleanUp
     onFilled*: ?OnFilled
 
-  OnCleanUp* = proc(
-    reprocessSlot = false, returnedCollateral = UInt256.none
-  ): Future[void] {.gcsafe, upraises: [].}
-  OnFilled* = proc(request: StorageRequest, slotIndex: uint64) {.gcsafe, upraises: [].}
+  OnCleanUp* = proc(reprocessSlot = false, returnedCollateral = UInt256.none) {.
+    async: (raises: [])
+  .}
+  OnFilled* = proc(request: StorageRequest, slotIndex: uint64) {.gcsafe, raises: [].}
 
   SalesAgentError = object of CodexError
   AllSlotsFilledError* = object of SalesAgentError
@@ -132,7 +132,7 @@ proc subscribe*(agent: SalesAgent) {.async.} =
   await agent.subscribeCancellation()
   agent.subscribed = true
 
-proc unsubscribe*(agent: SalesAgent) {.async.} =
+proc unsubscribe*(agent: SalesAgent) {.async: (raises: [CancelledError]).} =
   if not agent.subscribed:
     return
 
@@ -143,6 +143,6 @@ proc unsubscribe*(agent: SalesAgent) {.async.} =
 
   agent.subscribed = false
 
-proc stop*(agent: SalesAgent) {.async.} =
+proc stop*(agent: SalesAgent) {.async: (raises: [CancelledError]).} =
   await Machine(agent).stop()
   await agent.unsubscribe()

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -132,7 +132,7 @@ proc subscribe*(agent: SalesAgent) {.async.} =
   await agent.subscribeCancellation()
   agent.subscribed = true
 
-proc unsubscribe*(agent: SalesAgent) {.async: (raises: [CancelledError]).} =
+proc unsubscribe*(agent: SalesAgent) {.async: (raises: []).} =
   if not agent.subscribed:
     return
 
@@ -143,6 +143,6 @@ proc unsubscribe*(agent: SalesAgent) {.async: (raises: [CancelledError]).} =
 
   agent.subscribed = false
 
-proc stop*(agent: SalesAgent) {.async: (raises: [CancelledError]).} =
+proc stop*(agent: SalesAgent) {.async: (raises: []).} =
   await Machine(agent).stop()
   await agent.unsubscribe()

--- a/codex/sales/states/preparing.nim
+++ b/codex/sales/states/preparing.nim
@@ -82,7 +82,7 @@ method run*(
     info "Availability found for request, creating reservation"
 
     without reservation =?
-      await reservations.createReservation(
+      await noCancel reservations.createReservation(
         availability.id, request.ask.slotSize, request.id, data.slotIndex,
         request.ask.collateralPerByte, requestEnd,
       ), error:

--- a/codex/utils/asyncstatemachine.nim
+++ b/codex/utils/asyncstatemachine.nim
@@ -2,7 +2,6 @@ import pkg/questionable
 import pkg/chronos
 import ../logutils
 import ./trackedfutures
-import ./exceptions
 
 {.push raises: [].}
 
@@ -89,7 +88,7 @@ proc start*(machine: Machine, initialState: State) =
   machine.trackedFutures.track(fut)
   machine.schedule(Event.transition(machine.state, initialState))
 
-proc stop*(machine: Machine) {.async.} =
+proc stop*(machine: Machine) {.async: (raises: []).} =
   if not machine.started:
     return
 

--- a/tests/codex/helpers/mockreservations.nim
+++ b/tests/codex/helpers/mockreservations.nim
@@ -30,7 +30,7 @@ method createReservation*(
     slotIndex: uint64,
     collateralPerByte: UInt256,
     validUntil: SecondsSince1970,
-): Future[?!Reservation] {.async.} =
+): Future[?!Reservation] {.async: (raises: [CancelledError]).} =
   if self.createReservationThrowBytesOutOfBoundsError:
     let error = newException(
       BytesOutOfBoundsError,

--- a/tests/codex/sales/states/testcancelled.nim
+++ b/tests/codex/sales/states/testcancelled.nim
@@ -31,7 +31,7 @@ asyncchecksuite "sales state 'cancelled'":
     market = MockMarket.new()
     let onCleanUp = proc(
         reprocessSlot = false, returnedCollateral = UInt256.none
-    ) {.async.} =
+    ) {.async: (raises: []).} =
       reprocessSlotWas = some reprocessSlot
       returnedCollateralValue = returnedCollateral
 

--- a/tests/codex/sales/states/testerrored.nim
+++ b/tests/codex/sales/states/testerrored.nim
@@ -25,7 +25,7 @@ asyncchecksuite "sales state 'errored'":
   setup:
     let onCleanUp = proc(
         reprocessSlot = false, returnedCollateral = UInt256.none
-    ) {.async.} =
+    ) {.async: (raises: []).} =
       reprocessSlotWas = reprocessSlot
 
     let context = SalesContext(market: market, clock: clock)

--- a/tests/codex/sales/states/testfinished.nim
+++ b/tests/codex/sales/states/testfinished.nim
@@ -31,7 +31,7 @@ asyncchecksuite "sales state 'finished'":
     market = MockMarket.new()
     let onCleanUp = proc(
         reprocessSlot = false, returnedCollateral = UInt256.none
-    ) {.async.} =
+    ) {.async: (raises: []).} =
       reprocessSlotWas = some reprocessSlot
       returnedCollateralValue = returnedCollateral
 

--- a/tests/codex/sales/states/testignored.nim
+++ b/tests/codex/sales/states/testignored.nim
@@ -25,7 +25,7 @@ asyncchecksuite "sales state 'ignored'":
   setup:
     let onCleanUp = proc(
         reprocessSlot = false, returnedCollateral = UInt256.none
-    ) {.async.} =
+    ) {.async: (raises: []).} =
       reprocessSlotWas = reprocessSlot
 
     let context = SalesContext(market: market, clock: clock)

--- a/tests/integration/codexclient.nim
+++ b/tests/integration/codexclient.nim
@@ -424,3 +424,10 @@ proc requestId*(
 
 proc buildUrl*(client: CodexClient, path: string): string =
   return client.baseurl & path
+
+proc getSlots*(
+    client: CodexClient
+): Future[?!seq[Slot]] {.async: (raises: [CancelledError, HttpError]).} =
+  let url = client.baseurl & "/sales/slots"
+  let body = await client.getContent(url)
+  seq[Slot].fromJson(body)

--- a/tests/integration/testmarketplace.nim
+++ b/tests/integration/testmarketplace.nim
@@ -225,16 +225,20 @@ marketplacesuite "Marketplace payouts":
     NodeConfigs(
       # Uncomment to start Hardhat automatically, typically so logs can be inspected locally
       hardhat: HardhatConfig.none,
-      clients: CodexConfigs.init(nodes = 1)
-      #  .debug() # uncomment to enable console log output.debug()
-      #  .withLogFile() # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
-      #  .withLogTopics("node", "erasure")
-      .some,
-      providers: CodexConfigs.init(nodes = 1)
-      #  .debug() # uncomment to enable console log output
-      #  .withLogFile() # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
-      #  .withLogTopics("node", "marketplace", "sales", "reservations", "node", "statemachine")
-      .some,
+      clients: CodexConfigs
+        .init(nodes = 1)
+        #  .debug() # uncomment to enable console log output.debug()
+        .withLogFile()
+        # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
+        .withLogTopics("node", "erasure").some,
+      providers: CodexConfigs
+        .init(nodes = 1)
+        #  .debug() # uncomment to enable console log output
+        .withLogFile()
+        # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
+        .withLogTopics(
+          "node", "marketplace", "sales", "reservations", "node", "statemachine"
+        ).some,
     ):
     let duration = 20.periods
     let expiry = 10.periods

--- a/tests/integration/testmarketplace.nim
+++ b/tests/integration/testmarketplace.nim
@@ -226,14 +226,14 @@ marketplacesuite "Marketplace payouts":
       # Uncomment to start Hardhat automatically, typically so logs can be inspected locally
       hardhat: HardhatConfig.none,
       clients: CodexConfigs.init(nodes = 1)
-      # .debug() # uncomment to enable console log output.debug()
-      # .withLogFile() # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
-      # .withLogTopics("node", "erasure")
+      #  .debug() # uncomment to enable console log output.debug()
+      #  .withLogFile() # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
+      #  .withLogTopics("node", "erasure")
       .some,
       providers: CodexConfigs.init(nodes = 1)
-      # .debug() # uncomment to enable console log output
-      # .withLogFile() # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
-      # .withLogTopics("node", "marketplace", "sales", "reservations", "node", "proving", "clock")
+      #  .debug() # uncomment to enable console log output
+      #  .withLogFile() # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
+      #  .withLogTopics("node", "marketplace", "sales", "reservations", "node", "statemachine")
       .some,
     ):
     let duration = 20.periods
@@ -284,7 +284,10 @@ marketplacesuite "Marketplace payouts":
 
     # wait until sale is cancelled
     await ethProvider.advanceTime(expiry.u256)
-    check eventually await providerApi.saleStateIs(slotId, "SaleCancelled")
+    check eventually(
+      await providerApi.saleStateIs(slotId, "SaleCancelled"),
+      timeout = expiry.int * 1000,
+    )
 
     await advanceToNextPeriod()
 

--- a/tests/integration/testmarketplace.nim
+++ b/tests/integration/testmarketplace.nim
@@ -225,20 +225,20 @@ marketplacesuite "Marketplace payouts":
     NodeConfigs(
       # Uncomment to start Hardhat automatically, typically so logs can be inspected locally
       hardhat: HardhatConfig.none,
-      clients: CodexConfigs
-        .init(nodes = 1)
-        #  .debug() # uncomment to enable console log output.debug()
-        .withLogFile()
-        # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
-        .withLogTopics("node", "erasure").some,
-      providers: CodexConfigs
-        .init(nodes = 1)
-        #  .debug() # uncomment to enable console log output
-        .withLogFile()
-        # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
-        .withLogTopics(
-          "node", "marketplace", "sales", "reservations", "node", "statemachine"
-        ).some,
+      clients: CodexConfigs.init(nodes = 1)
+      #  .debug() # uncomment to enable console log output.debug()
+      # .withLogFile()
+      # # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
+      # .withLogTopics("node", "erasure")
+      .some,
+      providers: CodexConfigs.init(nodes = 1)
+      #  .debug() # uncomment to enable console log output
+      # .withLogFile()
+      # # uncomment to output log file to tests/integration/logs/<start_datetime> <suite_name>/<test_name>/<node_role>_<node_idx>.log
+      # .withLogTopics(
+      #   "node", "marketplace", "sales", "reservations", "node", "statemachine"
+      # )
+      .some,
     ):
     let duration = 20.periods
     let expiry = 10.periods
@@ -288,9 +288,11 @@ marketplacesuite "Marketplace payouts":
 
     # wait until sale is cancelled
     await ethProvider.advanceTime(expiry.u256)
+
     check eventually(
       await providerApi.saleStateIs(slotId, "SaleCancelled"),
-      timeout = expiry.int * 1000,
+      timeout = 5 * 1000,
+      pollInterval = 200,
     )
 
     await advanceToNextPeriod()


### PR DESCRIPTION
When an SP was processing a slot and the sale was ignored, the cleanup function was blocked, preventing workers from picking up new items from the slot queue.

This PR should fix that and maybe #1210.  