### PR TITLE
fix(tests): auto import all tests files and fix forgotten tests

### DIFF
--- a/tests/codex/stores/repostore/testcoders.nim
+++ b/tests/codex/stores/repostore/testcoders.nim
@@ -34,26 +34,26 @@ suite "Test coders":
     StoreResult(kind: rand(StoreResultKind), used: rand(NBytes))
 
   test "Natural encode/decode":
-    for val in newSeqWith[Natural](100, rand(Natural)) & @[Natural.low, Natural.high]:
+    for val in newSeqWith(100, rand(Natural)) & @[Natural.low, Natural.high]:
       check:
         success(val) == Natural.decode(encode(val))
 
   test "QuotaUsage encode/decode":
-    for val in newSeqWith[QuotaUsage](100, rand(QuotaUsage)):
+    for val in newSeqWith(100, rand(QuotaUsage)):
       check:
         success(val) == QuotaUsage.decode(encode(val))
 
   test "BlockMetadata encode/decode":
-    for val in newSeqWith[BlockMetadata](100, rand(BlockMetadata)):
+    for val in newSeqWith(100, rand(BlockMetadata)):
       check:
         success(val) == BlockMetadata.decode(encode(val))
 
   test "DeleteResult encode/decode":
-    for val in newSeqWith[DeleteResult](100, rand(DeleteResult)):
+    for val in newSeqWith(100, rand(DeleteResult)):
       check:
         success(val) == DeleteResult.decode(encode(val))
 
   test "StoreResult encode/decode":
-    for val in newSeqWith[StoreResult](100, rand(StoreResult)):
+    for val in newSeqWith(100, rand(StoreResult)):
       check:
         success(val) == StoreResult.decode(encode(val))

--- a/tests/codex/stores/testkeyutils.nim
+++ b/tests/codex/stores/testkeyutils.nim
@@ -11,6 +11,7 @@ import std/random
 import std/sequtils
 import pkg/chronos
 import pkg/questionable/results
+import pkg/libp2p
 import pkg/codex/blocktype as bt
 import pkg/codex/stores/repostore
 import pkg/codex/clock

--- a/tests/imports.nim
+++ b/tests/imports.nim
@@ -9,5 +9,8 @@ macro importTests*(dir: static string): untyped =
   for file in walkDirRec(dir):
     let (_, name, ext) = splitFile(file)
     if name.startsWith("test") and ext == ".nim":
-      imports.add(quote do: import `file`)
+      imports.add(
+        quote do:
+          import `file`
+      )
   imports

--- a/tests/imports.nim
+++ b/tests/imports.nim
@@ -1,0 +1,13 @@
+import std/macros
+import std/os
+import std/strutils
+
+macro importTests*(dir: static string): untyped =
+  ## imports all files in the specified directory whose filename
+  ## starts with "test" and ends in ".nim"
+  let imports = newStmtList()
+  for file in walkDirRec(dir):
+    let (_, name, ext) = splitFile(file)
+    if name.startsWith("test") and ext == ".nim":
+      imports.add(quote do: import `file`)
+  imports

--- a/tests/testCodex.nim
+++ b/tests/testCodex.nim
@@ -1,21 +1,6 @@
-import ./codex/teststores
-import ./codex/testblockexchange
-import ./codex/testasyncheapqueue
-import ./codex/testchunking
-import ./codex/testlogutils
-import ./codex/testmanifest
-import ./codex/testnode
-import ./codex/teststorestream
-import ./codex/testpurchasing
-import ./codex/testsales
-import ./codex/testerasure
-import ./codex/testutils
-import ./codex/testclock
-import ./codex/testsystemclock
-import ./codex/testvalidation
-import ./codex/testasyncstreamwrapper
-import ./codex/testmerkletree
-import ./codex/testslots
-import ./codex/testindexingstrategy
+import std/os
+import ./imports
+
+importTests(currentSourcePath().parentDir() / "codex")
 
 {.warning[UnusedImport]: off.}

--- a/tests/testContracts.nim
+++ b/tests/testContracts.nim
@@ -1,7 +1,6 @@
-import ./contracts/testContracts
-import ./contracts/testMarket
-import ./contracts/testDeployment
-import ./contracts/testClock
-import ./contracts/testProvider
+import std/os
+import ./imports
+
+importTests(currentSourcePath().parentDir() / "contracts")
 
 {.warning[UnusedImport]: off.}

--- a/tests/testIntegration.nim
+++ b/tests/testIntegration.nim
@@ -1,14 +1,6 @@
-import ./integration/testcli
-import ./integration/testrestapi
-import ./integration/testrestapivalidation
-import ./integration/testupdownload
-import ./integration/testsales
-import ./integration/testpurchasing
-import ./integration/testblockexpiration
-import ./integration/testmarketplace
-import ./integration/testproofs
-import ./integration/testvalidator
-import ./integration/testecbug
-import ./integration/testslotrepair
+import std/os
+import ./imports
+
+importTests(currentSourcePath().parentDir() / "integration")
 
 {.warning[UnusedImport]: off.}

--- a/tests/testTools.nim
+++ b/tests/testTools.nim
@@ -1,3 +1,6 @@
-import ./tools/cirdl/testcirdl
+import std/os
+import ./imports
+
+importTests(currentSourcePath().parentDir() / "tools")
 
 {.warning[UnusedImport]: off.}


### PR DESCRIPTION
Imports all files that are named `test*.nim` automatically, so we cannot forget to add them.
Includes compilation fixes for tests that were forgotten, and were therefore not run in the CI before.