### PR TITLE
fix(sales): fix marketplace block expiry

### DIFF
--- a/codex/sales.nim
+++ b/codex/sales.nim
@@ -148,26 +148,12 @@ proc cleanUp(
 
   # Re-add items back into the queue to prevent small availabilities from
   # draining the queue. Seen items will be ordered last.
-  if data.slotIndex <= uint16.high.uint64 and reprocessSlot and request =? data.request:
-    let res =
-      await noCancel sales.context.market.slotCollateral(data.requestId, data.slotIndex)
-    if res.isErr:
-      error "Failed to re-add item back to the slot queue: unable to calculate collateral",
-        error = res.error.msg
-    else:
-      let collateral = res.get()
-      let queue = sales.context.slotQueue
-      var seenItem = SlotQueueItem.init(
-        data.requestId,
-        data.slotIndex.uint16,
-        data.ask,
-        request.expiry,
-        seen = true,
-        collateral = collateral,
-      )
-      trace "pushing ignored item to queue, marked as seen"
-      if err =? queue.push(seenItem).errorOption:
-        error "failed to readd slot to queue", errorType = $(type err), error = err.msg
+  if reprocessSlot and request =? data.request and var item =? agent.data.slotQueueItem:
+    let queue = sales.context.slotQueue
+    item.seen = true
+    trace "pushing ignored item to queue, marked as seen"
+    if err =? queue.push(item).errorOption:
+      error "failed to readd slot to queue", errorType = $(type err), error = err.msg
 
   let fut = sales.remove(agent)
   sales.trackedFutures.track(fut)
@@ -181,8 +167,9 @@ proc processSlot(
 ) {.async: (raises: [CancelledError]).} =
   debug "Processing slot from queue", requestId = item.requestId, slot = item.slotIndex
 
-  let agent =
-    newSalesAgent(sales.context, item.requestId, item.slotIndex, none StorageRequest)
+  let agent = newSalesAgent(
+    sales.context, item.requestId, item.slotIndex, none StorageRequest, some item
+  )
 
   let completed = newAsyncEvent()
 

--- a/codex/sales/salesagent.nim
+++ b/codex/sales/salesagent.nim
@@ -11,6 +11,7 @@ import ./statemachine
 import ./salescontext
 import ./salesdata
 import ./reservations
+import ./slotqueue
 
 export reservations
 
@@ -42,10 +43,16 @@ proc newSalesAgent*(
     requestId: RequestId,
     slotIndex: uint64,
     request: ?StorageRequest,
+    slotQueueItem = SlotQueueItem.none,
 ): SalesAgent =
   var agent = SalesAgent.new()
   agent.context = context
-  agent.data = SalesData(requestId: requestId, slotIndex: slotIndex, request: request)
+  agent.data = SalesData(
+    requestId: requestId,
+    slotIndex: slotIndex,
+    request: request,
+    slotQueueItem: slotQueueItem,
+  )
   return agent
 
 proc retrieveRequest*(agent: SalesAgent) {.async.} =

--- a/codex/sales/salescontext.nim
+++ b/codex/sales/salescontext.nim
@@ -28,7 +28,11 @@ type
     gcsafe, async: (raises: [CancelledError])
   .}
   OnStore* = proc(
-    request: StorageRequest, slot: uint64, blocksCb: BlocksCb, isRepairing: bool
+    request: StorageRequest,
+    expiry: SecondsSince1970,
+    slot: uint64,
+    blocksCb: BlocksCb,
+    isRepairing: bool,
   ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).}
   OnProve* = proc(slot: Slot, challenge: ProofChallenge): Future[?!Groth16Proof] {.
     gcsafe, async: (raises: [CancelledError])

--- a/codex/sales/salesdata.nim
+++ b/codex/sales/salesdata.nim
@@ -2,6 +2,7 @@ import pkg/chronos
 import ../contracts/requests
 import ../market
 import ./reservations
+import ./slotqueue
 
 type SalesData* = ref object
   requestId*: RequestId
@@ -10,3 +11,4 @@ type SalesData* = ref object
   slotIndex*: uint64
   cancelled*: Future[void]
   reservation*: ?Reservation
+  slotQueueItem*: ?SlotQueueItem

--- a/codex/sales/slotqueue.nim
+++ b/codex/sales/slotqueue.nim
@@ -196,6 +196,9 @@ proc collateralPerByte*(self: SlotQueueItem): UInt256 =
 proc seen*(self: SlotQueueItem): bool =
   self.seen
 
+proc `seen=`*(self: var SlotQueueItem, seen: bool) =
+  self.seen = seen
+
 proc running*(self: SlotQueue): bool =
   self.running
 

--- a/tests/codex/node/testcontracts.nim
+++ b/tests/codex/node/testcontracts.nim
@@ -116,8 +116,7 @@ asyncchecksuite "Test Node - Host contracts":
     let onStore = !sales.onStore
     var request = StorageRequest.example
     request.content.cid = verifiableBlock.cid
-    request.expiry =
-      (getTime() + DefaultBlockTtl.toTimesDuration + 1.hours).toUnix.uint64
+    let expiry = (getTime() + DefaultBlockTtl.toTimesDuration + 1.hours).toUnix
     var fetchedBytes: uint = 0
 
     let onBlocks = proc(
@@ -127,7 +126,7 @@ asyncchecksuite "Test Node - Host contracts":
         fetchedBytes += blk.data.len.uint
       return success()
 
-    (await onStore(request, 1.uint64, onBlocks, isRepairing = false)).tryGet()
+    (await onStore(request, expiry, 1.uint64, onBlocks, isRepairing = false)).tryGet()
     check fetchedBytes == 12 * DefaultBlockSize.uint
 
     let indexer = verifiable.protectedStrategy.init(
@@ -141,4 +140,4 @@ asyncchecksuite "Test Node - Host contracts":
         bytes = (await localStoreMetaDs.get(key)).tryGet
         blkMd = BlockMetadata.decode(bytes).tryGet
 
-      check blkMd.expiry == request.expiry.toSecondsSince1970
+      check blkMd.expiry == expiry

--- a/tests/codex/sales/testslotqueue.nim
+++ b/tests/codex/sales/testslotqueue.nim
@@ -300,10 +300,7 @@ suite "Slot queue":
     let uint64Slots = uint64(maxUInt16)
     request.ask.slots = uint64Slots
     let items = SlotQueueItem.init(
-      request.id,
-      request.ask,
-      request.expiry,
-      collateral = request.ask.collateralPerSlot,
+      request.id, request.ask, 0, collateral = request.ask.collateralPerSlot
     )
     check items.len.uint16 == maxUInt16
 
@@ -314,10 +311,7 @@ suite "Slot queue":
     request.ask.slots = uint64Slots
     expect SlotsOutOfRangeError:
       discard SlotQueueItem.init(
-        request.id,
-        request.ask,
-        request.expiry,
-        collateral = request.ask.collateralPerSlot,
+        request.id, request.ask, 0, collateral = request.ask.collateralPerSlot
       )
 
   test "cannot push duplicate items":
@@ -433,11 +427,12 @@ suite "Slot queue":
 
   test "sorts items by expiry descending (longer expiry = higher priority)":
     var request = StorageRequest.example
-    let item0 =
-      SlotQueueItem.init(request, 0, collateral = request.ask.collateralPerSlot)
-    request.expiry += 1
-    let item1 =
-      SlotQueueItem.init(request, 1, collateral = request.ask.collateralPerSlot)
+    let item0 = SlotQueueItem.init(
+      request.id, 0, request.ask, expiry = 3, collateral = request.ask.collateralPerSlot
+    )
+    let item1 = SlotQueueItem.init(
+      request.id, 1, request.ask, expiry = 7, collateral = request.ask.collateralPerSlot
+    )
     check item1 < item0
 
   test "sorts items by slot size descending (bigger dataset = higher profitability = higher priority)":
@@ -545,12 +540,7 @@ suite "Slot queue":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
     let request = StorageRequest.example
     let item0 = SlotQueueItem.init(
-      request.id,
-      0'u16,
-      request.ask,
-      request.expiry,
-      request.ask.collateralPerSlot,
-      seen = true,
+      request.id, 0'u16, request.ask, 0, request.ask.collateralPerSlot, seen = true
     )
     check queue.paused
     check queue.push(item0).isOk
@@ -560,12 +550,7 @@ suite "Slot queue":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
     let request = StorageRequest.example
     let item = SlotQueueItem.init(
-      request.id,
-      1'u16,
-      request.ask,
-      request.expiry,
-      request.ask.collateralPerSlot,
-      seen = false,
+      request.id, 1'u16, request.ask, 0, request.ask.collateralPerSlot, seen = false
     )
     check queue.paused
     # push causes unpause
@@ -578,20 +563,10 @@ suite "Slot queue":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
     let request = StorageRequest.example
     let unseen = SlotQueueItem.init(
-      request.id,
-      0'u16,
-      request.ask,
-      request.expiry,
-      request.ask.collateralPerSlot,
-      seen = false,
+      request.id, 0'u16, request.ask, 0, request.ask.collateralPerSlot, seen = false
     )
     let seen = SlotQueueItem.init(
-      request.id,
-      1'u16,
-      request.ask,
-      request.expiry,
-      request.ask.collateralPerSlot,
-      seen = true,
+      request.id, 1'u16, request.ask, 0, request.ask.collateralPerSlot, seen = true
     )
     # push causes unpause
     check queue.push(unseen).isSuccess
@@ -606,20 +581,10 @@ suite "Slot queue":
     newSlotQueue(maxSize = 4, maxWorkers = 1)
     let request = StorageRequest.example
     let item0 = SlotQueueItem.init(
-      request.id,
-      0'u16,
-      request.ask,
-      request.expiry,
-      request.ask.collateralPerSlot,
-      seen = true,
+      request.id, 0'u16, request.ask, 0, request.ask.collateralPerSlot, seen = true
     )
     let item1 = SlotQueueItem.init(
-      request.id,
-      1'u16,
-      request.ask,
-      request.expiry,
-      request.ask.collateralPerSlot,
-      seen = true,
+      request.id, 1'u16, request.ask, 0, request.ask.collateralPerSlot, seen = true
     )
     check queue.push(item0).isOk
     check queue.push(item1).isOk

--- a/tests/codex/testpurchasing.nim
+++ b/tests/codex/testpurchasing.nim
@@ -96,21 +96,19 @@ asyncchecksuite "Purchasing":
     check purchase.error.isNone
 
   test "fails when request times out":
-    let expiry = getTime().toUnix() + 10
-    market.requestExpiry[populatedRequest.id] = expiry
     let purchase = await purchasing.purchase(populatedRequest)
     check eventually market.requested.len > 0
 
+    let expiry = market.requestExpiry[populatedRequest.id]
     clock.set(expiry + 1)
     expect PurchaseTimeout:
       await purchase.wait()
 
   test "checks that funds were withdrawn when purchase times out":
-    let expiry = getTime().toUnix() + 10
-    market.requestExpiry[populatedRequest.id] = expiry
     let purchase = await purchasing.purchase(populatedRequest)
     check eventually market.requested.len > 0
     let request = market.requested[0]
+    let expiry = market.requestExpiry[populatedRequest.id]
     clock.set(expiry + 1)
     expect PurchaseTimeout:
       await purchase.wait()

--- a/tests/codex/testvalidation.nim
+++ b/tests/codex/testvalidation.nim
@@ -50,7 +50,7 @@ asyncchecksuite "validation":
   setup:
     groupIndex = groupIndexForSlotId(slot.id, !validationGroups)
     clock = MockClock.new()
-    market = MockMarket.new(clock = Clock(clock).some)
+    market = MockMarket.new(clock)
     market.config.proofs.period = period
     market.config.proofs.timeout = timeout
     validation = newValidation(clock, market, maxSlots, validationGroups, groupIndex)


### PR DESCRIPTION
Previously we used request.expiry as the block expiry, but the former is a duration in seconds, whereas the latter is a timestamp.

- Slot queue items can now either contain an expiry (when they represent a newly created request) or not contain an expiry (when they represent a recently freed slot that need repairing)
- Slot queue items are now added to the sales agent state, so that they can be re-added easily, instead of having to recreate the slot queue item from on-chain state.

Extracted the fix from #1196