### PR TITLE
chore: bump contracts

### DIFF
--- a/codex/contracts/market.nim
+++ b/codex/contracts/market.nim
@@ -23,6 +23,7 @@ type
     rewardRecipient: ?Address
     configuration: ?MarketplaceConfig
     requestCache: LruCache[string, StorageRequest]
+    allowanceLock: AsyncLock
 
   MarketSubscription = market.Subscription
   EventSubscription = ethers.Subscription
@@ -76,6 +77,18 @@ proc config(
 
   return resolvedConfig
 
+template withAllowanceLock*(market: OnChainMarket, body: untyped) =
+  if market.allowanceLock.isNil:
+    market.allowanceLock = newAsyncLock()
+  await market.allowanceLock.acquire()
+  try:
+    body
+  finally:
+    try:
+      market.allowanceLock.release()
+    except AsyncLockError as error:
+      raise newException(Defect, error.msg, error)
+
 proc approveFunds(
     market: OnChainMarket, amount: UInt256
 ) {.async: (raises: [CancelledError, MarketError]).} =
@@ -83,7 +96,11 @@ proc approveFunds(
   convertEthersError("Failed to approve funds"):
     let tokenAddress = await market.contract.token()
     let token = Erc20Token.new(tokenAddress, market.signer)
-    discard await token.increaseAllowance(market.contract.address(), amount).confirm(1)
+    let owner = await market.signer.getAddress()
+    let spender = market.contract.address
+    market.withAllowanceLock:
+      let allowance = await token.allowance(owner, spender)
+      discard await token.approve(spender, allowance + amount).confirm(1)
 
 method loadConfig*(
     market: OnChainMarket


### PR DESCRIPTION
This PR bumps contracts needed for the following PRs: 

- https://github.com/codex-storage/nim-codex/pull/1235
- https://github.com/codex-storage/nim-codex/pull/1188
- https://github.com/codex-storage/nim-codex/pull/1160

It includes a fix for token allowance extracted from [vault PR](https://github.com/codex-storage/nim-codex/pull/1196/commits/9b9d0b23fe16e3746eee098bc95b90d3640249c4)