### PR TITLE
fix(tests): fetching past contract events test

### DIFF
--- a/tests/contracts/testMarket.nim
+++ b/tests/contracts/testMarket.nim
@@ -537,6 +537,8 @@ ethersuite "On-Chain Market":
 
     let (_, fromTime) = await ethProvider.blockNumberAndTimestamp(BlockTag.latest)
 
+    await ethProvider.advanceTime(1.u256)
+
     await market.reserveSlot(request.id, 1.uint64)
     await market.reserveSlot(request.id, 2.uint64)
     await market.fillSlot(request.id, 1.uint64, proof, request.ask.collateralPerSlot)


### PR DESCRIPTION
Fetching past contract events test was failing with fetched contract events out of order. Advancing the time increasing the timestamp of the next automined block, allowing the events to occur in different blocks but with the same timestamp.